### PR TITLE
Render traj commands as fenced code blocks in context

### DIFF
--- a/bin/context
+++ b/bin/context
@@ -296,8 +296,14 @@ render_step() {
         if [[ "$num_content" -eq 1 ]]; then
             # Single content key: just the value.
             output="$val"
+        elif [[ "$k" == "cmd" ]]; then
+            # Render commands as fenced code blocks so the model sees
+            # its own output format in history, not [cmd] markers.
+            output+='```bash'$'\n'"${val}"$'\n```\n\n'
+        elif [[ "$k" == "thought" ]]; then
+            output+="${val}"$'\n\n'
         else
-            # Multiple keys: use [key] wrappers.
+            # Generic fallback for other multi-key steps.
             output+="[${k}]"$'\n'"${val}"$'\n\n'
         fi
     done


### PR DESCRIPTION
## Summary
- The `context` tool was wrapping multi-field traj steps with `[key]` markers (e.g. `[cmd]`, `[thought]`). The model saw these in its conversation history and started imitating them — emitting `[cmd]` as a code delimiter instead of ` ```bash ` fences.
- This caused **63% of iterations to fail** with "command not found" (exit 127) during terminal-bench 2.0 evaluation, since `[cmd]` isn't a bash command and `bash -e` aborts.
- Fix: render the `cmd` field as a ` ```bash ` fenced block and the `thought` field as plain text, matching the format the model should produce. The model's conversation history now mirrors its expected output format.

## Test plan
- [x] Identified root cause via terminal-bench 2.0 eval (62.7% iteration waste from `[cmd]`)
- [ ] Verify model no longer emits `[cmd]` markers in new runs
- [ ] Run terminal-bench smoke test to confirm pass rate improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)