### PR TITLE
Revert multi-block extraction; signal truncation to model when extra blocks present

### DIFF
--- a/shellm
+++ b/shellm
@@ -1018,11 +1018,14 @@ call_llm() {
 extract_code() {
     local response="$1"
 
-    # Concatenate ALL fenced code blocks (```bash, ```sh, or bare ```) into
-    # one script, separated by `### --- block N --- ###` comment lines.
+    # Extract the FIRST fenced code block (```bash, ```sh, or bare ```).
     # Heredoc-aware: lines like ``` inside an open heredoc do NOT close the
     # outer code fence.  We track heredoc opens (<<[-]DELIM) and closes
     # (delimiter alone on a line) so nested markdown fences pass through.
+    # If extra fenced blocks follow the first, awk writes a "TRUNCATED" line
+    # to stderr so we can prepend a notice that the model can see next turn.
+    local truncation_file
+    truncation_file=$(mktemp)
     local code
     code=$(printf '%s\n' "$response" | awk -v sq="'" '
         # ── try_open_heredoc: inspect a line for <<[-]DELIM and push delimiter
@@ -1056,21 +1059,24 @@ extract_code() {
             }
         }
 
-        BEGIN { in_block = 0; hd_top = 0; block_num = 0 }
+        BEGIN { in_block = 0; hd_top = 0; first_block_closed = 0 }
 
-        # Outside a block — look for an opening fence
-        !in_block {
-            if ($0 ~ /^```bash/ || $0 ~ /^```sh/ || $0 ~ /^```/) {
-                in_block = 1
-                block_num++
-                if (block_num > 1) {
-                    print "### --- block " block_num " --- ###"
-                }
+        # After first block closed: look for another opening fence
+        first_block_closed && !in_block {
+            if ($0 ~ /^```/) {
+                print "TRUNCATED" > "/dev/stderr"
+                exit
             }
             next
         }
 
-        # Inside a code block
+        # Before the opening fence — look for ```bash, ```sh, or bare ```
+        !in_block {
+            if ($0 ~ /^```bash/ || $0 ~ /^```sh/ || $0 ~ /^```/) { in_block = 1 }
+            next
+        }
+
+        # Inside the code block
         in_block {
             # Check for heredoc close (delimiter alone on its own line)
             if (hd_top > 0) {
@@ -1082,10 +1088,11 @@ extract_code() {
                 }
             }
 
-            # A bare ``` only closes the fence when no heredoc is open.
-            # Stop after the first block — extra blocks are discarded.
+            # A bare ``` only closes the fence when no heredoc is open
             if ($0 ~ /^```[[:space:]]*$/ && hd_top == 0) {
-                exit
+                in_block = 0
+                first_block_closed = 1
+                next
             }
 
             # Track heredoc opens inside the code we are collecting
@@ -1093,11 +1100,24 @@ extract_code() {
 
             print
         }
-    ')
+    ' 2>"$truncation_file")
+
+    local truncation_signal
+    truncation_signal=$(cat "$truncation_file" 2>/dev/null || true)
+    rm -f "$truncation_file"
 
     # If no fenced blocks at all, use the whole response as code
     if [[ -z "$code" ]]; then
         code="$response"
+    fi
+
+    # If the model emitted extra blocks past the first, prepend a notice
+    # echoed to stderr.  Stderr is captured and shown back to the model on
+    # its next turn, so it learns its trailing blocks were dropped.  Prepend
+    # rather than append so the notice fires even if the user code exits
+    # early.
+    if [[ "$truncation_signal" == *TRUNCATED* ]]; then
+        code=$'echo "[rest of model response truncated after first block]" >&2\n'"$code"
     fi
 
     echo "$code"

--- a/shellm
+++ b/shellm
@@ -1117,7 +1117,7 @@ extract_code() {
     # rather than append so the notice fires even if the user code exits
     # early.
     if [[ "$truncation_signal" == *TRUNCATED* ]]; then
-        code=$'echo "[rest of model response truncated after first block]" >&2\n'"$code"
+        code=$'echo "[rest of model response truncated after first code block]" >&2\n'"$code"
     fi
 
     echo "$code"

--- a/shellm
+++ b/shellm
@@ -1082,11 +1082,10 @@ extract_code() {
                 }
             }
 
-            # A bare ``` only closes the fence when no heredoc is open;
-            # keep scanning afterwards in case more fenced blocks follow.
+            # A bare ``` only closes the fence when no heredoc is open.
+            # Stop after the first block — extra blocks are discarded.
             if ($0 ~ /^```[[:space:]]*$/ && hd_top == 0) {
-                in_block = 0
-                next
+                exit
             }
 
             # Track heredoc opens inside the code we are collecting
@@ -1119,12 +1118,11 @@ build_system_prompt() {
     cat <<'SYSPROMPT'
 You are shellm, an AI assistant operating inside a bash shell environment. You solve tasks by generating and executing bash code.
 
+IMPORTANT: End your response with exactly ONE ```bash code block. Your response is NOT streamed — code blocks are not executed until your entire response is complete. Combine multiple steps into a single script. Only the first code block is executed; all others are silently discarded.
+
 ## How you work
 - Do any reasoning you want before generating your shell code
-- When you're ready, end your response with one or more ```bash fenced code blocks
-- All ```bash blocks in your response are concatenated and executed as a single
-  script (separated by `### --- block N --- ###` comment lines for traceability);
-  they share the same shell state.
+- When you're ready, end your response with a single ```bash fenced code block
 - Your code is executed in a bash subprocess
 - You see the stdout/stderr output from execution
 - Break down problems and recursively call a sub-instances of shellm to make progress


### PR DESCRIPTION
## Summary

This PR walks back PR #5 + PR #6 and replaces them with a more conservative behavior: **single-block extraction, with a visible truncation signal** when the model emits more than one block.

### Why revert multi-block

PR #5 changed `extract_code` to concatenate every fenced block in a turn. In practice, the model misread this as "blocks execute as the response streams" and started writing turns shaped like *block 1, more thinking based on imagined output, block 2 acting on that imagined output*. That's worse than the original behavior — the model is now reasoning on hallucinated state.

Commit `3e1e2aa` (already in this branch as the first commit) restores the single-block contract and the "exactly ONE ```bash code block" instruction in the system prompt, plus a sentence clarifying that the response isn't streamed.

### Why add a truncation signal

The original "silently discarded" behavior had its own failure mode (Pattern C from the failure analysis): the model emits multiple blocks, sees no output for blocks 2..N, and thrashes wondering whether the shell is broken. Now `extract_code` detects extra opening fences past the first block's close fence and prepends:

```
echo "[rest of model response truncated after first block]" >&2
```

to the executed script. Stderr surfaces back to the model on its next turn, so it learns its trailing blocks were dropped — no more silent failure.

The marker is **prepended** (not appended) so it fires even if the user code exits early. Heredoc-aware: nested `` ``` `` inside an open heredoc don't trigger the marker (verified by unit tests).

## Commits

1. `3e1e2aa` — Revert to single code block per response
2. `bf1f69e` — Signal truncation when discarding extra fenced blocks

## Test plan

Six unit tests in `/tmp/test_extract_code.sh`, all passing:

- [x] single bash block → no marker
- [x] block followed by trailing prose only → no marker
- [x] heredoc with nested fences → no marker (heredoc-aware false-positive avoidance)
- [x] no fences at all → fallback to whole-response (preserved)
- [x] bash + python after → marker prepended
- [x] two bash blocks → marker prepended
- [x] `bash -n shellm` syntax-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)