### PR TITLE
Drop unnecessary shift in traj_append_step

### DIFF
--- a/bin/shellm
+++ b/bin/shellm
@@ -221,8 +221,7 @@ _shellm_time() {
 # traj_dir is <rundir>/.shellm/traj
 traj_append_step() {
     local traj_dir="$1"
-    shift
-    local json="$1"
+    local json="$2"
     printf '%s' "$json" | traj append "$traj_dir"
 }
 


### PR DESCRIPTION
Trivial cleanup — `local traj_dir="$1"; shift; local json="$1"` is equivalent to `local traj_dir="$1"; local json="$2"`, just with extra steps. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)