### PR TITLE
Root-trajectory inheritance, executive attention, TUI history & live-view improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.swp
 .DS_Store
 .env
+__pycache__/
+.chatrc
+.harbor-jobs/
 .shelly/
 .memories/
 .skills/

--- a/bin/chat
+++ b/bin/chat
@@ -65,7 +65,7 @@ cmd_send() {
         if [[ -z "$from" ]]; then
             die "No --from specified and no default_send_from in $CHATRC.
 Create a .chatrc file with:
-  echo 'default_send_from=your-name' > $CHATRC"
+  mkdir -p \$(dirname $CHATRC) && echo 'default_send_from=your-name' > $CHATRC"
         fi
     fi
 
@@ -126,7 +126,7 @@ cmd_send_file() {
         if [[ -z "$from" ]]; then
             die "No --from specified and no default_send_from in $CHATRC.
 Create a .chatrc file with:
-  echo 'default_send_from=your-name' > $CHATRC"
+  mkdir -p \$(dirname $CHATRC) && echo 'default_send_from=your-name' > $CHATRC"
         fi
     fi
 

--- a/bin/identity
+++ b/bin/identity
@@ -11,6 +11,7 @@ set -euo pipefail
 
 IDENTITY_VERSION="0.1.0"
 VERBOSE=0
+KERNEL_SKILLS=(mem chat goals)
 
 # Inside an identity shell, IDENTITY_DIR points to the specific identity
 # (e.g., .identities/andy). This CLI needs the root (e.g., .identities).
@@ -53,23 +54,42 @@ _destroy_containers() {
     done
 }
 
-# Bootstrap the kernel directory (mem + chat)
-_ensure_kernel() {
-    local kernel_dir="$1"
+# Locate a bundled skill either from the repo checkout (when tools are symlinked)
+# or from the installed core-skills directory (when tools are copied).
+_bundled_skill_dir() {
+    local skill="$1"
     local script_dir
     script_dir="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 
+    local candidate
+    for candidate in "$script_dir/../skills/$skill" "$HOME/.skills/core-skills/$skill"; do
+        if [[ -f "$candidate/SKILL.md" ]]; then
+            (cd "$candidate" && pwd)
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Bootstrap the kernel directory with symlinks to bundled core skills.
+_ensure_kernel() {
+    local kernel_dir="$1"
+    mkdir -p "$kernel_dir"
+
     local skill
-    for skill in mem chat goals; do
-        mkdir -p "$kernel_dir/$skill"
-        if [[ ! -f "$kernel_dir/$skill/SKILL.md" ]]; then
-            local bundled="$script_dir/../skills/$skill/SKILL.md"
-            if [[ -f "$bundled" ]]; then
-                cp "$bundled" "$kernel_dir/$skill/SKILL.md"
-                debug "Bootstrapped $skill kernel skill"
-            elif [[ "$skill" == "mem" ]]; then
-                debug "Warning: bundled mem skill not found at $bundled; creating minimal bootstrap"
-                cat > "$kernel_dir/$skill/SKILL.md" << 'MEMSKILL'
+    for skill in "${KERNEL_SKILLS[@]}"; do
+        local bundled=""
+        bundled=$(_bundled_skill_dir "$skill" 2>/dev/null) || bundled=""
+
+        if [[ -n "$bundled" ]]; then
+            rm -rf "$kernel_dir/$skill"
+            ln -s "$bundled" "$kernel_dir/$skill"
+            debug "Linked $skill kernel skill -> $bundled"
+        elif [[ "$skill" == "mem" && ! -f "$kernel_dir/$skill/SKILL.md" ]]; then
+            mkdir -p "$kernel_dir/$skill"
+            debug "Warning: bundled mem skill not found; creating minimal bootstrap"
+            cat > "$kernel_dir/$skill/SKILL.md" << 'MEMSKILL'
 ---
 name: mem
 description: Life context and memory system
@@ -77,8 +97,9 @@ description: Life context and memory system
 # mem — Life context system
 Commands: mem add --type TYPE <text> | mem search <query> | mem list | mem show <name> | mem forget <name> | mem edit <name> <text>
 MEMSKILL
-                debug "Bootstrapped mem kernel skill (minimal)"
-            fi
+            debug "Bootstrapped mem kernel skill (minimal)"
+        else
+            debug "Warning: bundled $skill skill not found; skipping"
         fi
     done
 }
@@ -121,12 +142,16 @@ _ensure_thinkers() {
     local script_dir
     script_dir="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 
-    # Source: repo thinkers/ or installed ~/.shelly-thinkers/
+    # Source: repo thinkers/ or installed ~/.shellm-thinkers/
     local bundled_dir="$script_dir/../thinkers"
     if [[ ! -d "$bundled_dir" ]]; then
-        bundled_dir="$HOME/.shelly-thinkers"
+        bundled_dir="$HOME/.shellm-thinkers"
     fi
     [[ -d "$bundled_dir" ]] || return 0
+
+    # Check if install was done with --symlinks
+    local use_symlinks=0
+    [[ -f "$HOME/.shellm-thinkers/.use-symlinks" ]] && use_symlinks=1
 
     mkdir -p "$thinkers_dir"
 
@@ -137,20 +162,52 @@ _ensure_thinkers() {
         name=$(basename "$src_dir")
         local dest="$thinkers_dir/$name"
 
-        # Skip if already exists
-        [[ -d "$dest" ]] && continue
+        # Resolve src_dir through symlinks (bundled_dir entries may be symlinks)
+        local real_src
+        real_src="$(cd "$src_dir" && pwd -P)"
 
-        cp -R "$src_dir" "$dest"
+        if [[ "$use_symlinks" -eq 1 ]]; then
+            # Symlink mode: link code files, copy subscriptions.jsonl
+            mkdir -p "$dest"
 
-        # Ensure executables
-        for script in "$dest"/{step,start,stop}; do
-            [[ -f "$script" ]] && chmod +x "$script"
-        done
+            # Symlink code files (step, start, stop, *.md, *.sh)
+            local src_file
+            for src_file in "$real_src"/*; do
+                [[ -e "$src_file" ]] || continue
+                local fname
+                fname=$(basename "$src_file")
+
+                # subscriptions.jsonl is per-identity — only copy if missing
+                if [[ "$fname" == "subscriptions.jsonl" ]]; then
+                    [[ -f "$dest/$fname" ]] || cp "$src_file" "$dest/$fname"
+                    continue
+                fi
+
+                # For everything else, ensure it's a symlink to the source
+                if [[ -L "$dest/$fname" ]]; then
+                    local cur_target
+                    cur_target=$(readlink "$dest/$fname") || true
+                    [[ "$cur_target" == "$src_file" ]] && continue
+                fi
+                # Replace regular file or stale symlink with correct symlink
+                rm -f "$dest/$fname"
+                ln -s "$src_file" "$dest/$fname"
+            done
+        else
+            # Copy mode: skip if already exists
+            [[ -d "$dest" ]] && continue
+            cp -R "$src_dir" "$dest"
+
+            # Ensure executables
+            for script in "$dest"/{step,start,stop}; do
+                [[ -f "$script" ]] && chmod +x "$script"
+            done
+        fi
 
         # Update subscriptions.jsonl with identity's TRAJ_ID if present
         local root_traj
         root_traj=$(grep '^root_trajectory=' "$identity_dir/info.txt" 2>/dev/null | cut -d= -f2-) || true
-        if [[ -n "$root_traj" && -f "$dest/subscriptions.jsonl" ]]; then
+        if [[ -n "$root_traj" && -f "$dest/subscriptions.jsonl" && ! -L "$dest/subscriptions.jsonl" ]]; then
             # Add traj_id to subscriptions that don't have one
             local tmp_subs
             tmp_subs=$(mktemp)
@@ -472,6 +529,36 @@ cmd_list() {
     done <<< "$dirs"
 }
 
+_resolve_identity_path() {
+    local target="${1:-}"
+    local identity_path
+
+    if [[ -n "$target" ]]; then
+        if [[ -d "$IDENTITY_DIR/$target" ]]; then
+            identity_path=$(cd "$IDENTITY_DIR/$target" && pwd)
+        else
+            local matches
+            matches=$(ls -1 "$IDENTITY_DIR" 2>/dev/null | grep -v '^default$' | grep "$target" || true)
+            local count
+            count=$(printf '%s' "$matches" | grep -c . 2>/dev/null) || count=0
+            if [[ "$count" -eq 1 ]]; then
+                identity_path=$(cd "$IDENTITY_DIR/$matches" && pwd)
+            elif [[ "$count" -gt 1 ]]; then
+                die "Ambiguous: '$target' matches multiple identities:
+$matches"
+            else
+                die "No identity matching: $target"
+            fi
+        fi
+    elif [[ -n "$_ACTIVE_IDENTITY_DIR" ]]; then
+        identity_path="$_ACTIVE_IDENTITY_DIR"
+    else
+        identity_path=$(_resolve_default)
+    fi
+
+    printf '%s\n' "$identity_path"
+}
+
 cmd_info() {
     local mode="full"
     while [[ $# -gt 0 ]]; do
@@ -576,6 +663,57 @@ $matches"
         traj_count=$(TRAJ_DIR="$identity_dir/trajectories" TRAJ_ID="$_info_root_traj" traj count 2>/dev/null) || traj_count=0
     fi
     printf 'Traj:     %d steps\n' "$traj_count"
+}
+
+cmd_sync_kernel() {
+    local all=0 target=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --all) all=1; shift ;;
+            -h|--help)
+                cat <<'EOF'
+Usage: identity sync-kernel [name|--all]
+
+Replace bundled kernel skills (mem, chat, goals) with symlinks to the installed
+core skill directories, so repo updates are reflected automatically.
+EOF
+                return 0
+                ;;
+            -*)
+                die "sync-kernel: unknown option: $1"
+                ;;
+            *)
+                [[ -n "$target" ]] && die "Usage: identity sync-kernel [name|--all]"
+                target="$1"; shift
+                ;;
+        esac
+    done
+
+    if [[ "$all" -eq 1 ]]; then
+        [[ -n "$target" ]] && die "sync-kernel: pass either a name or --all, not both"
+        [[ -d "$IDENTITY_DIR" ]] || die "No identities found"
+
+        local d identity_path synced=0
+        for d in "$IDENTITY_DIR"/*; do
+            [[ -d "$d" ]] || continue
+            [[ "$(basename "$d")" == "default" ]] && continue
+            identity_path=$(cd "$d" && pwd)
+            _ensure_kernel "$identity_path/kernel"
+            printf 'Synced kernel skills: %s\n' "$(basename "$identity_path")" >&2
+            synced=$((synced + 1))
+        done
+        [[ "$synced" -gt 0 ]] || die "No identities found"
+        return 0
+    fi
+
+    local identity_path identity_name
+    identity_path=$(_resolve_identity_path "$target")
+    identity_name=$(grep '^name=' "$identity_path/info.txt" 2>/dev/null | cut -d= -f2-) || true
+    [[ -z "$identity_name" ]] && identity_name=$(basename "$identity_path")
+
+    _ensure_kernel "$identity_path/kernel"
+    printf 'Synced kernel skills: %s\n' "$identity_name" >&2
 }
 
 cmd_default() {
@@ -688,6 +826,9 @@ $matches"
 
     # Ensure activate script exists (for identities created before this feature)
     [[ -f "$identity_dir/activate" ]] || _write_activate_script "$identity_dir"
+
+    # Sync thinker files (replaces stale copies with symlinks when installed with --symlinks)
+    _ensure_thinkers "$identity_dir"
 
     # Read model defaults from info.txt
     local think_model think_tick_interval
@@ -850,6 +991,7 @@ Usage:
   identity new <name> [--default] [--memories DIR]  Create a new identity
   identity list [-a]         List all identities (-a: show directories)
   identity info [name] [-n|-p]  Show identity info (default: default; -n: name, -p: dir)
+  identity sync-kernel [name|--all]  Symlink bundled kernel skills into identities
   identity default [name]     Show or set the default identity
   identity delete <name>     Delete an identity
   identity shell [name]      Start a subshell with identity env vars set
@@ -918,6 +1060,10 @@ main() {
             ;;
         info)
             cmd_info "$@"
+            ;;
+        sync-kernel)
+            _require_identity
+            cmd_sync_kernel "$@"
             ;;
         default)
             cmd_default "$@"

--- a/bin/shellm
+++ b/bin/shellm
@@ -136,7 +136,8 @@ Options:
   --system-prompt-file FILE Override the default system prompt with contents of FILE
   --docker-image IMAGE Docker image to use (default: ubuntu:latest)
   --docker-access MODE Docker access for generated code: none, broker, socket, dind
-  --resume [TRAJ_ID]     Resume a previous run (default: most recent trajectory)
+  --traj TRAJ_ID         Write steps to an existing trajectory (no child traj or fork)
+  --resume               Shorthand for --traj with the most recent trajectory
   --traj-dir DIR         Trajectory directory (default: $HOME/.shellm/trajectories)
   --var NAME=VALUE       Set env var for generated code (repeatable)
   --bin PATH             Make binary available on PATH (repeatable)
@@ -1621,47 +1622,38 @@ run_loop() {
 
     local _run_traj_id _new_output run_name
 
-    if [[ -n "${_resume_traj:-}" ]]; then
-        # --- Resume path ---
-        # Resolve "latest" to actual ID
-        if [[ "$_resume_traj" == "__latest__" ]]; then
-            _resume_traj=$(_find_latest_traj "$_run_traj_dir") \
+    if [[ -n "$_use_traj" ]]; then
+        # --- Use existing trajectory (--traj / --resume) ---
+        # Resolve "latest" for --resume
+        if [[ "$_use_traj" == "__latest__" ]]; then
+            _use_traj=$(_find_latest_traj "$_run_traj_dir") \
                 || die "No trajectories found in $_run_traj_dir"
         fi
 
-        # Validate trajectory exists
-        traj exists --traj_dir "$_run_traj_dir" "$_resume_traj" 2>/dev/null \
-            || die "Cannot find trajectory: $_resume_traj"
+        traj exists --traj_dir "$_run_traj_dir" "$_use_traj" 2>/dev/null \
+            || die "Cannot find trajectory: $_use_traj"
 
-        _run_traj_id="$_resume_traj"
+        _run_traj_id="$_use_traj"
 
-        # Extract workdir and env from the shellm-run step
+        # Inherit workdir and env from the trajectory if not explicitly provided
         local _orig_meta
-        _orig_meta=$(traj tail -n 50 --raw --traj_dir "$_run_traj_dir" "$_resume_traj" \
-            | jq -c 'select(.type=="shellm-run")' 2>/dev/null | head -1)
-        local _orig_workdir _orig_env
-        _orig_workdir=$(printf '%s' "$_orig_meta" | jq -r '.workdir // empty')
-        _orig_env=$(printf '%s' "$_orig_meta" | jq -r '.env.name // empty')
-
-        # Validate --workdir and --env match original
-        if [[ -n "$_SHELLM_WORKDIR_USER" && "$_SHELLM_WORKDIR_USER" != "$_orig_workdir" ]]; then
-            die "Cannot change workdir on resume (original: $_orig_workdir, requested: $_SHELLM_WORKDIR_USER)"
+        _orig_meta=$(traj tail -n 50 --raw --traj_dir "$_run_traj_dir" "$_use_traj" \
+            | jq -c 'select(.type=="shellm-run")' 2>/dev/null | tail -1)
+        if [[ -n "$_orig_meta" ]]; then
+            local _orig_workdir _orig_env
+            _orig_workdir=$(printf '%s' "$_orig_meta" | jq -r '.workdir // empty')
+            _orig_env=$(printf '%s' "$_orig_meta" | jq -r '.env.name // empty')
+            [[ -z "$_SHELLM_WORKDIR_USER" && -n "$_orig_workdir" ]] && _SHELLM_WORKDIR_USER="$_orig_workdir"
+            [[ -z "$_SHELLM_ENV_NAME" && -n "$_orig_env" ]] && _SHELLM_ENV_NAME="$_orig_env"
         fi
-        if [[ -n "$_SHELLM_ENV_NAME" && "$_SHELLM_ENV_NAME" != "$_orig_env" ]]; then
-            die "Cannot change env on resume (original: $_orig_env, requested: $_SHELLM_ENV_NAME)"
-        fi
-
-        # Use original workdir and env
-        _SHELLM_WORKDIR_USER="${_orig_workdir:-}"
-        [[ -n "$_orig_env" ]] && _SHELLM_ENV_NAME="$_orig_env"
 
         # Resolve run_name from trajectory dir
-        local _resume_file
-        _resume_file=$(traj show "$_resume_traj" --traj_dir "$_run_traj_dir" 2>/dev/null \
+        local _traj_file
+        _traj_file=$(traj show "$_use_traj" --traj_dir "$_run_traj_dir" 2>/dev/null \
             | grep '^File:' | awk '{print $2}') || true
-        run_name=$(basename "$(dirname "$_resume_file")")
+        run_name=$(basename "$(dirname "$_traj_file")")
 
-        progress "Resuming trajectory: $_run_traj_id"
+        progress "Using trajectory: $_run_traj_id"
     else
         # --- New trajectory path ---
         # Create the trajectory via traj new
@@ -1828,29 +1820,30 @@ run_loop() {
 
     local _ctx_summary_pid=""
 
-    if [[ -z "${_resume_traj:-}" ]]; then
-        # Build context_files JSON array
-        local _ctx_files_json="[]"
-        for _cf in "${context_files[@]+"${context_files[@]}"}"; do
-            _ctx_files_json=$(printf '%s' "$_ctx_files_json" | jq --arg f "$_cf" '. + [$f]')
-        done
+    # Build context_files JSON array
+    local _ctx_files_json="[]"
+    for _cf in "${context_files[@]+"${context_files[@]}"}"; do
+        _ctx_files_json=$(printf '%s' "$_ctx_files_json" | jq --arg f "$_cf" '. + [$f]')
+    done
 
-        # Write shellm-run step as the first step in the trajectory
-        local _shellm_run_json
-        _shellm_run_json=$(jq -nc \
-            --arg cmd "$_SHELLM_ORIGINAL_CMD" \
-            --arg wd "$workdir" \
-            --arg model "$SHELLM_MODEL" \
-            --arg effort "$SHELLM_EFFORT" \
-            --arg max_iter "${SHELLM_MAX_ITERATIONS:-}" \
-            --arg max_tok "${SHELLM_MAX_TOKENS:-}" \
-            --arg inactivity_timeout "$SHELLM_INACTIVITY_TIMEOUT" \
-            --argjson ctx "$_ctx_files_json" \
-            --argjson env "$_env_json" \
-            '{type:"shellm-run", command:$cmd, workdir:$wd, model:$model, effort:$effort, max_iterations:$max_iter, max_tokens:$max_tok, inactivity_timeout:$inactivity_timeout, context_files:$ctx, env:$env}')
-        printf '%s' "$_shellm_run_json" | traj append --traj_dir "$_run_traj_dir" "$_run_traj_id" >/dev/null
+    # Write shellm-run step
+    local _shellm_run_json
+    _shellm_run_json=$(jq -nc \
+        --arg cmd "$_SHELLM_ORIGINAL_CMD" \
+        --arg wd "$workdir" \
+        --arg model "$SHELLM_MODEL" \
+        --arg effort "$SHELLM_EFFORT" \
+        --arg max_iter "${SHELLM_MAX_ITERATIONS:-}" \
+        --arg max_tok "${SHELLM_MAX_TOKENS:-}" \
+        --arg inactivity_timeout "$SHELLM_INACTIVITY_TIMEOUT" \
+        --argjson ctx "$_ctx_files_json" \
+        --argjson env "$_env_json" \
+        --argjson resumed "$(if [[ -n "$_use_traj" ]]; then echo true; else echo false; fi)" \
+        '{type:"shellm-run", command:$cmd, workdir:$wd, model:$model, effort:$effort, max_iterations:$max_iter, max_tokens:$max_tok, inactivity_timeout:$inactivity_timeout, context_files:$ctx, env:$env, resumed:$resumed}')
+    printf '%s' "$_shellm_run_json" | traj append --traj_dir "$_run_traj_dir" "$_run_traj_id" >/dev/null
 
-        # Kick off async run-summary generation (background)
+    if [[ -z "$_use_traj" ]]; then
+        # New trajectory — kick off async run-summary generation
         local stdin_ctx_file=""
         if [[ -n "$stdin_context" ]]; then
             stdin_ctx_file="$rundir/.stdin_context"
@@ -1860,13 +1853,11 @@ run_loop() {
             "${context_files[@]+"${context_files[@]}"}" &
         _ctx_summary_pid=$!
         debug "Run summary generation started (PID: $_ctx_summary_pid)"
+    fi
 
-        # Write initial prompt to trajectory
+    # Write prompt step
+    if [[ -n "$prompt" ]]; then
         printf '%s' "$(jq -n --arg p "$prompt" '{type:"prompt",content:$p}')" \
-            | traj append --traj_dir "$_run_traj_dir" "$_run_traj_id" >/dev/null
-    elif [[ -n "$prompt" ]]; then
-        # Resuming with new prompt — append as feedback step
-        printf '%s' "$(jq -n --arg p "$prompt" '{type:"feedback",content:$p}')" \
             | traj append --traj_dir "$_run_traj_dir" "$_run_traj_id" >/dev/null
     fi
 
@@ -2237,7 +2228,8 @@ exit \$__shellm_rc
             [[ "$QUIET" -eq 0 ]] && echo >&2
             progress_dim "Trajectory: $_run_traj_id"
             # Write thought step to parent traj referencing this sub-traj
-            if [[ -n "${_SHELLM_PARENT_TRAJ_ID:-}" ]]; then
+            # Skip when using --traj (steps already went to the shared traj)
+            if [[ -n "${_SHELLM_PARENT_TRAJ_ID:-}" && -z "$_use_traj" ]]; then
                 local _last_step_id _child_dir_name _from_traj_ref
                 _last_step_id=$(traj last --traj_dir "$_run_traj_dir" "$_run_traj_id" --field step_id 2>/dev/null) || true
                 _child_dir_name=$(basename "$run_name")
@@ -2293,7 +2285,8 @@ exit \$__shellm_rc
     [[ "$QUIET" -eq 0 ]] && echo >&2
     progress "\033[1;31mMax iterations ($SHELLM_MAX_ITERATIONS) reached without final answer\033[0m"
     # Write thought step to parent traj (even on failure)
-    if [[ -n "${_SHELLM_PARENT_TRAJ_ID:-}" ]]; then
+    # Skip when using --traj (steps already went to the shared traj)
+    if [[ -n "${_SHELLM_PARENT_TRAJ_ID:-}" && -z "$_use_traj" ]]; then
         local _last_step_id _child_dir_name _from_traj_ref
         _last_step_id=$(traj last --traj_dir "$_run_traj_dir" "$_run_traj_id" --field step_id 2>/dev/null) || true
         _child_dir_name=$(basename "$run_name")
@@ -2319,7 +2312,7 @@ main() {
     local print_prompt=0
     local _SHELLM_ENV_NAME="${SHELLM_ENV:-}"
     local _new_env=0
-    local _resume_traj=""
+    local _use_traj=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -2394,18 +2387,17 @@ main() {
                 SHELLM_DOCKER_ACCESS="${2:?--docker-access requires a value}"
                 shift 2
                 ;;
+            --traj)
+                _use_traj="${2:?--traj requires TRAJ_ID}"
+                shift 2
+                ;;
             --traj-dir)
                 SHELLM_TRAJ_DIR="${2:?--traj-dir requires DIR}"
                 shift 2
                 ;;
             --resume)
-                _resume_traj="${2:-}"
-                if [[ -n "$_resume_traj" && "$_resume_traj" != -* ]]; then
-                    shift 2
-                else
-                    _resume_traj="__latest__"
-                    shift
-                fi
+                _use_traj="__latest__"
+                shift
                 ;;
             --var)
                 _SHELLM_EXTRA_VARS+=("${2:?--var requires NAME=VALUE}")
@@ -2439,7 +2431,7 @@ main() {
         exit 0
     fi
 
-    [[ -z "$prompt" && -z "$_resume_traj" ]] && { usage; }
+    [[ -z "$prompt" && -z "$_use_traj" ]] && { usage; }
 
     if [[ "${#context_files[@]}" -gt 0 ]]; then
         run_loop "$prompt" "${context_files[@]}"

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,7 @@ if [[ -d "thinkers" ]]; then
             [[ -d "$td" ]] || continue
             ln -sfn "$(pwd)/$td" "$THINKERS_PREFIX/$(basename "$td")"
         done
+        touch "$THINKERS_PREFIX/.use-symlinks"
     else
         for td in thinkers/*/; do
             [[ -d "$td" ]] || continue
@@ -105,6 +106,7 @@ if [[ -d "thinkers" ]]; then
             rm -rf "$THINKERS_PREFIX/$name"
             cp -R "$td" "$THINKERS_PREFIX/$name"
         done
+        rm -f "$THINKERS_PREFIX/.use-symlinks"
     fi
     echo "Installed thinker templates → $THINKERS_PREFIX"
 fi

--- a/thinkers/actor/step
+++ b/thinkers/actor/step
@@ -56,7 +56,7 @@ THINK_FAST_MODEL="${THINK_FAST_MODEL:-gemini-3.5-flash}"
 is_reply=$(printf 'Action: %s\n\nIs this action about replying, responding, or sending a message to someone in chat? Answer only YES or NO.' "$action_body" | \
     llm -m "$THINK_FAST_MODEL" -s "Answer only YES or NO." 2>/dev/null) || true
 
-if [[ "${is_reply^^}" == *"YES"* ]]; then
+if [[ "$(printf '%s' "$is_reply" | tr '[:lower:]' '[:upper:]')" == *"YES"* ]]; then
     printf '  fast reply...\n' >&2
     reply=$(printf '%s' "$act_prompt" | \
         llm -m "$THINK_FAST_MODEL" \

--- a/thinkers/actor/step
+++ b/thinkers/actor/step
@@ -63,19 +63,32 @@ if [[ "${is_reply^^}" == *"YES"* ]]; then
         -s "Write a short, natural reply. Output ONLY the message text, nothing else." \
         2>/dev/null) || true
     if [[ -n "$reply" ]]; then
-        chat reply "$reply"
-        printf '{"type":"observation","content":%s,"source":"actor"}' \
-            "$(printf 'Replied: %s' "$reply" | jq -Rsa .)" | traj append
-        printf '  [reply] %s\n' "$(printf '%s' "$reply" | head -1)" >&2
-        exit 0
+        reply_to=$(printf '%s' "$step_json" | jq -r '.to // .recipient // empty' 2>/dev/null) || true
+        if [[ -z "$reply_to" ]]; then
+            reply_to=$(traj cat "${ROOT_TRAJ_ID:-$TRAJ_ID}" --filter type=message,human-msg --raw 2>/dev/null | \
+                jq -sr --arg me "${IDENTITY_NAME:-}" '
+                    reverse
+                    | map(select(
+                        (.type == "message" and (.to // "") == $me and (.from // "") != "")
+                        or (.type == "human-msg" and (.from // "") != "")
+                    ))
+                    | .[0].from // empty
+                ' 2>/dev/null) || true
+        fi
+
+        if [[ -n "$reply_to" ]] && printf '%s' "$reply" | chat reply "$reply_to"; then
+            printf '{"type":"observation","content":%s,"source":"actor"}' \
+                "$(printf 'Replied to %s: %s' "$reply_to" "$reply" | jq -Rsa .)" | traj append
+            printf '  [reply -> %s] %s\n' "$reply_to" "$(printf '%s' "$reply" | head -1)" >&2
+            exit 0
+        fi
     fi
 fi
 
-# Full shellm agentic loop for non-chat actions (fork/merge via _SHELLM_PARENT_TRAJ_ID)
+# Full shellm agentic loop for non-chat actions (writes to root trajectory)
 printf '  executing action...\n' >&2
-act_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
-    SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+act_response=$(SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
+    shellm --traj "$TRAJ_ID" \
     "${shellm_flags[@]}" \
     "$act_prompt") || true
 

--- a/thinkers/executive/prompt.md
+++ b/thinkers/executive/prompt.md
@@ -1,9 +1,25 @@
-Your job as the core thought generator is to generate the next single thought in the stream of consciousness, i.e. a step of type: "thought"
+Your job as the executive thinker is to generate the next single thought in the stream of consciousness, i.e. a step of type: "thought"
 
 Your job is to:
 - Always make progress
 - ADVANCE the stream — never restate it. Subsequent thoughts should NEVER be very similar to previous ones.
 - If the thought stream is stuck in a loop (saying a similar thing twice in close succession), break it out of the loop!
+
+## Attention
+
+The root trajectory is a shared stream. Other thinkers (actor, learning, values, etc.) write their steps here too. You will see their work in the recent stream:
+
+- `shellm-run` (resumed:true) — a thinker started a new invocation
+- `reasoning` — a thinker's LLM reasoning (what it plans to do next)
+- `shell-output` — command output from a thinker's execution
+- `observation` (source:actor) — the actor reporting a result
+- `action` (source:executive) — an action you requested
+
+Use these to stay aware of what other thinkers are doing:
+- If the actor is mid-execution (you see `reasoning` or `shell-output` steps from it), don't re-request the same action. Wait for its result.
+- If the actor produced an `observation`, acknowledge it and decide what's next.
+- If you see a thinker struggling (errors, retries), you can note it — but don't try to do its job.
+- When nothing is happening and you have nothing to add, output just the word `idle` instead of filler thoughts like "waiting" or ".".
 
 ## Rules
 

--- a/thinkers/executive/step
+++ b/thinkers/executive/step
@@ -148,6 +148,10 @@ response=$(printf '%s' "$full_message" | \
 step_type="thought"
 step_content="$response"
 case "$response" in
+    "idle"|"action: idle"|"action:idle")
+        step_type="idle"
+        step_content="idle"
+        ;;
     "action: "*)
         step_type="action"
         step_content="${response#action: }"

--- a/thinkers/intentions-goals-creator/step
+++ b/thinkers/intentions-goals-creator/step
@@ -49,9 +49,8 @@ done < <(_build_shellm_flags "$IDENTITY_DIR")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
-thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
-    SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+thinker_response=$(SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
+    shellm --traj "$TRAJ_ID" \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/intentions-goals-enforcer/step
+++ b/thinkers/intentions-goals-enforcer/step
@@ -49,9 +49,8 @@ done < <(_build_shellm_flags "$IDENTITY_DIR")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
-thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
-    SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+thinker_response=$(SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
+    shellm --traj "$TRAJ_ID" \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/learning/step
+++ b/thinkers/learning/step
@@ -49,9 +49,8 @@ done < <(_build_shellm_flags "$IDENTITY_DIR")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
-thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
-    SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+thinker_response=$(SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
+    shellm --traj "$TRAJ_ID" \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/mind-wandering/step
+++ b/thinkers/mind-wandering/step
@@ -49,9 +49,8 @@ done < <(_build_shellm_flags "$IDENTITY_DIR")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
-thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
-    SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+thinker_response=$(SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
+    shellm --traj "$TRAJ_ID" \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/system-architecture/step
+++ b/thinkers/system-architecture/step
@@ -49,9 +49,8 @@ done < <(_build_shellm_flags "$IDENTITY_DIR")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
-thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
-    SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+thinker_response=$(SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
+    shellm --traj "$TRAJ_ID" \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/values-beliefs-creator/step
+++ b/thinkers/values-beliefs-creator/step
@@ -49,9 +49,8 @@ done < <(_build_shellm_flags "$IDENTITY_DIR")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
-thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
-    SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+thinker_response=$(SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
+    shellm --traj "$TRAJ_ID" \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/thinkers/values-beliefs-enforcer/step
+++ b/thinkers/values-beliefs-enforcer/step
@@ -49,9 +49,8 @@ done < <(_build_shellm_flags "$IDENTITY_DIR")
 
 
 printf '  thinker: %s...\n' "$THINKER_NAME" >&2
-thinker_response=$(_SHELLM_PARENT_TRAJ_ID="$TRAJ_ID" \
-    SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
-    shellm --env "$IDENTITY_NAME" --workdir "$run_dir" \
+thinker_response=$(SHELLM_NO_BANNER=1 SHELLM_MODEL="$THINK_MODEL" \
+    shellm --traj "$TRAJ_ID" \
     "${shellm_flags[@]}" \
     "$thinker_message") || true
 

--- a/tui/shellm/src/main.rs
+++ b/tui/shellm/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env, io, mem, process::Stdio, time::Duration};
+use std::{env, io, mem, process::Stdio, time::{Duration, Instant}};
 
 use crossterm::{
     event::{self, Event, KeyCode, KeyModifiers, MouseEventKind, EnableMouseCapture, DisableMouseCapture},
@@ -37,7 +37,10 @@ struct App {
     from: Option<String>,
     scroll_offset: usize,
     kill_ring: String,
-    history: Vec<String>,
+    chat_history: Vec<String>,
+    thinkers_history: Vec<String>,
+    traj_history: Vec<String>,
+    command_history: Vec<String>,
     history_idx: Option<usize>,
     stashed_input: String,
     mode: Mode,
@@ -45,6 +48,8 @@ struct App {
     cmd_scroll: usize,
     cmd_base: String,
     mouse_captured: bool,
+    quit_armed: Option<Instant>,
+    refresh_paused: bool,
 }
 
 impl App {
@@ -69,6 +74,55 @@ impl App {
             Mode::Chat => self.scroll_offset = self.scroll_offset.saturating_sub(n),
             _ => self.cmd_scroll = self.cmd_scroll.saturating_sub(n),
         }
+    }
+
+    /// History bucket for the current mode.
+    fn history(&self) -> &Vec<String> {
+        match self.mode {
+            Mode::Chat => &self.chat_history,
+            Mode::Thinkers => &self.thinkers_history,
+            Mode::Traj => &self.traj_history,
+            Mode::Command => &self.command_history,
+        }
+    }
+
+    fn history_mut(&mut self) -> &mut Vec<String> {
+        match self.mode {
+            Mode::Chat => &mut self.chat_history,
+            Mode::Thinkers => &mut self.thinkers_history,
+            Mode::Traj => &mut self.traj_history,
+            Mode::Command => &mut self.command_history,
+        }
+    }
+
+    fn history_prev(&mut self) {
+        if self.history().is_empty() {
+            return;
+        }
+        let idx = match self.history_idx {
+            None => {
+                self.stashed_input = self.input.clone();
+                self.history().len() - 1
+            }
+            Some(i) if i > 0 => i - 1,
+            Some(i) => i,
+        };
+        self.history_idx = Some(idx);
+        self.input = self.history()[idx].clone();
+        self.cursor = self.input.chars().count();
+    }
+
+    fn history_next(&mut self) {
+        let Some(idx) = self.history_idx else { return };
+        if idx + 1 < self.history().len() {
+            let next = idx + 1;
+            self.history_idx = Some(next);
+            self.input = self.history()[next].clone();
+        } else {
+            self.history_idx = None;
+            self.input = mem::take(&mut self.stashed_input);
+        }
+        self.cursor = self.input.chars().count();
     }
 }
 
@@ -269,6 +323,8 @@ fn help_text() -> Vec<String> {
         "Keys:".into(),
         "  Ctrl+C/D       Exit".into(),
         "  Shift+Enter    Newline in input".into(),
+        "  Up/Down        Command history (from top/bottom line)".into(),
+        "  Enter (empty)  Return to live view after a command (thinkers/traj)".into(),
         "  PageUp/Down    Scroll output".into(),
         "  Ctrl+G         Toggle mouse (scroll vs. text select)".into(),
         "  Option+click   Select text (iTerm2) without toggling".into(),
@@ -520,7 +576,10 @@ async fn run(
         from,
         scroll_offset: 0,
         kill_ring: String::new(),
-        history: Vec::new(),
+        chat_history: Vec::new(),
+        thinkers_history: Vec::new(),
+        traj_history: Vec::new(),
+        command_history: Vec::new(),
         history_idx: None,
         stashed_input: String::new(),
         mode: initial_mode,
@@ -528,6 +587,8 @@ async fn run(
         cmd_scroll: 0,
         cmd_base: String::new(),
         mouse_captured: true,
+        quit_armed: None,
+        refresh_paused: false,
     };
 
     let mut needs_clear = false;
@@ -543,6 +604,10 @@ async fn run(
 
         while let Ok(lines) = cmd_rx.try_recv() {
             app.cmd_output = lines;
+        }
+
+        if app.quit_armed.is_some_and(|t| t.elapsed() > Duration::from_secs(2)) {
+            app.quit_armed = None;
         }
 
         // Force full redraw when chat messages change to avoid
@@ -565,8 +630,15 @@ async fn run(
                 }
             }
             if let Event::Key(key) = ev {
+                if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                    if app.quit_armed.is_some() {
+                        break;
+                    }
+                    app.quit_armed = Some(Instant::now());
+                    continue;
+                }
+                app.quit_armed = None;
                 match key.code {
-                    KeyCode::Char('c') | KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => break,
                     KeyCode::Esc => break,
                     KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         app.mouse_captured = !app.mouse_captured;
@@ -582,14 +654,44 @@ async fn run(
                         app.cursor += 1;
                     }
                     KeyCode::Enter => {
-                        if !app.input.is_empty() {
+                        if app.input.is_empty() {
+                            // Empty Enter resumes the live view after a one-off command
+                            if app.refresh_paused {
+                                app.refresh_paused = false;
+                                app.cmd_scroll = 0;
+                                app.cmd_output = vec!["Loading...".into()];
+                                if let Some(h) = auto_refresh.take() {
+                                    h.abort();
+                                }
+                                auto_refresh = Some(match app.mode {
+                                    Mode::Thinkers => spawn_auto_refresh(
+                                        cmd_tx.clone(),
+                                        "thinkers".into(),
+                                        vec!["status".into()],
+                                        Duration::from_secs(2),
+                                    ),
+                                    _ => spawn_auto_refresh(
+                                        cmd_tx.clone(),
+                                        "traj".into(),
+                                        vec!["tail".into(), "-r".into(), "-n".into(), "50".into()],
+                                        Duration::from_secs(2),
+                                    ),
+                                });
+                            }
+                        } else {
                             let msg = mem::take(&mut app.input);
                             app.cursor = 0;
                             app.history_idx = None;
-                            app.history.push(msg.clone());
+                            let hist = app.history_mut();
+                            if hist.last() != Some(&msg) {
+                                hist.push(msg.clone());
+                            }
                             let trimmed = msg.trim();
 
                             // Slash command handling (available in all modes)
+                            if trimmed.starts_with('/') {
+                                app.refresh_paused = false;
+                            }
                             if trimmed == "/thinkers" {
                                 app.mode = Mode::Thinkers;
                                 app.cmd_output = vec!["Loading...".into()];
@@ -698,6 +800,7 @@ async fn run(
                                         if let Some(h) = auto_refresh.take() {
                                             h.abort();
                                         }
+                                        app.refresh_paused = true;
                                         let tx = cmd_tx.clone();
                                         let args_str = msg;
                                         tokio::spawn(async move {
@@ -710,6 +813,7 @@ async fn run(
                                         if let Some(h) = auto_refresh.take() {
                                             h.abort();
                                         }
+                                        app.refresh_paused = true;
                                         let tx = cmd_tx.clone();
                                         let args_str = msg;
                                         tokio::spawn(async move {
@@ -787,19 +891,9 @@ async fn run(
                         if cy > 0 {
                             // Move cursor up one display row
                             app.cursor = char_at_xy(&app.input, cx, cy - 1, inner_w);
-                        } else if !app.history.is_empty() {
+                        } else {
                             // At top line — cycle history
-                            let idx = match app.history_idx {
-                                None => {
-                                    app.stashed_input = app.input.clone();
-                                    app.history.len() - 1
-                                }
-                                Some(i) if i > 0 => i - 1,
-                                Some(i) => i,
-                            };
-                            app.history_idx = Some(idx);
-                            app.input = app.history[idx].clone();
-                            app.cursor = app.input.chars().count();
+                            app.history_prev();
                         }
                     }
                     KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -809,18 +903,9 @@ async fn run(
                         if cy + 1 < total {
                             // Move cursor down one display row
                             app.cursor = char_at_xy(&app.input, cx, cy + 1, inner_w);
-                        } else if let Some(idx) = app.history_idx {
+                        } else {
                             // At bottom line — cycle history
-                            if idx + 1 < app.history.len() {
-                                let next = idx + 1;
-                                app.history_idx = Some(next);
-                                app.input = app.history[next].clone();
-                                app.cursor = app.input.chars().count();
-                            } else {
-                                app.history_idx = None;
-                                app.input = mem::take(&mut app.stashed_input);
-                                app.cursor = app.input.chars().count();
-                            }
+                            app.history_next();
                         }
                     }
                     KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -852,12 +937,14 @@ async fn run(
                         }
                     }
                     KeyCode::Up => {
-                        // Move cursor up one display row
+                        // Move cursor up one display row; recall history from the top row
                         let inner_w = terminal.size().map_or(78, |s| s.width.saturating_sub(2)) as usize;
                         if inner_w > 0 {
                             let (cx, cy) = cursor_xy(&app.input, app.cursor, inner_w);
                             if cy > 0 {
                                 app.cursor = char_at_xy(&app.input, cx, cy - 1, inner_w);
+                            } else {
+                                app.history_prev();
                             }
                         }
                     }
@@ -868,6 +955,8 @@ async fn run(
                             let total = wrap_input(&app.input, inner_w).len() as u16;
                             if cy + 1 < total {
                                 app.cursor = char_at_xy(&app.input, cx, cy + 1, inner_w);
+                            } else {
+                                app.history_next();
                             }
                         }
                     }
@@ -951,7 +1040,11 @@ fn draw(f: &mut Frame, app: &App) {
         .split(f.size());
 
     // Title bar — inverted (white on dark) full-width bar
-    let title_text = app.mode_title();
+    let title_text = if app.quit_armed.is_some() {
+        format!("{}— press ctrl+c again to quit ", app.mode_title())
+    } else {
+        app.mode_title()
+    };
     let bar_width = chunks[0].width as usize;
     let padded = format!("{:<width$}", title_text, width = bar_width);
     let title = Line::from(Span::styled(
@@ -1018,7 +1111,14 @@ fn draw(f: &mut Frame, app: &App) {
         0
     };
 
-    let input_text: Vec<Line> = wrapped.iter().map(|l| Line::from(l.as_str())).collect();
+    let input_text: Vec<Line> = if app.input.is_empty() && app.refresh_paused {
+        vec![Line::from(Span::styled(
+            "press enter to return to the live view",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        wrapped.iter().map(|l| Line::from(l.as_str())).collect()
+    };
     let input = Paragraph::new(input_text)
         .block(Block::default().borders(Borders::ALL).title(" > "))
         .scroll((input_scroll, 0));


### PR DESCRIPTION
## Summary
- **Trajectory inheritance**: add `--traj` flag with `--resume` as a shorthand; thinkers now write to the root trajectory
- **Executive attention**: the executive thinker reads other thinkers' steps and gains an `idle` type
- **Symlink installs**: `--symlinks` installs symlink thinker and kernel files into identities
- **TUI history**: Up/Down recall command history when the cursor is on the top/bottom input row (readline convention), kept per mode (chat/thinkers/traj/command), skipping consecutive duplicates
- **TUI live view**: after running a one-off command in thinkers/traj mode, pressing Enter on an empty input returns to the auto-refreshing live view, with a placeholder hint in the input box

🤖 Generated with [Claude Code](https://claude.com/claude-code)