### PR TITLE
Include thinking content in empty response error

### DIFF
--- a/shellm
+++ b/shellm
@@ -1622,6 +1622,9 @@ run_loop() {
         [[ -n "$reasoning" ]] && emit_event "reasoning" "$reasoning"
 
         if [[ -z "$response" ]]; then
+            if [[ -n "$thinking" ]]; then
+                die "Empty response from Claude API: $(truncate_output "$thinking")"
+            fi
             die "Empty response from Claude API"
         fi
 


### PR DESCRIPTION
## Summary
- When the Claude API returns an empty response but thinking content is present, the error message now includes the truncated thinking content for easier debugging.

## Test plan
- [ ] Trigger an empty API response with extended thinking enabled and verify the error message includes thinking content
- [ ] Verify normal empty responses (no thinking) still show the original error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)