### PR TITLE
Fix bash 3.2 crash in docker broker, fix executive loop stall

### DIFF
--- a/bin/shellm-docker-broker
+++ b/bin/shellm-docker-broker
@@ -69,34 +69,37 @@ path_under() {
 
 symlink_mounts() {
     local workdir="$1"
-    local -A mount_dirs=()
-    while IFS= read -r -d '' link; do
-        local target
-        target=$(readlink -f "$link" 2>/dev/null) || continue
-        path_under "$target" "$workdir" && continue
-        [[ -e "$target" ]] || continue
-        local parent
-        parent=$(dirname "$target")
-        mount_dirs["$parent"]=1
-    done < <(find "$workdir" -type l -print0 2>/dev/null)
+
+    # bash 3.2 lacks associative arrays, so dedupe via sort -u.
+    local -a mount_dirs=()
+    local line
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && mount_dirs+=("$line")
+    done < <(
+        while IFS= read -r -d '' link; do
+            local target
+            target=$(readlink -f "$link" 2>/dev/null) || continue
+            path_under "$target" "$workdir" && continue
+            [[ -e "$target" ]] || continue
+            dirname "$target"
+        done < <(find "$workdir" -type l -print0 2>/dev/null) \
+        | sort -u
+    )
+
+    [[ "${#mount_dirs[@]}" -eq 0 ]] && return 0
 
     # Remove dirs that are subdirs of other dirs in the set
-    local -a unique=()
-    local dir other
-    for dir in "${!mount_dirs[@]}"; do
-        local dominated=false
-        for other in "${!mount_dirs[@]}"; do
+    local dir other dominated
+    for dir in "${mount_dirs[@]}"; do
+        dominated=0
+        for other in "${mount_dirs[@]}"; do
             [[ "$dir" == "$other" ]] && continue
             if path_under "$dir" "$other"; then
-                dominated=true
+                dominated=1
                 break
             fi
         done
-        $dominated || unique+=("$dir")
-    done
-
-    for dir in "${unique[@]}"; do
-        printf -- '-v\n%s:%s:ro\n' "$dir" "$dir"
+        [[ "$dominated" -eq 0 ]] && printf -- '-v\n%s:%s:ro\n' "$dir" "$dir"
     done
 }
 

--- a/thinkers/executive/step
+++ b/thinkers/executive/step
@@ -142,7 +142,14 @@ response=$(printf '%s' "$full_message" | \
     -s "Output only a single thought or action. No explanation, no commands, no preamble." \
     2>/dev/null) || true
 
-[[ -z "$response" ]] && { printf 'executive/step: empty response from shellm\n' >&2; exit 1; }
+# The executive is an infinite loop via trigger_self: it must ALWAYS append
+# something to the traj so the dispatcher re-fires.  Empty/duplicate responses
+# are degraded but still emit a thought to keep the loop alive.
+if [[ -z "$response" ]]; then
+    printf 'executive/step: empty response from llm — emitting placeholder\n' >&2
+    response="(executive received an empty response from the LLM; continuing)"
+    sleep 1   # brief backoff so transient API failures don't tight-loop
+fi
 
 # Determine step type and strip prefix from content
 step_type="thought"
@@ -162,16 +169,18 @@ case "$response" in
         ;;
 esac
 
-# Write to traj
+# Write to traj — always append (even duplicates) to keep trigger_self alive
 last_content=""
 if traj exists 2>/dev/null; then
     last_content=$(traj last --field content 2>/dev/null) || true
 fi
 
-if [[ "$last_content" != "$step_content" ]]; then
-    printf '{"type":"%s","content":%s,"source":"executive"}' \
-        "$step_type" "$(printf '%s' "$step_content" | jq -Rsa .)" \
-        | traj append >/dev/null
+if [[ "$response" == "$last_content" ]]; then
+    step_content="$step_content (repeat)"
 fi
+
+printf '{"type":"%s","content":%s,"source":"executive"}' \
+    "$step_type" "$(printf '%s' "$step_content" | jq -Rsa .)" \
+    | traj append >/dev/null
 
 printf '[%s] %s\n' "$step_type" "$step_content"


### PR DESCRIPTION
## Summary

Two bug fixes extracted from the now-closed PR #12:

- **`shellm-docker-broker` bash 3.2 crash** — `symlink_mounts()` used `local -A` (associative arrays, bash 4+ only), which silently crashes on macOS default bash 3.2. Replaced with indexed array populated via `sort -u` dedup.

- **Executive infinite-loop stall** — the executive relies on `trigger_self=true` to re-fire after each thought, but two conditions broke the loop: empty LLM response (`exit 1`, no traj append) and duplicate response (dedup guard skips append). Both leave the FIFO dry. Fix: always append — placeholder on empty (with 1s backoff), `" (repeat)"` suffix on duplicate.

## Test plan

- [ ] `bash -n bin/shellm-docker-broker` passes under bash 3.2
- [ ] Executive no longer stalls when LLM returns empty or duplicate responses
- [ ] `symlink_mounts` still correctly deduplicates and filters subdirectory mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)