### PR TITLE
SHELLM_THINKER_ENV override, bash 3.2 compat, executive infinite loop

### DIFF
--- a/bin/shellm-docker-broker
+++ b/bin/shellm-docker-broker
@@ -69,34 +69,39 @@ path_under() {
 
 symlink_mounts() {
     local workdir="$1"
-    local -A mount_dirs=()
-    while IFS= read -r -d '' link; do
-        local target
-        target=$(readlink -f "$link" 2>/dev/null) || continue
-        path_under "$target" "$workdir" && continue
-        [[ -e "$target" ]] || continue
-        local parent
-        parent=$(dirname "$target")
-        mount_dirs["$parent"]=1
-    done < <(find "$workdir" -type l -print0 2>/dev/null)
+
+    # bash 3.2 lacks associative arrays, so dedupe via sort -u into an
+    # indexed array.  Paths containing newlines are not supported (the old
+    # implementation also could not survive them).
+    local -a mount_dirs=()
+    local line
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && mount_dirs+=("$line")
+    done < <(
+        while IFS= read -r -d '' link; do
+            local target
+            target=$(readlink -f "$link" 2>/dev/null) || continue
+            path_under "$target" "$workdir" && continue
+            [[ -e "$target" ]] || continue
+            dirname "$target"
+        done < <(find "$workdir" -type l -print0 2>/dev/null) \
+        | sort -u
+    )
+
+    [[ "${#mount_dirs[@]}" -eq 0 ]] && return 0
 
     # Remove dirs that are subdirs of other dirs in the set
-    local -a unique=()
-    local dir other
-    for dir in "${!mount_dirs[@]}"; do
-        local dominated=false
-        for other in "${!mount_dirs[@]}"; do
+    local dir other dominated
+    for dir in "${mount_dirs[@]}"; do
+        dominated=0
+        for other in "${mount_dirs[@]}"; do
             [[ "$dir" == "$other" ]] && continue
             if path_under "$dir" "$other"; then
-                dominated=true
+                dominated=1
                 break
             fi
         done
-        $dominated || unique+=("$dir")
-    done
-
-    for dir in "${unique[@]}"; do
-        printf -- '-v\n%s:%s:ro\n' "$dir" "$dir"
+        [[ "$dominated" -eq 0 ]] && printf -- '-v\n%s:%s:ro\n' "$dir" "$dir"
     done
 }
 

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -161,9 +161,12 @@ _build_skill_var_flags() {
     fi
 }
 
-# Build common --var and --bin flags for shellm calls
+# Build common shellm flags: --env, --workdir, --var, --bin.
+# Honors SHELLM_THINKER_ENV to override the env (e.g. =local to skip the
+# per-identity Docker container).
 _build_shellm_flags() {
     local identity_dir="$1"
+    local run_dir="${2:-$identity_dir/workdir}"
     local abs_mem_dir abs_skills_dir abs_kernel_dir abs_traj_dir
 
     abs_mem_dir=$(_abs_path "$MEM_DIR")
@@ -171,6 +174,8 @@ _build_shellm_flags() {
     abs_kernel_dir=$(_abs_path "$SKILLS_KERNEL_DIR")
     abs_traj_dir=$(_abs_path "$TRAJ_DIR")
 
+    printf '%s\n' "--env" "${SHELLM_THINKER_ENV:-$IDENTITY_NAME}"
+    printf '%s\n' "--workdir" "$run_dir"
     printf '%s\n' "--var" "MEM_DIR=$abs_mem_dir"
     printf '%s\n' "--var" "SKILLS_DIR=$abs_skills_dir"
     printf '%s\n' "--var" "SKILLS_KERNEL_DIR=$abs_kernel_dir"

--- a/thinkers/actor/step
+++ b/thinkers/actor/step
@@ -34,7 +34,7 @@ mkdir -p "$run_dir"
 shellm_flags=()
 while IFS= read -r _flag; do
     [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
-done < <(_build_shellm_flags "$IDENTITY_DIR")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
 
 # Load thinker prompt
 prompt_file="$SCRIPT_DIR/prompt.md"
@@ -56,7 +56,7 @@ THINK_FAST_MODEL="${THINK_FAST_MODEL:-gemini-3.5-flash}"
 is_reply=$(printf 'Action: %s\n\nIs this action about replying, responding, or sending a message to someone in chat? Answer only YES or NO.' "$action_body" | \
     llm -m "$THINK_FAST_MODEL" -s "Answer only YES or NO." 2>/dev/null) || true
 
-if [[ "${is_reply^^}" == *"YES"* ]]; then
+if [[ "$(printf '%s' "$is_reply" | tr '[:lower:]' '[:upper:]')" == *"YES"* ]]; then
     printf '  fast reply...\n' >&2
     reply=$(printf '%s' "$act_prompt" | \
         llm -m "$THINK_FAST_MODEL" \
@@ -75,7 +75,7 @@ fi
 printf '  executing action...\n' >&2
 act_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
     SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+    shellm \
     "${shellm_flags[@]}" \
     "$act_prompt") || true
 

--- a/thinkers/executive/step
+++ b/thinkers/executive/step
@@ -52,18 +52,24 @@ response=$(printf '%s' "$full_message" | \
     -s "Output only a single thought. No explanation, no commands, no preamble." \
     2>/dev/null) || true
 
-[[ -z "$response" ]] && { printf 'executive/step: empty response from shellm\n' >&2; exit 1; }
-
-# Write thought to traj
+# The executive is an infinite loop: it must ALWAYS append something to the
+# traj so that trigger_self re-fires.  Empty/duplicate responses are degraded
+# but still emit a thought so the dispatcher keeps us alive.
 last_content=""
 if traj exists 2>/dev/null; then
     last_content=$(traj last --field content 2>/dev/null) || true
 fi
 
-if [[ "$last_content" != "$response" ]]; then
-    printf '{"type":"thought","content":%s,"source":"executive"}' \
-        "$(printf '%s' "$response" | jq -Rsa .)" \
-        | traj append >/dev/null
+if [[ -z "$response" ]]; then
+    printf 'executive/step: empty response from llm — emitting placeholder\n' >&2
+    response="(executive received an empty response from the LLM; continuing)"
+    sleep 1   # brief backoff so transient API failures don't tight-loop
+elif [[ "$response" == "$last_content" ]]; then
+    response="$response (repeat)"
 fi
+
+printf '{"type":"thought","content":%s,"source":"executive"}' \
+    "$(printf '%s' "$response" | jq -Rsa .)" \
+    | traj append >/dev/null
 
 printf '[thought] %s\n' "$response"

--- a/thinkers/intentions-goals-creator/step
+++ b/thinkers/intentions-goals-creator/step
@@ -46,13 +46,13 @@ mkdir -p "$run_dir"
 shellm_flags=()
 while IFS= read -r _flag; do
     [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
-done < <(_build_shellm_flags "$IDENTITY_DIR")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
 thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
     SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+    shellm \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/intentions-goals-enforcer/step
+++ b/thinkers/intentions-goals-enforcer/step
@@ -46,13 +46,13 @@ mkdir -p "$run_dir"
 shellm_flags=()
 while IFS= read -r _flag; do
     [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
-done < <(_build_shellm_flags "$IDENTITY_DIR")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
 thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
     SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+    shellm \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/learning/step
+++ b/thinkers/learning/step
@@ -46,13 +46,13 @@ mkdir -p "$run_dir"
 shellm_flags=()
 while IFS= read -r _flag; do
     [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
-done < <(_build_shellm_flags "$IDENTITY_DIR")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
 thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
     SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+    shellm \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/mind-wandering/step
+++ b/thinkers/mind-wandering/step
@@ -46,13 +46,13 @@ mkdir -p "$run_dir"
 shellm_flags=()
 while IFS= read -r _flag; do
     [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
-done < <(_build_shellm_flags "$IDENTITY_DIR")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
 thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
     SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+    shellm \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/system-architecture/step
+++ b/thinkers/system-architecture/step
@@ -46,13 +46,13 @@ mkdir -p "$run_dir"
 shellm_flags=()
 while IFS= read -r _flag; do
     [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
-done < <(_build_shellm_flags "$IDENTITY_DIR")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
 thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
     SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+    shellm \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/values-beliefs-creator/step
+++ b/thinkers/values-beliefs-creator/step
@@ -46,13 +46,13 @@ mkdir -p "$run_dir"
 shellm_flags=()
 while IFS= read -r _flag; do
     [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
-done < <(_build_shellm_flags "$IDENTITY_DIR")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
 thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
     SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+    shellm \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/values-beliefs-enforcer/step
+++ b/thinkers/values-beliefs-enforcer/step
@@ -46,13 +46,13 @@ mkdir -p "$run_dir"
 shellm_flags=()
 while IFS= read -r _flag; do
     [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
-done < <(_build_shellm_flags "$IDENTITY_DIR")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
 thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
     SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+    shellm \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 


### PR DESCRIPTION
## Summary

Three related fixes:

- **`SHELLM_THINKER_ENV` override** — `_build_shellm_flags` now emits `--env` and `--workdir`, gated by `SHELLM_THINKER_ENV` (defaults to `$IDENTITY_NAME`). All 8 step scripts drop their hardcoded `--env`/`--workdir`. Usage: `SHELLM_THINKER_ENV=local thinkers start` skips Docker envs.

- **bash 3.2 compatibility** — macOS ships bash 3.2; two bash-4+ constructs were silently crashing:
  - `actor/step`: `${is_reply^^}` → portable `tr` uppercase. **This was the root cause of zero actions/forks in the trajectory** — every actor invocation died at line 59 before reaching the shellm call.
  - `shellm-docker-broker`: `local -A` (associative array) → indexed array deduped via `sort -u`.

- **Executive infinite-loop guarantee** — the executive relies on `trigger_self=true` to re-fire after each thought, but two conditions broke the loop: empty LLM response (`exit 1`, no traj append) and duplicate response (dedup guard skips append). Both leave the FIFO dry. Fix: always append — placeholder on empty (with 1s backoff), `" (repeat)"` suffix on duplicate.

## Test plan

- [x] `bash -n` passes on all 11 files under macOS bash 3.2
- [x] `shellm-docker-broker` `symlink_mounts` rewrite verified under bash 3.2 with unit tests (single link, multiple links with dedup + dominance filtering, empty/missing workdir)
- [x] Actor bash-4 crash confirmed in `actor.log` (52 identical `bad substitution` lines); fix verified by syntax check
- [ ] Restart thinkers and confirm executive no longer goes idle + actor forks appear in trajectory

🤖 Generated with [Claude Code](https://claude.com/claude-code)