### PR TITLE
Default install.sh prefix to ~/.local/bin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PREFIX="${PREFIX:-/usr/local/bin}"
+PREFIX="${PREFIX:-$HOME/.local/bin}"
 SYMLINKS="${SYMLINKS:-0}"
 TOOLS=(shellm shellm-docker shellm-docker-broker shelly skills mem llm shellm-explore)
 
@@ -16,7 +16,7 @@ Usage: ./install.sh [options]
 Installs shellm, shellm-docker, shellm-docker-broker, shellm-explore, shelly, skills, and mem to a directory on your PATH.
 
 Options:
-  --prefix DIR   Install directory (default: /usr/local/bin)
+  --prefix DIR   Install directory (default: ~/.local/bin)
   --symlinks     Create symlinks instead of copies (edits take effect without reinstalling)
   -h, --help     Show this help
 
@@ -25,9 +25,9 @@ Environment variables:
   SYMLINKS=1     Same as --symlinks
 
 Examples:
-  ./install.sh                          # copy to /usr/local/bin
-  ./install.sh --symlinks               # symlink to /usr/local/bin
-  ./install.sh --prefix ~/.local/bin    # copy to ~/.local/bin
+  ./install.sh                          # copy to ~/.local/bin
+  ./install.sh --symlinks               # symlink to ~/.local/bin
+  ./install.sh --prefix /usr/local/bin  # copy to /usr/local/bin (may need sudo)
   PREFIX=~/bin SYMLINKS=1 ./install.sh  # symlink to ~/bin
 EOF
             exit 0
@@ -35,6 +35,8 @@ EOF
         *) echo "Unknown option: $1 (try --help)" >&2; exit 1 ;;
     esac
 done
+
+mkdir -p "$PREFIX"
 
 for tool in "${TOOLS[@]}"; do
     if [[ "$SYMLINKS" -eq 1 ]]; then
@@ -46,3 +48,13 @@ for tool in "${TOOLS[@]}"; do
         echo "Installed $tool → $PREFIX/$tool"
     fi
 done
+
+case ":$PATH:" in
+    *":$PREFIX:"*) ;;
+    *)
+        echo
+        echo "Warning: $PREFIX is not on your PATH."
+        echo "Add this line to your shell rc (~/.zshrc, ~/.bashrc, etc.):"
+        echo "  export PATH=\"$PREFIX:\$PATH\""
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Default `PREFIX` from `/usr/local/bin` → `~/.local/bin` (works without sudo on macOS/Linux)
- `mkdir -p "$PREFIX"` before installing so a missing dir doesn't error out
- Print a "not on PATH" warning with the exact `export PATH=...` line when the install dir isn't on PATH
- Update `--help` text and examples to match new default

Motivation: the previous default failed on a fresh macOS where `/usr/local/bin` doesn't exist and `/usr/local` is root-owned. `~/.local/bin` is the systemd/XDG-standard user bin dir on Linux (auto-added to PATH on most distros), and on macOS the new warning tells the user how to add it.

## Test plan
- [x] `./install.sh --symlinks` (default prefix) succeeds and creates `~/.local/bin` if missing
- [x] `./install.sh --symlinks --prefix /tmp/shellm-test-bin` from a shell where prefix isn't on PATH prints the PATH warning
- [ ] `./install.sh` (copy mode) on a Linux box still installs and chmods correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)