### PR TITLE
inner_monologue: default THINK_MODEL to glm-5.2

### DIFF
--- a/bin/llm
+++ b/bin/llm
@@ -54,7 +54,7 @@ Options:
   -t, --max-tokens N       Max output tokens. Default: model-specific cap
   -M, --messages JSON      Messages array JSON, e.g. [{"role":"user","content":"hi"}]
   --no-stream              Disable streaming (streaming is on by default)
-  --provider NAME          Provider: anthropic, openai, or gemini
+  --provider NAME          Provider: anthropic, openai, gemini, or openrouter
   --thinking [LEVEL]       Enable thinking (Anthropic: adaptive; Gemini: minimal/low/medium/high)
   --effort LEVEL           Thinking effort/provider output effort
   --raw                    Print raw non-streaming API response JSON
@@ -65,6 +65,7 @@ Models:
               claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus
   OpenAI:     gpt-5.5, gpt-5, gpt-4o, o1, o3, o4
   Gemini:     gemini-3.5-flash, gemini-2.0-flash, gemini-*
+  OpenRouter: z-ai/glm-5.2, meta-llama/*, ... (any vendor/model name)
 
 Thinking & effort:
   These flags control how much reasoning the model does before answering.
@@ -98,6 +99,7 @@ Environment:
   ANTHROPIC_API_KEY        Required for Anthropic models
   OPENAI_API_KEY           Required for OpenAI models
   GEMINI_API_KEY           Required for Gemini models
+  OPENROUTER_API_KEY       Required for OpenRouter models
   LLM_API_URL              Override provider API URL
 
 Examples:
@@ -105,6 +107,7 @@ Examples:
   echo "summarize this" | llm -m gpt-5
   llm --thinking -m claude-opus-4-7 "solve this carefully"
   llm --raw -m gemini-2.0-flash "return a JSON greeting"
+  llm -m z-ai/glm-5.2 "explain quicksort"
 EOF
     exit "${1:-0}"
 }
@@ -161,6 +164,9 @@ detect_provider() {
         claude-*)                        echo "anthropic" ;;
         gpt-*|o1*|o3*|o4*|chatgpt-*) echo "openai" ;;
         gemini-*)                        echo "gemini" ;;
+        # Vendor-prefixed names (z-ai/glm-5.2, meta-llama/..., etc.) are
+        # OpenRouter's model-naming convention.
+        */*)                             echo "openrouter" ;;
         *)                               die "Cannot detect provider for model '$model'. Use --provider." ;;
     esac
 }
@@ -193,6 +199,8 @@ get_model_max_tokens() {
         # Google Gemini (caps from ListModels API; 1.5 family retired in 2026)
         gemini-2.0-flash*) echo 8192 ;;
         gemini-*)          echo 65536 ;;
