### PR TITLE
Add --env and --workdir to _build_shellm_flags for thinkers

### DIFF
--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -161,9 +161,11 @@ _build_skill_var_flags() {
     fi
 }
 
-# Build common --var and --bin flags for shellm calls
+# Build common shellm flags: --env, --workdir, --var, --bin.
+# Honors SHELLM_THINKER_ENV to override the env (e.g. =local to skip Docker).
 _build_shellm_flags() {
     local identity_dir="$1"
+    local run_dir="${2:-$identity_dir/workdir}"
     local abs_mem_dir abs_skills_dir abs_kernel_dir abs_traj_dir
 
     abs_mem_dir=$(_abs_path "$MEM_DIR")
@@ -171,6 +173,8 @@ _build_shellm_flags() {
     abs_kernel_dir=$(_abs_path "$SKILLS_KERNEL_DIR")
     abs_traj_dir=$(_abs_path "$TRAJ_DIR")
 
+    printf '%s\n' "--env" "${SHELLM_THINKER_ENV:-$IDENTITY_NAME}"
+    printf '%s\n' "--workdir" "$run_dir"
     printf '%s\n' "--var" "MEM_DIR=$abs_mem_dir"
     printf '%s\n' "--var" "SKILLS_DIR=$abs_skills_dir"
     printf '%s\n' "--var" "SKILLS_KERNEL_DIR=$abs_kernel_dir"

--- a/thinkers/actor/step
+++ b/thinkers/actor/step
@@ -34,7 +34,7 @@ mkdir -p "$run_dir"
 shellm_flags=()
 while IFS= read -r _flag; do
     [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
-done < <(_build_shellm_flags "$IDENTITY_DIR")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
 
 # Load thinker prompt
 prompt_file="$SCRIPT_DIR/prompt.md"


### PR DESCRIPTION
## Summary

- **`_build_shellm_flags` missing --env/--workdir** — PR #14 removed hardcoded `--env`/`--workdir` from all thinker step scripts in favor of using `_build_shellm_flags()`, but the function was never updated to emit those flags. Thinkers were calling shellm with no env or workdir, causing each invocation to fall through to default env selection (potentially creating new Docker containers instead of reusing the identity's).

- Adds `--env` flag defaulting to `$IDENTITY_NAME`, overridable via `SHELLM_THINKER_ENV` (e.g. `=local` to skip Docker)
- Adds `--workdir` flag defaulting to `$identity_dir/workdir`, overridable via second argument (used by actor for its custom `run_dir`)

## Test plan

- [ ] Thinker shellm calls reuse the identity's Docker env instead of creating new ones
- [ ] `SHELLM_THINKER_ENV=local thinkers start` runs thinkers without Docker
- [ ] Actor passes its custom `run_dir` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)