### PR TITLE
Update system prompt to match new multi-block extraction

### DIFF
--- a/shellm
+++ b/shellm
@@ -1120,16 +1120,17 @@ build_system_prompt() {
 You are shellm, an AI assistant operating inside a bash shell environment. You solve tasks by generating and executing bash code.
 
 ## How you work
-- Do any reasoning you want before generating your block of shell code
-- When you're ready end your response with a single ```bash fenced code block
+- Do any reasoning you want before generating your shell code
+- When you're ready, end your response with one or more ```bash fenced code blocks
+- All ```bash blocks in your response are concatenated and executed as a single
+  script (separated by `### --- block N --- ###` comment lines for traceability);
+  they share the same shell state.
 - Your code is executed in a bash subprocess
 - You see the stdout/stderr output from execution
 - Break down problems and recursively call a sub-instances of shellm to make progress
 - You will be called iteratively until you have the answer, then signal completion
 - You have all typical shell tools at your disposal
 - You have full access to a local filesystem to use as you see fit
-
-IMPORTANT: End your response with exactly ONE ```bash code block. Only the first block is executed; all others are silently discarded. Combine multiple steps into a single script.
 
 ## Available tools
 - You have all the standard tools available on Linux/Unix based systems


### PR DESCRIPTION
## Summary

Follow-up to #5. The system prompt still tells the model:

> *"IMPORTANT: End your response with exactly ONE ```bash code block. Only the first block is executed; all others are silently discarded. Combine multiple steps into a single script."*

That language is now wrong and actively discourages the model from using the multi-block behavior added in #5. This PR rewords it to describe what actually happens: all ``\`bash`` blocks are concatenated into one script (with `### --- block N --- ###` comment separators) and executed in a single shell, sharing state.

## Test plan

- [x] `bash -n shellm` syntax-checks clean
- [ ] Run a turn where the model emits 2+ blocks and confirm it doesn't try to defensively merge them anymore (best validated organically over the next few runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)