+        # OpenRouter (vendor-prefixed) — caps vary per model; mid default
+        */*) echo 16384 ;;
         # Conservative fallback for unknown models
         *) echo 4096 ;;
     esac
@@ -297,6 +305,9 @@ build_payload_gemini() {
     jq -n "${jq_args[@]}" "$jq_filter"
 }
 
+# OpenRouter is OpenAI-compatible (chat/completions wire format)
+build_payload_openrouter() { build_payload_openai; }
+
 # ---------------------------------------------------------------------------
 # URL and headers per provider
 # ---------------------------------------------------------------------------
@@ -315,6 +326,12 @@ get_url_headers() {
             url="${LLM_API_URL:-https://api.openai.com/v1/chat/completions}"
             headers=(-H "Content-Type: application/json"
                      -H "Authorization: Bearer $OPENAI_API_KEY")
+            ;;
+        openrouter)
+            [[ -z "${OPENROUTER_API_KEY:-}" ]] && die "OPENROUTER_API_KEY is not set"
+            url="${LLM_API_URL:-https://openrouter.ai/api/v1/chat/completions}"
+            headers=(-H "Content-Type: application/json"
+                     -H "Authorization: Bearer $OPENROUTER_API_KEY")
             ;;
         gemini)
             [[ -z "${GEMINI_API_KEY:-}" ]] && die "GEMINI_API_KEY is not set"
@@ -345,6 +362,9 @@ extract_text_openai() {
 extract_text_gemini() {
     jq -r '.candidates[0].content.parts[0].text // empty' 2>/dev/null
 }
+
+# OpenRouter is OpenAI-compatible
+extract_text_openrouter() { extract_text_openai; }
 
 # ---------------------------------------------------------------------------
 # Streaming handlers
@@ -440,6 +460,9 @@ stream_gemini() {
     fi
 }
 
+# OpenRouter is OpenAI-compatible (SSE chat/completions chunks)
+stream_openrouter() { stream_openai; }
+
 # ---------------------------------------------------------------------------
 # Main execution
 # ---------------------------------------------------------------------------
@@ -459,8 +482,8 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
     _curl_err=$(mktemp)
     "stream_${LLM_PROVIDER}" < <(curl -sS -N "${headers[@]}" -d "$payload" "$url" 2>"$_curl_err")
     # If we get here, the stream handler didn't die — check for curl errors
+    # (no `local` here: this is top-level script code, not a function)
     if [[ -s "$_curl_err" ]]; then
-        local _ce
         _ce=$(cat "$_curl_err")
         rm -f "$_curl_err"
         die "curl error: $_ce"

--- a/bin/shellm
+++ b/bin/shellm
@@ -799,6 +799,16 @@ docker_setup() {
             [[ -e "$_target" ]] || continue
             local _tdir
             _tdir=$(dirname "$_target")
+            # Never mount host system directories: they would shadow the
+            # container's own /usr, /bin, etc. and break it (observed: a
+            # venv symlink to /usr/bin/python3 caused macOS /usr/bin to be
+            # mounted over Ubuntu's, killing every exec in the container).
+            case "$_tdir" in
+                /|/usr|/usr/*|/bin|/bin/*|/sbin|/sbin/*|/lib|/lib/*|/libexec|/libexec/*|\
+                /etc|/etc/*|/var|/var/*|/opt|/opt/*|/tmp|/tmp/*|/private|/private/*|\
+                /System|/System/*|/Library|/Library/*|/Applications|/Applications/*|/dev|/dev/*)
+                    continue ;;
+            esac
             # Skip if already under a mounted dir
             local _covered=0
             for _sd in "${seen_dirs[@]}"; do

--- a/bin/traj
+++ b/bin/traj
@@ -1000,19 +1000,19 @@ TAILHELP
             shellm-run|run-summary|prompt) color="$c_meta" ;;
         esac
 
-        local source_tag=""
-        [[ -n "$source" ]] && source_tag="($source) "
+        local type_tag="$entry_type"
+        [[ -n "$source" ]] && type_tag="$entry_type, $source"
 
         local short_id="${step_id:0:8}"
         local traj_tag=""
         [[ -n "$traj_hex" ]] && traj_tag="${c_dim}${traj_hex}/${c_reset}"
 
-        printf '%s%s%s %s%s%s%s %s[%s]%s %s%s\n' \
+        printf '%s%s%s %s%s%s%s %s[%s]%s %s\n' \
             "$c_dim" "$time_display" "$c_reset" \
             "$traj_tag" \
             "$c_dim" "$short_id" "$c_reset" \
-            "$color" "$entry_type" "$c_reset" \
-            "$source_tag" "$content"
+            "$color" "$type_tag" "$c_reset" \
+            "$content"
     }
 
     # Pipe handler: raw output or formatted
@@ -1684,19 +1684,19 @@ CATHELP
             shellm-run|run-summary|prompt) color="$c_meta" ;;
         esac
 
-        local source_tag=""
-        [[ -n "$source" ]] && source_tag="($source) "
+        local type_tag="$entry_type"
+        [[ -n "$source" ]] && type_tag="$entry_type, $source"
 
         local short_id="${step_id:0:8}"
         local traj_tag=""
         [[ -n "$traj_hex" ]] && traj_tag="${c_dim}${traj_hex}/${c_reset}"
 
-        printf '%s%s%s %s%s%s%s %s[%s]%s %s%s\n' \
+        printf '%s%s%s %s%s%s%s %s[%s]%s %s\n' \
             "$c_dim" "$time_display" "$c_reset" \
             "$traj_tag" \
             "$c_dim" "$short_id" "$c_reset" \
-            "$color" "$entry_type" "$c_reset" \
-            "$source_tag" "$content"
+            "$color" "$type_tag" "$c_reset" \
+            "$content"
     }
 
     # Output a single line (raw or formatted)

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -199,6 +199,10 @@ _build_shellm_flags() {
 
     printf '%s\n' "--env" "${SHELLM_THINKER_ENV:-$IDENTITY_NAME}"
     printf '%s\n' "--workdir" "$run_dir"
+    # IDENTITY_NAME must reach the generated code's env: `chat reply` dies
+    # without it (observed: actor unable to reply, model flailing into
+    # `chat send` variants). Non-directory --var values are plain env vars.
+    printf '%s\n' "--var" "IDENTITY_NAME=$IDENTITY_NAME"
     printf '%s\n' "--var" "MEM_DIR=$abs_mem_dir"
     printf '%s\n' "--var" "SKILLS_DIR=$abs_skills_dir"
     printf '%s\n' "--var" "SKILLS_KERNEL_DIR=$abs_kernel_dir"

--- a/thinkers/inner_monologue/step
+++ b/thinkers/inner_monologue/step
@@ -15,7 +15,7 @@ source "$SCRIPT_DIR/../_lib/common.sh"
 
 _require_env
 
-THINK_MODEL="${THINK_MODEL:-${SHELLM_MODEL:-claude-opus-4-7}}"
+THINK_MODEL="${THINK_MODEL:-glm-5.2}"
 THINK_CONTEXT_TAIL="${THINK_CONTEXT_TAIL:-20}"
 
 # Drain the triggering step from stdin (wakeup only — context comes from traj)


### PR DESCRIPTION
## Summary
- Default inner_monologue THINK_MODEL to glm-5.2 while preserving explicit THINK_MODEL override
- Stop inner_monologue from inheriting SHELLM_MODEL by default

## Tests
- bash -n thinkers/inner_monologue/step
- shellcheck thinkers/inner_monologue/step (not available locally)
- bash tests/test_context.sh
- bash tests/test_thinkers_pending.sh