### PR TITLE
flesh out admin dashboard; deploy tooling

### DIFF
--- a/bin/thinkers
+++ b/bin/thinkers
@@ -142,6 +142,8 @@ _list_thinker_dirs() {
         name=$(basename "$dir")
         # Skip internal directories
         [[ "$name" == _* ]] && continue
+        # Skip thinkers disabled via marker file (touch <thinker>/disabled)
+        [[ -f "$dir/disabled" ]] && continue
         # Must have step and subscriptions.jsonl
         [[ -f "$dir/step" && -f "$dir/subscriptions.jsonl" ]] || continue
         printf '%s\n' "$dir"
@@ -567,6 +569,8 @@ cmd_start() {
         for name in "$@"; do
             local thinker_dir="$THINKERS_DIR/$name"
             [[ -d "$thinker_dir" ]] || die "Thinker not found: $name"
+            [[ -f "$thinker_dir/disabled" ]] && \
+                die "Thinker '$name' is disabled (remove $thinker_dir/disabled to enable)"
             [[ -f "$thinker_dir/step" && -f "$thinker_dir/subscriptions.jsonl" ]] || \
                 die "Thinker '$name' missing step or subscriptions.jsonl"
         done

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -1,0 +1,132 @@
+# Deploying shellm-web behind Cloudflare Zero Trust
+
+Goal: a private URL (e.g. `https://agents.example.com`) where allow-listed
+people can watch, start/stop, and chat with identities. Architecture:
+
+```
+boss's browser ── Cloudflare Access (SSO / email OTP)
+                        │
+                  Cloudflare Tunnel (outbound-only from the VM)
+                        │
+                 127.0.0.1:8080  shellm-web (systemd)
+                        │ spawns
+                 dispatchers + thinkers (own sessions, survive restarts)
+```
+
+No inbound ports are ever opened on the VM. Auth lives entirely in
+Cloudflare Access; the app itself stays auth-free.
+
+## 0. Prerequisites
+
+- A domain on Cloudflare and access to the Zero Trust dashboard (free tier
+  covers this seat count).
+- A small Ubuntu 22.04/24.04 VM (EC2 t4g.small / Lightsail / etc.).
+  **Treat it as burnable** — the agent executes arbitrary bash on it. Run
+  nothing else there.
+- A **dedicated, spend-capped** Anthropic API key. A runaway thinker loop
+  is a token furnace; the cap is your real safety net.
+
+## 1. Provision the app
+
+```bash
+git clone https://github.com/andyk/shellm.git
+sudo bash shellm/deploy/setup.sh          # or run from your checkout
+```
+
+The script creates a `shellm` system user, clones the repo to
+`/opt/shellm/app`, installs uv + bun, prebuilds the viewer, and starts the
+`shellm-web` systemd service on `127.0.0.1:8080`. Pass `SHELLM_REPO` /
+`SHELLM_BRANCH` env vars to deploy a fork or feature branch.
+
+Then add the API key:
+
+```bash
+sudo -u shellm nano /opt/shellm/app/.env    # set ANTHROPIC_API_KEY=...
+sudo systemctl restart shellm-web
+curl -s localhost:8080/api/health           # {"status":"ok"}
+```
+
+## 2. Cloudflare Tunnel
+
+In the Zero Trust dashboard: **Networks → Tunnels → Create a tunnel**
+(Cloudflared connector). Copy the install command it shows and run it on
+the VM — it installs `cloudflared` and a systemd service in one step:
+
+```bash
+curl -L https://pkg.cloudflare.com/cloudflared-stable-linux-amd64.deb -o cloudflared.deb
+sudo dpkg -i cloudflared.deb              # (arm64 build for t4g instances)
+sudo cloudflared service install <TOKEN-FROM-DASHBOARD>
+```
+
+In the tunnel's **Public Hostname** tab, add:
+
+- Subdomain/domain: `agents.example.com`
+- Service: `HTTP://localhost:8080`
+
+Visit the hostname — you should see the viewer (still unprotected; next
+step fixes that, so do it immediately).
+
+## 3. Cloudflare Access policy
+
+**Access → Applications → Add an application → Self-hosted**:
+
+- Application domain: `agents.example.com`
+- Policy: Action **Allow**, Include → **Emails** → your email + your
+  boss's email. (Or an IdP group if you have Google/Okta wired up.)
+- Session duration: e.g. 1 week.
+
+That's the whole login system. Anyone not on the list gets Cloudflare's
+block page; people on it authenticate once and land in the viewer.
+
+## 4. Lock CORS to the public hostname
+
+Uncomment in `/etc/systemd/system/shellm-web.service`:
+
+```ini
+Environment="SHELLM_WEB_ALLOWED_ORIGINS=https://agents.example.com"
+```
+
+then `sudo systemctl daemon-reload && sudo systemctl restart shellm-web`.
+(Default is `*`, which is fine on a laptop but pointless exposure on a
+deployment. Comma-separate multiple origins if you need them.)
+
+## 5. Operating it
+
+| Task | Command |
+|---|---|
+| Logs | `journalctl -u shellm-web -f` |
+| Restart web server (agents keep running) | `sudo systemctl restart shellm-web` |
+| Stop every agent process | `sudo -u shellm /opt/shellm/app/bin/shellm-killall` |
+| Update to latest code | see below |
+| View-only mode | uncomment `SHELLM_WEB_READONLY=1` in the unit |
+
+**Updating:**
+
+```bash
+sudo -u shellm git -C /opt/shellm/app pull
+sudo -u shellm rm -rf /opt/shellm/app/web/src/shellm_web/static  # forces frontend rebuild
+sudo systemctl restart shellm-web
+```
+
+**Kill switches, in escalating order:** Kill All button in the UI →
+`shellm-killall` on the box → `systemctl stop shellm-web` → stop the VM.
+
+## Security notes
+
+- The VM is the sandbox. Dedicated key with a spend cap, nothing else on
+  the machine, snapshot before demos if you're nervous.
+- `shellm-web` binds `127.0.0.1` and the tunnel is outbound-only, so the
+  only path in is through Access. Don't "temporarily" bind `0.0.0.0`.
+- Secrets: root key in `/opt/shellm/app/.env` (mode 600); per-identity
+  overrides via the Config tab (stored in `<identity>/.env`).
+- Optional: install Docker (`apt install docker.io`, add `shellm` to the
+  `docker` group) so generated code runs in shellm's Docker sandbox
+  instead of directly on the host.
+
+## Quick demo alternative (no VM)
+
+Run the tunnel from any machine you already have (dev box, spare Mac):
+create the same dashboard tunnel + Access app, run
+`cloudflared service install <TOKEN>` locally, point the public hostname
+at `http://localhost:8080`, and start `./bin/shellm-web`. Same URL, same
+login, zero infra — it just stops when your laptop sleeps.

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -31,6 +31,15 @@ echo "==> Installing system packages"
 apt-get update -qq
 apt-get install -y -qq git jq curl unzip
 
+# Real Node is required for the frontend build: without it, bun shims
+# `node` with itself and react-router's build crashes on react-dom's
+# bun-specific server entry (renderToPipeableStream missing).
+if ! command -v node >/dev/null 2>&1; then
+    echo "==> Installing Node.js 22"
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+    apt-get install -y -qq nodejs
+fi
+
 echo "==> Creating service user $SHELLM_USER (home: $SHELLM_HOME)"
 if ! id "$SHELLM_USER" >/dev/null 2>&1; then
     useradd --system --create-home --home-dir "$SHELLM_HOME" --shell /bin/bash "$SHELLM_USER"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# deploy/setup.sh — provision a fresh Ubuntu VM to run shellm-web.
+#
+# Creates a dedicated `shellm` user, clones the repo to /opt/shellm/app,
+# installs uv + bun for that user, prebuilds the viewer frontend, and
+# installs + starts the systemd service (listening on 127.0.0.1:8080).
+#
+# Run as root (or with sudo) on Ubuntu 22.04/24.04:
+#   sudo bash deploy/setup.sh
+#
+# Override defaults via env:
+#   SHELLM_REPO=https://github.com/andyk/shellm.git
+#   SHELLM_BRANCH=main
+#   SHELLM_HOME=/opt/shellm
+#
+# After this script: put your (spend-capped!) API key in
+# /opt/shellm/app/.env and set up the Cloudflare tunnel — see DEPLOY.md.
+
+SHELLM_REPO="${SHELLM_REPO:-https://github.com/andyk/shellm.git}"
+SHELLM_BRANCH="${SHELLM_BRANCH:-main}"
+SHELLM_HOME="${SHELLM_HOME:-/opt/shellm}"
+SHELLM_USER="shellm"
+APP_DIR="$SHELLM_HOME/app"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[[ "$(id -u)" -eq 0 ]] || { echo "Run as root (sudo bash deploy/setup.sh)" >&2; exit 1; }
+
+echo "==> Installing system packages"
+apt-get update -qq
+apt-get install -y -qq git jq curl unzip
+
+echo "==> Creating service user $SHELLM_USER (home: $SHELLM_HOME)"
+if ! id "$SHELLM_USER" >/dev/null 2>&1; then
+    useradd --system --create-home --home-dir "$SHELLM_HOME" --shell /bin/bash "$SHELLM_USER"
+fi
+
+echo "==> Cloning $SHELLM_REPO ($SHELLM_BRANCH) to $APP_DIR"
+if [[ -d "$APP_DIR/.git" ]]; then
+    sudo -u "$SHELLM_USER" git -C "$APP_DIR" fetch origin "$SHELLM_BRANCH"
+    sudo -u "$SHELLM_USER" git -C "$APP_DIR" checkout "$SHELLM_BRANCH"
+    sudo -u "$SHELLM_USER" git -C "$APP_DIR" pull --ff-only origin "$SHELLM_BRANCH"
+else
+    sudo -u "$SHELLM_USER" git clone --branch "$SHELLM_BRANCH" "$SHELLM_REPO" "$APP_DIR"
+fi
+
+echo "==> Installing uv and bun for $SHELLM_USER"
+sudo -u "$SHELLM_USER" bash -c 'command -v ~/.local/bin/uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh'
+sudo -u "$SHELLM_USER" bash -c 'command -v ~/.bun/bin/bun >/dev/null 2>&1 || curl -fsSL https://bun.sh/install | bash'
+
+echo "==> Prebuilding the viewer frontend"
+sudo -u "$SHELLM_USER" bash -c "
+    set -euo pipefail
+    export PATH=\"\$HOME/.local/bin:\$HOME/.bun/bin:\$PATH\"
+    cd '$APP_DIR/web/viewer'
+    bun install --frozen-lockfile
+    bun run build
+    rm -rf '$APP_DIR/web/src/shellm_web/static'
+    cp -R build/client '$APP_DIR/web/src/shellm_web/static'
+    cd '$APP_DIR/web' && uv sync
+"
+
+echo "==> Seeding $APP_DIR/.env (add your API key here)"
+if [[ ! -f "$APP_DIR/.env" ]]; then
+    sudo -u "$SHELLM_USER" tee "$APP_DIR/.env" >/dev/null <<'ENV'
+# Root env sourced by web-launched thinkers (and llm/shellm run from here).
+# Use a DEDICATED, SPEND-CAPPED key: the agent executes arbitrary bash.
+ANTHROPIC_API_KEY=
+# SHELLM_MODEL=claude-opus-4-7
+ENV
+    chmod 600 "$APP_DIR/.env"
+fi
+
+echo "==> Installing systemd service"
+sed "s|@SHELLM_HOME@|$SHELLM_HOME|g" "$SCRIPT_DIR/shellm-web.service" \
+    > /etc/systemd/system/shellm-web.service
+systemctl daemon-reload
+systemctl enable --now shellm-web
+
+echo
+echo "Done. shellm-web is running on 127.0.0.1:8080 (not publicly reachable)."
+echo
+echo "Next steps:"
+echo "  1. Add your spend-capped API key to $APP_DIR/.env"
+echo "     then: systemctl restart shellm-web"
+echo "  2. Set up the Cloudflare tunnel + Access policy — see deploy/DEPLOY.md"

--- a/deploy/shellm-web.service
+++ b/deploy/shellm-web.service
@@ -1,0 +1,31 @@
+# shellm-web systemd unit. Installed by deploy/setup.sh, which substitutes
+# @SHELLM_HOME@ (default /opt/shellm; the repo lives at @SHELLM_HOME@/app).
+#
+# The web server binds 127.0.0.1 only — expose it exclusively through the
+# Cloudflare tunnel (see deploy/DEPLOY.md). Dispatchers started from the UI
+# run in their own sessions and survive restarts of this service.
+
+[Unit]
+Description=shellm web viewer + control plane
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=shellm
+WorkingDirectory=@SHELLM_HOME@/app
+Environment="PATH=@SHELLM_HOME@/.local/bin:@SHELLM_HOME@/.bun/bin:/usr/local/bin:/usr/bin:/bin"
+# Lock CORS to your public hostname once the tunnel is up:
+#Environment="SHELLM_WEB_ALLOWED_ORIGINS=https://agents.example.com"
+# For a view-only deployment (no start/stop/chat/config mutations):
+#Environment="SHELLM_WEB_READONLY=1"
+ExecStart=@SHELLM_HOME@/app/bin/shellm-web @SHELLM_HOME@/app --host 127.0.0.1 --port 8080
+Restart=always
+RestartSec=3
+
+# The agent needs broad shell access by design — do NOT run anything else on
+# this machine. Kill switches: `systemctl stop shellm-web` stops the control
+# plane; `@SHELLM_HOME@/app/bin/shellm-killall` stops all agent processes.
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -1,0 +1,9 @@
+.envrc
+env.sh
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.*
+terraform.tfvars
+*.auto.tfvars
+crash.log

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -192,7 +192,7 @@ arbitrary bash on this box; the cap is the real safety net.
 | Shell on the box | `$(terraform output -raw ssm_session_command)` |
 | Watch first-boot progress | in a session: `tail -f /var/log/shellm-bootstrap.log` |
 | App logs | `journalctl -u shellm-web -f` |
-| Update the app | `sudo -u shellm git -C /opt/shellm/app pull && sudo -u shellm rm -rf /opt/shellm/app/web/src/shellm_web/static && sudo systemctl restart shellm-web` |
+| Update the app (after pushing!) | `eval "$(terraform output -raw update_command)"` — streams deploy/update.sh (pull, rebuild, restart, health check) |
 | Add/remove viewers | edit `allowed_emails`, `terraform apply` |
 | Panic | Kill All in the UI → `shellm-killall` on the box → stop the instance |
 | Rebuild from scratch | `terraform destroy && terraform apply`, then re-install the API key (identities/trajectories are lost — copy them off first if they matter) |

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -22,6 +22,8 @@ One `terraform apply` builds the whole stack from `deploy/DEPLOY.md`:
 - A Cloudflare API token in `CLOUDFLARE_API_TOKEN` with:
   - **Account → Cloudflare Tunnel → Edit**
   - **Account → Access: Apps and Policies → Edit**
+  - **Account → Access: Organizations, Identity Providers, and Groups → Edit**
+    (for the email-OTP login method)
   - **Zone → DNS → Edit** (scoped to your zone)
 - Your Cloudflare **account ID** and the zone's **zone ID** (both on the
   dashboard).

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,185 @@
+# Terraform: shellm demo box (AWS + Cloudflare Zero Trust)
+
+One `terraform apply` builds the whole stack from `deploy/DEPLOY.md`:
+
+- **AWS**: a t4g.large Ubuntu 24.04 (arm64) instance with a 40 GB gp3 disk,
+  a security group with **zero inbound rules**, and an SSM instance profile
+  so you get a shell without SSH. First boot runs `deploy/setup.sh`
+  (app under `/opt/shellm/app`, systemd service on `127.0.0.1:8080`),
+  installs cloudflared with the tunnel token, and pins CORS to your
+  hostname.
+- **Cloudflare**: a remotely-configured tunnel with an ingress rule to
+  `localhost:8080`, the proxied CNAME (`agents.example.com` →
+  `<tunnel>.cfargotunnel.com`), and an Access application + email-allowlist
+  policy. Auth lives entirely here; the app has none.
+
+## Prerequisites
+
+- Terraform >= 1.5
+- AWS credentials in your environment (`AWS_PROFILE` / `aws configure`)
+  with rights to manage EC2, IAM roles/instance profiles, and security
+  groups.
+- A Cloudflare API token in `CLOUDFLARE_API_TOKEN` with:
+  - **Account → Cloudflare Tunnel → Edit**
+  - **Account → Access: Apps and Policies → Edit**
+  - **Zone → DNS → Edit** (scoped to your zone)
+- Your Cloudflare **account ID** and the zone's **zone ID** (both on the
+  dashboard).
+
+## AWS permissions
+
+Granularity is IAM policy on the user/role your CLI credentials belong to
+(the CLI itself is just a passthrough). Two sane options:
+
+- **Personal/sandbox account:** attach `AdministratorAccess` and move on.
+- **Scoped:** attach `aws-policy.json` from this directory. It grants full
+  EC2 (Terraform's describe/create/destroy churn makes narrower EC2
+  painful), IAM confined to `shellm-*` roles/instance-profiles (including
+  the sensitive `iam:PassRole`), and the SSM actions for shell sessions:
+
+  ```bash
+  aws iam create-policy --policy-name shellm-terraform \
+      --policy-document file://aws-policy.json
+  aws iam attach-user-policy --user-name <you> \
+      --policy-arn arn:aws:iam::<account-id>:policy/shellm-terraform
+  ```
+
+For the SSM shell you'll also need the client plugin — see "Install the
+tools" below. (It's first-party AWS, Apache-2.0, open source at
+github.com/aws/session-manager-plugin; not a daemon — the CLI spawns it
+per session.)
+
+## What goes where
+
+- **`terraform.tfvars`** — facts about the infrastructure (region, account
+  and zone IDs, domain, emails, branch). Not secrets; edit when the infra
+  should change. Gitignored anyway because the optional API key can live
+  there.
+- **Shell environment** — credentials for the tools: AWS creds live in
+  `~/.aws` via `aws configure` (no export needed for the default profile),
+  and `CLOUDFLARE_API_TOKEN` is the one real export, handled by direnv:
+  `.envrc` (from `envrc.example`) loads it — via 1Password — when you cd
+  into this directory and unloads it when you leave. direnv refuses to run
+  an edited `.envrc` until you `direnv allow` it again. Prefer no plugin?
+  `env.sh.example` is the manual `source` equivalent.
+
+## Setup
+
+### 0. Install the tools (macOS / brew)
+
+```bash
+brew install awscli                       # AWS CLI v2
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform      # brew core's terraform is frozen at 1.5.7
+brew install --cask session-manager-plugin
+brew install --cask 1password-cli         # the `op` command (optional but recommended)
+brew install direnv
+echo 'eval "$(direnv hook bash)"' >> ~/.bashrc && exec bash
+```
+
+`session-manager-plugin` is the client-side helper that gives
+`aws ssm start-session` an interactive terminal — the box has no SSH and
+no inbound ports, so SSM sessions (relayed outbound through AWS,
+authorized by your IAM creds) are the only shell path. The AWS CLI finds
+the plugin on PATH; you never invoke it directly.
+
+For `op`: in the 1Password app enable Settings → Developer →
+"Integrate with 1Password CLI", then store the Cloudflare token once:
+
+```bash
+op item create --category=apiCredential --title=cloudflare-tf \
+    --vault=Private credential=<paste-token>
+```
+
+Verify everything:
+
+```bash
+aws sts get-caller-identity        # AWS creds work
+terraform version                  # from the hashicorp tap
+session-manager-plugin             # "...was installed successfully"
+op vault list                      # 1Password CLI integrated + unlocked
+```
+
+### 1. Configure and apply
+
+```bash
+aws configure                                  # once; verify: aws sts get-caller-identity
+cd deploy/terraform
+cp terraform.tfvars.example terraform.tfvars   # fill in IDs, domain, emails
+cp envrc.example .envrc                        # wire up the CF token (via op or paste)
+direnv allow                                   # re-run after any .envrc edit
+terraform init
+terraform plan
+terraform apply
+```
+
+First boot takes ~5 minutes (apt, uv/bun install, frontend build). Then
+open the `url` output — you'll hit the Access login; anyone not on
+`allowed_emails` gets blocked.
+
+### The API key (recommended flow: keep it off your laptop entirely)
+
+Leave `anthropic_api_key` unset in tfvars and install the key on the box
+after each (re)creation:
+
+```bash
+# 1. wait for first boot to finish (~5 min)
+$(terraform output -raw ssm_session_command)
+tail -f /var/log/shellm-bootstrap.log        # until "shellm bootstrap done"
+
+# 2. install the key — read -rs keeps it out of history and `ps`
+read -rs KEY                                  # paste sk-ant-..., press enter
+sudo -u shellm sed -i "s|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=$KEY|" /opt/shellm/app/.env
+unset KEY
+
+# 3. verify without printing it
+sudo -u shellm grep -q '^ANTHROPIC_API_KEY=sk-' /opt/shellm/app/.env && echo key installed
+```
+
+No restart needed: thinkers source this `.env` every time they start, and
+the web server itself never reads the key.
+
+**Repeat steps 2–3 whenever the instance is recreated** — the key lives
+only on the box, and `user_data_replace_on_change` means changing
+repo/branch/emails recreates it. The tell if you forget: thinker logs loop
+with `ANTHROPIC_API_KEY is not set`.
+
+Alternative (zero-touch rebuilds): set `anthropic_api_key` in tfvars — the
+key then also lives in Terraform state and the EC2 user-data attribute
+(console-visible). Acceptable for a spend-capped key with local state.
+
+Either way: use a **dedicated, spend-capped key**. The agent executes
+arbitrary bash on this box; the cap is the real safety net.
+
+## Day-2 operations
+
+| Task | How |
+|---|---|
+| Shell on the box | `$(terraform output -raw ssm_session_command)` |
+| Watch first-boot progress | in a session: `tail -f /var/log/shellm-bootstrap.log` |
+| App logs | `journalctl -u shellm-web -f` |
+| Update the app | `sudo -u shellm git -C /opt/shellm/app pull && sudo -u shellm rm -rf /opt/shellm/app/web/src/shellm_web/static && sudo systemctl restart shellm-web` |
+| Add/remove viewers | edit `allowed_emails`, `terraform apply` |
+| Panic | Kill All in the UI → `shellm-killall` on the box → stop the instance |
+| Rebuild from scratch | `terraform destroy && terraform apply`, then re-install the API key (identities/trajectories are lost — copy them off first if they matter) |
+| Pause billing | stop the instance in the console (~$3/mo for the disk); the tunnel reconnects on start |
+
+## Notes & caveats
+
+- **State contains secrets** (tunnel token; the API key if you set it).
+  State and `terraform.tfvars` are gitignored — keep it that way, or move
+  state to a private S3 bucket once this outlives the demo.
+- The Cloudflare provider is **pinned to v4** (`~> 4.52`). v5 renamed and
+  reshaped the tunnel/Access resource schemas; upgrading means rewriting
+  those ~5 resources, so don't bump the pin casually.
+- The instance lives in your **default VPC** in a public subnet (it needs
+  outbound internet for the tunnel and LLM APIs; nothing can dial in).
+  If your account has no default VPC, add a small vpc module or create
+  one first.
+- `user_data_replace_on_change = true` means changing repo/branch/emails
+  that feed user_data **recreates the instance** on apply — that's the
+  burnable-box philosophy working as intended, but remember it wipes
+  identities.
+- SSM Session Manager needs no SG rules or public IP settings changes —
+  the agent is preinstalled on Ubuntu AMIs and dials out, same as the
+  tunnel.

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -54,9 +54,8 @@ per session.)
 ## What goes where
 
 - **`terraform.tfvars`** — facts about the infrastructure (region, account
-  and zone IDs, domain, emails, branch). Not secrets; edit when the infra
-  should change. Gitignored anyway because the optional API key can live
-  there.
+  and zone IDs, domain, emails, branch). No secrets live here; edit when
+  the infra should change. (Gitignored regardless.)
 - **Shell environment** — credentials for the tools: AWS creds live in
   `~/.aws` via `aws configure` (no export needed for the default profile),
   and `CLOUDFLARE_API_TOKEN` is the one real export, handled by direnv:
@@ -119,13 +118,12 @@ First boot takes ~5 minutes (apt, uv/bun install, frontend build). Then
 open the `url` output — you'll hit the Access login; anyone not on
 `allowed_emails` gets blocked.
 
-### The API keys (.env)
+### The .env (API keys + model choice)
 
-**Recommended: mirror your whole local `.env` via SSM Parameter Store
-(zero-touch, survives rebuilds).** One SecureString parameter holds the
-full root `.env` — ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENAI_ORG,
-GEMINI_API_KEY, OPENROUTER_API_KEY, whatever else you keep there. Upload
-from your laptop (never enters Terraform state):
+The box's whole `.env` lives in **one SSM SecureString parameter** — the
+provider API key(s) plus config like `SHELLM_MODEL`. This is the only
+secrets path: nothing sensitive enters tfvars or Terraform state. Upload
+from your laptop:
 
 ```bash
 aws ssm put-parameter --name /shellm/env --type SecureString \
@@ -133,57 +131,51 @@ aws ssm put-parameter --name /shellm/env --type SecureString \
     --region <your-region>
 ```
 
-Every boot overwrites `/opt/shellm/app/.env` (mode 600) with the parameter
-value; the instance role can read exactly that one parameter and nothing
-else. Parameter name = the `env_parameter` variable (default
-`/shellm/env`; `""` disables). Standard-tier parameters cap at 4 KB —
-plenty for an env file.
+**First boot** writes the parameter to `/opt/shellm/app/.env` (mode 600),
+so instance rebuilds self-heal; the instance role can read exactly that
+one parameter and nothing else. Parameter name = the `env_parameter`
+variable (default `/shellm/env`; `""` disables). Standard-tier parameters
+cap at 4 KB — plenty for an env file.
 
-- **Add/rotate keys:** edit your local `.env`, re-run the put-parameter
-  command, then either replace the instance or re-fetch in place:
+Which key(s) to include is a `SHELLM_MODEL` decision — e.g.
+`SHELLM_MODEL=openai/gpt-oss-120b` routes via OpenRouter and needs
+`OPENROUTER_API_KEY`; a `claude-*` model needs `ANTHROPIC_API_KEY`.
+Switching providers is just a different parameter value.
 
-  ```bash
-  # in an SSM session — pull the new .env without a rebuild
-  sudo -u shellm bash -c 'aws ssm get-parameter --name /shellm/env \
-      --with-decryption --region <your-region> \
-      --query Parameter.Value --output text > /opt/shellm/app/.env'
-  ```
-
-  (No service restart needed — thinkers source `.env` at every start.)
-
-If the parameter is missing at boot, the bootstrap warns and continues
-with the seeded stub — fall back to the manual flow below.
-
-**Fallback: install a key manually over SSM** after any (re)creation:
+**Rotating keys / changing model** — user-data runs *once per instance*,
+so after `put-parameter` the box needs one of:
 
 ```bash
-# 1. wait for first boot to finish (~5 min)
-$(terraform output -raw ssm_session_command)
-tail -f /var/log/shellm-bootstrap.log        # until "shellm bootstrap done"
+# option A: rebuild (clean, ~5 min gap; identities are wiped)
+terraform apply -replace=aws_instance.shellm
 
-# 2. install the key — read -rs keeps it out of history and `ps`
-read -rs KEY                                  # paste sk-ant-..., press enter
-sudo -u shellm sed -i "s|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=$KEY|" /opt/shellm/app/.env
-unset KEY
-
-# 3. verify without printing it
-sudo -u shellm grep -q '^ANTHROPIC_API_KEY=sk-' /opt/shellm/app/.env && echo key installed
+# option B: re-fetch in place (in an SSM session, no downtime)
+sudo -u shellm bash -c 'aws ssm get-parameter --name /shellm/env \
+    --with-decryption --region <your-region> \
+    --query Parameter.Value --output text > /opt/shellm/app/.env'
 ```
 
-No restart needed: thinkers source this `.env` every time they start, and
-the web server itself never reads the key.
+With option B, a rotated *key* applies from the next LLM call (`llm` and
+`shellm` re-read `.env` on every invocation) — but a changed
+`SHELLM_MODEL` needs a thinker stop/start in the UI: running dispatchers
+export the model they started with.
 
-**Repeat steps 2–3 whenever the instance is recreated** — the key lives
-only on the box, and `user_data_replace_on_change` means changing
-repo/branch/emails recreates it. The tell if you forget: thinker logs loop
-with `ANTHROPIC_API_KEY is not set`.
+**Fallback — parameter missing at boot:** the bootstrap warns and
+continues with the seeded stub; install the `.env` by hand in an SSM
+session (`read -rs` keeps the key out of history and `ps`):
 
-Alternative (zero-touch rebuilds): set `anthropic_api_key` in tfvars — the
-key then also lives in Terraform state and the EC2 user-data attribute
-(console-visible). Acceptable for a spend-capped key with local state.
+```bash
+$(terraform output -raw ssm_session_command)
+read -rs KEY                              # paste the key, press enter
+printf 'OPENROUTER_API_KEY=%s\nSHELLM_MODEL=openai/gpt-oss-120b\n' "$KEY" \
+    | sudo -u shellm tee /opt/shellm/app/.env >/dev/null
+unset KEY
+```
 
-Either way: use a **dedicated, spend-capped key**. The agent executes
-arbitrary bash on this box; the cap is the real safety net.
+Whatever the provider: use a **dedicated key with a hard spend limit**
+(OpenRouter: prepaid credits *are* the cap; Anthropic: set a spend cap).
+The agent executes arbitrary bash on this box; the cap is the real
+safety net.
 
 ## Day-2 operations
 
@@ -194,8 +186,9 @@ arbitrary bash on this box; the cap is the real safety net.
 | App logs | `journalctl -u shellm-web -f` |
 | Update the app (after pushing!) | `eval "$(terraform output -raw update_command)"` — streams deploy/update.sh (pull, rebuild, restart, health check) |
 | Add/remove viewers | edit `allowed_emails`, `terraform apply` |
+| Rotate keys / change model | `aws ssm put-parameter ... --overwrite`, then rebuild or re-fetch in place — see "The .env" above |
 | Panic | Kill All in the UI → `shellm-killall` on the box → stop the instance |
-| Rebuild from scratch | `terraform destroy && terraform apply`, then re-install the API key (identities/trajectories are lost — copy them off first if they matter) |
+| Rebuild from scratch | `terraform destroy && terraform apply` — `.env` self-heals from the SSM parameter (identities/trajectories are lost — copy them off first if they matter) |
 | Pause billing | stop the instance in the console (~$3/mo for the disk); the tunnel reconnects on start |
 
 ## Troubleshooting
@@ -209,14 +202,16 @@ arbitrary bash on this box; the cap is the real safety net.
   your laptop's working tree.** Any local fix needs commit+push before the
   box can see it. Verify what the remote actually has with
   `git ls-tree -r origin/<branch> --name-only | grep <file>`.
-- **Thinker logs loop with `ANTHROPIC_API_KEY is not set`**: the key isn't
-  on the box (fresh or recreated instance) — redo "The API key" steps.
+- **Thinker logs loop with `<PROVIDER>_API_KEY is not set`**: the box's
+  `.env` is missing, stale, or lacks the key that `SHELLM_MODEL` implies
+  (e.g. an `openai/...` OpenRouter model with no `OPENROUTER_API_KEY`).
+  Check the SSM parameter's contents and redo "The .env" steps.
 
 ## Notes & caveats
 
-- **State contains secrets** (tunnel token; the API key if you set it).
-  State and `terraform.tfvars` are gitignored — keep it that way, or move
-  state to a private S3 bucket once this outlives the demo.
+- **State contains secrets** (the tunnel token). State and
+  `terraform.tfvars` are gitignored — keep it that way, or move state to
+  a private S3 bucket once this outlives the demo.
 - The Cloudflare provider is **pinned to v4** (`~> 4.52`). v5 renamed and
   reshaped the tunnel/Access resource schemas; upgrading means rewriting
   those ~5 resources, so don't bump the pin casually.

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -117,10 +117,42 @@ First boot takes ~5 minutes (apt, uv/bun install, frontend build). Then
 open the `url` output — you'll hit the Access login; anyone not on
 `allowed_emails` gets blocked.
 
-### The API key (recommended flow: keep it off your laptop entirely)
+### The API keys (.env)
 
-Leave `anthropic_api_key` unset in tfvars and install the key on the box
-after each (re)creation:
+**Recommended: mirror your whole local `.env` via SSM Parameter Store
+(zero-touch, survives rebuilds).** One SecureString parameter holds the
+full root `.env` — ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENAI_ORG,
+GEMINI_API_KEY, OPENROUTER_API_KEY, whatever else you keep there. Upload
+from your laptop (never enters Terraform state):
+
+```bash
+aws ssm put-parameter --name /shellm/env --type SecureString \
+    --value "$(cat ~/laude/repos/shellm/.env)" --overwrite \
+    --region <your-region>
+```
+
+Every boot overwrites `/opt/shellm/app/.env` (mode 600) with the parameter
+value; the instance role can read exactly that one parameter and nothing
+else. Parameter name = the `env_parameter` variable (default
+`/shellm/env`; `""` disables). Standard-tier parameters cap at 4 KB —
+plenty for an env file.
+
+- **Add/rotate keys:** edit your local `.env`, re-run the put-parameter
+  command, then either replace the instance or re-fetch in place:
+
+  ```bash
+  # in an SSM session — pull the new .env without a rebuild
+  sudo -u shellm bash -c 'aws ssm get-parameter --name /shellm/env \
+      --with-decryption --region <your-region> \
+      --query Parameter.Value --output text > /opt/shellm/app/.env'
+  ```
+
+  (No service restart needed — thinkers source `.env` at every start.)
+
+If the parameter is missing at boot, the bootstrap warns and continues
+with the seeded stub — fall back to the manual flow below.
+
+**Fallback: install a key manually over SSM** after any (re)creation:
 
 ```bash
 # 1. wait for first boot to finish (~5 min)
@@ -163,6 +195,20 @@ arbitrary bash on this box; the cap is the real safety net.
 | Panic | Kill All in the UI → `shellm-killall` on the box → stop the instance |
 | Rebuild from scratch | `terraform destroy && terraform apply`, then re-install the API key (identities/trajectories are lost — copy them off first if they matter) |
 | Pause billing | stop the instance in the console (~$3/mo for the disk); the tunnel reconnects on start |
+
+## Troubleshooting
+
+- **Bootstrap log ends with `deploy/setup.sh: No such file or directory`**:
+  the box cloned a ref that predates the `deploy/` folder — almost always
+  `shellm_branch` unset/commented in tfvars (default is `main`). Set the
+  branch, push anything missing, and `terraform apply` (user_data changed,
+  so the instance replaces itself).
+- **Golden rule: the box runs what's *pushed* to `shellm_branch`, never
+  your laptop's working tree.** Any local fix needs commit+push before the
+  box can see it. Verify what the remote actually has with
+  `git ls-tree -r origin/<branch> --name-only | grep <file>`.
+- **Thinker logs loop with `ANTHROPIC_API_KEY is not set`**: the key isn't
+  on the box (fresh or recreated instance) — redo "The API key" steps.
 
 ## Notes & caveats
 

--- a/deploy/terraform/aws-policy.json
+++ b/deploy/terraform/aws-policy.json
@@ -1,0 +1,63 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Ec2ForTerraform",
+      "Effect": "Allow",
+      "Action": ["ec2:*"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IamScopedToShellmRole",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:TagRole",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListInstanceProfilesForRole",
+        "iam:AttachRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::*:role/shellm-*"
+    },
+    {
+      "Sid": "IamInstanceProfile",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateInstanceProfile",
+        "iam:DeleteInstanceProfile",
+        "iam:GetInstanceProfile",
+        "iam:TagInstanceProfile",
+        "iam:AddRoleToInstanceProfile",
+        "iam:RemoveRoleFromInstanceProfile"
+      ],
+      "Resource": "arn:aws:iam::*:instance-profile/shellm-*"
+    },
+    {
+      "Sid": "SsmShellAccess",
+      "Effect": "Allow",
+      "Action": ["ssm:StartSession"],
+      "Resource": [
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ssm:*:*:document/AWS-StartInteractiveCommand",
+        "arn:aws:ssm:*::document/SSM-SessionManagerRunShell"
+      ]
+    },
+    {
+      "Sid": "SsmSessionLifecycle",
+      "Effect": "Allow",
+      "Action": ["ssm:TerminateSession", "ssm:ResumeSession"],
+      "Resource": "arn:aws:ssm:*:*:session/*"
+    },
+    {
+      "Sid": "SsmDescribe",
+      "Effect": "Allow",
+      "Action": ["ssm:DescribeSessions", "ssm:DescribeInstanceInformation"],
+      "Resource": "*"
+    }
+  ]
+}

--- a/deploy/terraform/env.sh.example
+++ b/deploy/terraform/env.sh.example
@@ -1,0 +1,17 @@
+# No-direnv alternative: copy to env.sh (gitignored) and load it in any
+# shell where you'll run terraform:
+#
+#   source env.sh
+#
+# See envrc.example for the 1Password one-time setup. Same contents; the
+# only difference is you source this manually instead of direnv doing it.
+
+#export OP_ACCOUNT=yourteam.1password.com
+
+export CLOUDFLARE_API_TOKEN="$(op read 'op://Private/cloudflare-tf/credential')"
+
+# Static AWS key (username = access key id, credential = secret access key).
+# Skip if your credentials live in ~/.aws/credentials — but note that
+# browser-based `aws login` sessions are NOT visible to Terraform.
+export AWS_ACCESS_KEY_ID="$(op read 'op://Private/aws-terraform/username')"
+export AWS_SECRET_ACCESS_KEY="$(op read 'op://Private/aws-terraform/credential')"

--- a/deploy/terraform/envrc.example
+++ b/deploy/terraform/envrc.example
@@ -1,0 +1,35 @@
+# Copy to .envrc (gitignored), fill in the op:// references, then:
+#   direnv allow          # required after every edit to .envrc
+# direnv loads this when you cd into deploy/terraform and unloads it on
+# leaving — no credentials lingering in other shells.
+#
+# One-time 1Password CLI setup:
+#   brew install --cask 1password-cli
+#   1Password app -> Settings -> Developer -> "Integrate with 1Password CLI"
+# `op read` will Touch-ID prompt if 1Password is locked. Find any item's
+# vault/title/field-label reference with: op item get <title>
+
+# Needed when the CLI knows multiple accounts (or auth misbehaves without it):
+#export OP_ACCOUNT=yourteam.1password.com
+
+# --- Cloudflare API token (Tunnel:Edit, Access:Edit, DNS:Edit) --------------
+# Store once:
+#   op item create --category=apiCredential --vault=Private \
+#       --title=cloudflare-tf credential=<paste-token>
+export CLOUDFLARE_API_TOKEN="$(op read 'op://Private/cloudflare-tf/credential')"
+
+# --- AWS static access key (IAM console -> user -> Create access key) ------
+# Store once (username = access key id, credential = secret access key):
+#   op item create --category=apiCredential --vault=Private \
+#       --title=aws-terraform username=AKIA... credential=<secret-access-key>
+export AWS_ACCESS_KEY_ID="$(op read 'op://Private/aws-terraform/username')"
+export AWS_SECRET_ACCESS_KEY="$(op read 'op://Private/aws-terraform/credential')"
+# Do NOT set AWS_SESSION_TOKEN with static keys. Not needed if your AWS
+# credentials already live in ~/.aws/credentials — but note the CLI's
+# browser-based `aws login` sessions are NOT visible to Terraform; static
+# keys (or `aws configure export-credentials`) are the reliable path.
+
+# --- No 1Password? Plain paste works on a private machine ------------------
+#export CLOUDFLARE_API_TOKEN="REPLACE_ME"
+#export AWS_ACCESS_KEY_ID="REPLACE_ME"
+#export AWS_SECRET_ACCESS_KEY="REPLACE_ME"

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,181 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    # Pinned to v4: the v5 provider reshapes the tunnel/Access resource
+    # schemas. If you upgrade, expect to rewrite those resources.
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.52"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# Auth via CLOUDFLARE_API_TOKEN env var — see README for token permissions.
+provider "cloudflare" {}
+
+locals {
+  hostname = "${var.subdomain}.${var.domain}"
+}
+
+# ---------------------------------------------------------------------------
+# Cloudflare: tunnel, DNS, Access
+# ---------------------------------------------------------------------------
+
+resource "random_id" "tunnel_secret" {
+  byte_length = 32
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "shellm" {
+  account_id = var.cloudflare_account_id
+  name       = "shellm-${var.subdomain}"
+  secret     = random_id.tunnel_secret.b64_std
+  config_src = "cloudflare"
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "shellm" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.shellm.id
+
+  config {
+    ingress_rule {
+      hostname = local.hostname
+      service  = "http://localhost:8080"
+    }
+    # Catch-all required by Cloudflare: anything else gets a 404
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}
+
+resource "cloudflare_record" "shellm" {
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "CNAME"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.shellm.id}.cfargotunnel.com"
+  proxied = true
+}
+
+resource "cloudflare_zero_trust_access_application" "shellm" {
+  zone_id          = var.cloudflare_zone_id
+  name             = "shellm (${local.hostname})"
+  domain           = local.hostname
+  type             = "self_hosted"
+  session_duration = var.access_session_duration
+}
+
+resource "cloudflare_zero_trust_access_policy" "allowlist" {
+  application_id = cloudflare_zero_trust_access_application.shellm.id
+  zone_id        = var.cloudflare_zone_id
+  name           = "shellm email allowlist"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = var.allowed_emails
+  }
+}
+
+# ---------------------------------------------------------------------------
+# AWS: one burnable VM, no inbound network path at all
+# ---------------------------------------------------------------------------
+
+data "aws_ami" "ubuntu_arm64" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd*/ubuntu-noble-24.04-arm64-server-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+# Zero ingress rules — the tunnel dials out; admin access is via SSM.
+resource "aws_security_group" "shellm" {
+  name_prefix = "shellm-"
+  description = "shellm agent box: egress only, no inbound"
+  vpc_id      = data.aws_vpc.default.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_iam_role" "shellm" {
+  name_prefix = "shellm-"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.shellm.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "shellm" {
+  name_prefix = "shellm-"
+  role        = aws_iam_role.shellm.name
+}
+
+resource "aws_instance" "shellm" {
+  ami                    = data.aws_ami.ubuntu_arm64.id
+  instance_type          = var.instance_type
+  subnet_id              = data.aws_subnets.default.ids[0]
+  vpc_security_group_ids = [aws_security_group.shellm.id]
+  iam_instance_profile   = aws_iam_instance_profile.shellm.name
+
+  root_block_device {
+    volume_size = var.root_volume_gb
+    volume_type = "gp3"
+  }
+
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    tunnel_token = cloudflare_zero_trust_tunnel_cloudflared.shellm.tunnel_token
+    repo         = var.shellm_repo
+    branch       = var.shellm_branch
+    hostname     = local.hostname
+    api_key      = var.anthropic_api_key
+  })
+  user_data_replace_on_change = true
+
+  tags = {
+    Name = "shellm-${var.subdomain}"
+  }
+}

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -197,11 +197,10 @@ resource "aws_instance" "shellm" {
   }
 
   user_data = templatefile("${path.module}/user_data.sh.tpl", {
-    tunnel_token      = cloudflare_zero_trust_tunnel_cloudflared.shellm.tunnel_token
-    repo              = var.shellm_repo
-    branch            = var.shellm_branch
-    hostname          = local.hostname
-    api_key       = var.anthropic_api_key
+    tunnel_token  = cloudflare_zero_trust_tunnel_cloudflared.shellm.tunnel_token
+    repo          = var.shellm_repo
+    branch        = var.shellm_branch
+    hostname      = local.hostname
     env_parameter = var.env_parameter
     region        = var.aws_region
   })

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -69,12 +69,24 @@ resource "cloudflare_record" "shellm" {
   proxied = true
 }
 
+# Email OTP login: allow-listed users enter their email and get a 6-digit
+# code — no Cloudflare account needed.
+resource "cloudflare_zero_trust_access_identity_provider" "otp" {
+  account_id = var.cloudflare_account_id
+  name       = "Email one-time PIN"
+  type       = "onetimepin"
+}
+
 resource "cloudflare_zero_trust_access_application" "shellm" {
   zone_id          = var.cloudflare_zone_id
   name             = "shellm (${local.hostname})"
   domain           = local.hostname
   type             = "self_hosted"
   session_duration = var.access_session_duration
+
+  # Pin to OTP and skip the login-method picker entirely.
+  allowed_idps              = [cloudflare_zero_trust_access_identity_provider.otp.id]
+  auto_redirect_to_identity = true
 }
 
 resource "cloudflare_zero_trust_access_policy" "allowlist" {

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -149,6 +149,24 @@ resource "aws_iam_role_policy_attachment" "ssm" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+data "aws_caller_identity" "current" {}
+
+# Read-only access to the single parameter holding the .env contents.
+resource "aws_iam_role_policy" "env_parameter" {
+  count = var.env_parameter != "" ? 1 : 0
+
+  name_prefix = "shellm-env-"
+  role        = aws_iam_role.shellm.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameter"]
+      Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${var.env_parameter}"
+    }]
+  })
+}
+
 resource "aws_iam_instance_profile" "shellm" {
   name_prefix = "shellm-"
   role        = aws_iam_role.shellm.name
@@ -167,11 +185,13 @@ resource "aws_instance" "shellm" {
   }
 
   user_data = templatefile("${path.module}/user_data.sh.tpl", {
-    tunnel_token = cloudflare_zero_trust_tunnel_cloudflared.shellm.tunnel_token
-    repo         = var.shellm_repo
-    branch       = var.shellm_branch
-    hostname     = local.hostname
-    api_key      = var.anthropic_api_key
+    tunnel_token      = cloudflare_zero_trust_tunnel_cloudflared.shellm.tunnel_token
+    repo              = var.shellm_repo
+    branch            = var.shellm_branch
+    hostname          = local.hostname
+    api_key       = var.anthropic_api_key
+    env_parameter = var.env_parameter
+    region        = var.aws_region
   })
   user_data_replace_on_change = true
 

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "url" {
+  description = "Where your boss goes"
+  value       = "https://${local.hostname}"
+}
+
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.shellm.id
+}
+
+output "ssm_session_command" {
+  description = "Shell on the box (no SSH needed)"
+  value       = "aws ssm start-session --region ${var.aws_region} --target ${aws_instance.shellm.id}"
+}
+
+output "tunnel_id" {
+  description = "Cloudflare tunnel ID"
+  value       = cloudflare_zero_trust_tunnel_cloudflared.shellm.id
+}

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -17,3 +17,8 @@ output "tunnel_id" {
   description = "Cloudflare tunnel ID"
   value       = cloudflare_zero_trust_tunnel_cloudflared.shellm.id
 }
+
+output "update_command" {
+  description = "Update the box to the latest pushed branch: eval \"$(terraform output -raw update_command)\""
+  value       = "aws ssm start-session --region ${var.aws_region} --target ${aws_instance.shellm.id} --document-name AWS-StartInteractiveCommand --parameters command='sudo bash /opt/shellm/app/deploy/update.sh'"
+}

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -1,0 +1,22 @@
+# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored —
+# it (and the state file) contain secrets; keep both out of the repo.
+
+aws_region = "us-east-1"
+
+# Cloudflare — IDs are on the zone overview page / Zero Trust dashboard
+cloudflare_account_id = "REPLACE_ME"
+cloudflare_zone_id    = "REPLACE_ME"
+domain                = "example.com"
+subdomain             = "agents"
+
+allowed_emails = [
+  "nick@jalbert.io",
+  "boss@example.com",
+]
+
+# Deploy a specific branch while the feature branch is unmerged
+# shellm_branch = "nj/run_local_llm"
+
+# Optional: written to the VM's .env on first boot (lands in TF state!).
+# Leave unset to add the key via SSM after apply instead.
+# anthropic_api_key = "sk-ant-..."

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -1,5 +1,6 @@
-# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored —
-# it (and the state file) contain secrets; keep both out of the repo.
+# Copy to terraform.tfvars and fill in. No secrets belong here — the box's
+# .env (API keys, SHELLM_MODEL) lives in the SSM parameter; see README.
+# Gitignored anyway, and the state file DOES hold secrets (tunnel token).
 
 aws_region = "us-east-1"
 
@@ -16,7 +17,3 @@ allowed_emails = [
 
 # Deploy a specific branch while the feature branch is unmerged
 # shellm_branch = "nj/run_local_llm"
-
-# Optional: written to the VM's .env on first boot (lands in TF state!).
-# Leave unset to add the key via SSM after apply instead.
-# anthropic_api_key = "sk-ant-..."

--- a/deploy/terraform/user_data.sh.tpl
+++ b/deploy/terraform/user_data.sh.tpl
@@ -26,6 +26,26 @@ SHELLM_REPO='${repo}' SHELLM_BRANCH='${branch}' bash /tmp/shellm-src/deploy/setu
 sed -i 's|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${api_key}|' /opt/shellm/app/.env
 %{ endif ~}
 
+%{ if env_parameter != "" ~}
+# --- .env from SSM Parameter Store (survives rebuilds) ---------------------
+# The parameter holds the FULL root .env (all provider API keys). A missing
+# parameter or CLI hiccup must not kill the bootstrap: keys can still be
+# added by hand (see README), so warn and continue.
+apt-get install -y -qq awscli || snap install aws-cli --classic || true
+ENV_CONTENT=$(aws ssm get-parameter --name '${env_parameter}' \
+    --with-decryption --region '${region}' \
+    --query Parameter.Value --output text 2>/dev/null) || ENV_CONTENT=""
+if [ -n "$ENV_CONTENT" ]; then
+    printf '%s\n' "$ENV_CONTENT" > /opt/shellm/app/.env
+    chown shellm:shellm /opt/shellm/app/.env
+    chmod 600 /opt/shellm/app/.env
+    unset ENV_CONTENT
+    echo "==> .env installed from SSM parameter ${env_parameter}"
+else
+    echo "==> WARNING: no value at SSM parameter ${env_parameter}; add keys manually"
+fi
+%{ endif ~}
+
 # --- pin CORS to the public hostname --------------------------------------
 mkdir -p /etc/systemd/system/shellm-web.service.d
 cat > /etc/systemd/system/shellm-web.service.d/override.conf <<OVERRIDE

--- a/deploy/terraform/user_data.sh.tpl
+++ b/deploy/terraform/user_data.sh.tpl
@@ -21,11 +21,6 @@ rm -rf /tmp/shellm-src
 git clone --depth 1 --branch '${branch}' '${repo}' /tmp/shellm-src
 SHELLM_REPO='${repo}' SHELLM_BRANCH='${branch}' bash /tmp/shellm-src/deploy/setup.sh
 
-%{ if api_key != "" ~}
-# --- API key from terraform.tfvars ----------------------------------------
-sed -i 's|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${api_key}|' /opt/shellm/app/.env
-%{ endif ~}
-
 %{ if env_parameter != "" ~}
 # --- .env from SSM Parameter Store (survives rebuilds) ---------------------
 # The parameter holds the FULL root .env (all provider API keys). A missing

--- a/deploy/terraform/user_data.sh.tpl
+++ b/deploy/terraform/user_data.sh.tpl
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# First-boot bootstrap (rendered by Terraform; runs as root via cloud-init).
+set -euo pipefail
+exec > /var/log/shellm-bootstrap.log 2>&1
+
+echo "==> shellm bootstrap starting $(date -u)"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq git curl
+
+# --- cloudflared: install and connect the tunnel -------------------------
+arch=$(dpkg --print-architecture)
+curl -fsSL -o /tmp/cloudflared.deb \
+    "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$arch.deb"
+dpkg -i /tmp/cloudflared.deb
+cloudflared service install '${tunnel_token}'
+
+# --- shellm: clone for setup.sh, which does the real provisioning --------
+rm -rf /tmp/shellm-src
+git clone --depth 1 --branch '${branch}' '${repo}' /tmp/shellm-src
+SHELLM_REPO='${repo}' SHELLM_BRANCH='${branch}' bash /tmp/shellm-src/deploy/setup.sh
+
+%{ if api_key != "" ~}
+# --- API key from terraform.tfvars ----------------------------------------
+sed -i 's|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${api_key}|' /opt/shellm/app/.env
+%{ endif ~}
+
+# --- pin CORS to the public hostname --------------------------------------
+mkdir -p /etc/systemd/system/shellm-web.service.d
+cat > /etc/systemd/system/shellm-web.service.d/override.conf <<OVERRIDE
+[Service]
+Environment="SHELLM_WEB_ALLOWED_ORIGINS=https://${hostname}"
+OVERRIDE
+
+systemctl daemon-reload
+systemctl restart shellm-web
+
+echo "==> shellm bootstrap done $(date -u)"

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -63,10 +63,25 @@ variable "access_session_duration" {
 variable "anthropic_api_key" {
   description = <<-EOT
     Optional: spend-capped Anthropic API key written to the VM's .env on first
-    boot. NOTE: lands in Terraform state — keep state local/private, or leave
-    this empty and add the key over SSM after apply instead.
+    boot. NOTE: lands in Terraform state — prefer api_key_parameter instead.
   EOT
   type        = string
   default     = ""
   sensitive   = true
+}
+
+variable "env_parameter" {
+  description = <<-EOT
+    Name of an SSM SecureString parameter holding the FULL contents of the
+    box's root .env (ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENAI_ORG,
+    GEMINI_API_KEY, OPENROUTER_API_KEY, ...). Create/update it out-of-band
+    from your local shellm/.env (never enters Terraform state):
+      aws ssm put-parameter --name /shellm/env --type SecureString \
+          --value "$(cat ~/laude/repos/shellm/.env)" --overwrite \
+          --region <region>
+    Every boot writes it to /opt/shellm/app/.env; rebuilds self-heal.
+    Set to "" to disable.
+  EOT
+  type        = string
+  default     = "/shellm/env"
 }

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,72 @@
+variable "aws_region" {
+  description = "AWS region for the VM"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type (Graviton/arm64 assumed by the AMI filter)"
+  type        = string
+  default     = "t4g.large"
+}
+
+variable "root_volume_gb" {
+  description = "Root EBS volume size (gp3)"
+  type        = number
+  default     = 40
+}
+
+variable "shellm_repo" {
+  description = "Git repo to deploy"
+  type        = string
+  default     = "https://github.com/andyk/shellm.git"
+}
+
+variable "shellm_branch" {
+  description = "Branch to deploy"
+  type        = string
+  default     = "main"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID (Zero Trust dashboard URL or account home)"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Zone ID of the domain (overview page of the zone)"
+  type        = string
+}
+
+variable "domain" {
+  description = "The zone's domain, e.g. example.com"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "Subdomain for the viewer, e.g. agents -> agents.example.com"
+  type        = string
+  default     = "agents"
+}
+
+variable "allowed_emails" {
+  description = "Emails allowed through Cloudflare Access"
+  type        = list(string)
+}
+
+variable "access_session_duration" {
+  description = "How long an Access login lasts"
+  type        = string
+  default     = "168h"
+}
+
+variable "anthropic_api_key" {
+  description = <<-EOT
+    Optional: spend-capped Anthropic API key written to the VM's .env on first
+    boot. NOTE: lands in Terraform state — keep state local/private, or leave
+    this empty and add the key over SSM after apply instead.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -60,16 +60,6 @@ variable "access_session_duration" {
   default     = "168h"
 }
 
-variable "anthropic_api_key" {
-  description = <<-EOT
-    Optional: spend-capped Anthropic API key written to the VM's .env on first
-    boot. NOTE: lands in Terraform state — prefer api_key_parameter instead.
-  EOT
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
 variable "env_parameter" {
   description = <<-EOT
     Name of an SSM SecureString parameter holding the FULL contents of the
@@ -79,7 +69,13 @@ variable "env_parameter" {
       aws ssm put-parameter --name /shellm/env --type SecureString \
           --value "$(cat ~/laude/repos/shellm/.env)" --overwrite \
           --region <region>
-    Every boot writes it to /opt/shellm/app/.env; rebuilds self-heal.
+    First boot writes it to /opt/shellm/app/.env, so instance rebuilds
+    self-heal. NOTE: user-data runs once per instance — after changing the
+    parameter, either force a rebuild:
+      terraform apply -replace=aws_instance.shellm
+    or update the running box in place over SSM:
+      aws ssm start-session --target <instance-id> --region <region>
+      # then on the box: re-run the fetch and restart shellm-web
     Set to "" to disable.
   EOT
   type        = string

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# deploy/update.sh — pull the deploy branch, force a frontend rebuild,
+# restart the web service. Running agents are untouched (dispatchers live
+# in their own sessions).
+#
+# From your laptop:  eval "$(terraform output -raw update_command)"
+# From an SSM session:  sudo bash /opt/shellm/app/deploy/update.sh
+
+APP_DIR="${APP_DIR:-/opt/shellm/app}"
+
+echo "==> Pulling latest"
+sudo -u shellm git -C "$APP_DIR" pull --ff-only
+
+echo "==> Forcing frontend rebuild on restart"
+sudo -u shellm rm -rf "$APP_DIR/web/src/shellm_web/static"
+
+echo "==> Restarting shellm-web (rebuild takes ~1-2 min)"
+sudo systemctl restart shellm-web
+
+for _ in $(seq 1 36); do
+    if curl -fsS localhost:8080/api/health >/dev/null 2>&1; then
+        echo "==> Healthy: $(curl -fsS localhost:8080/api/health)"
+        echo "==> Now running: $(sudo -u shellm git -C "$APP_DIR" log -1 --oneline)"
+        exit 0
+    fi
+    sleep 5
+done
+
+echo "==> ERROR: service not healthy after 3 minutes; check: journalctl -u shellm-web -n 50" >&2
+exit 1

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -3,6 +3,28 @@
 # Source this file from thinker step scripts.
 
 # ---------------------------------------------------------------------------
+# .env loading
+# ---------------------------------------------------------------------------
+
+# Fill in vars from a .env file WITHOUT overriding anything already set: the
+# dispatcher's environment (web _ENV_WRAPPER, identity shell, an explicit
+# THINK_MODEL=...) always wins, and earlier files beat later ones. Values are
+# extracted by actually sourcing the file in a subshell so quoting behaves
+# exactly like the loaders in bin/llm and bin/shellm.
+_load_env_defaults() {
+    local envfile="$1"
+    [[ -f "$envfile" ]] || return 1
+    local key val
+    while IFS= read -r key; do
+        [[ -n "$key" ]] || continue
+        [[ -n "${!key+x}" ]] && continue
+        val=$(set -a; . "$envfile" 2>/dev/null; printf '%s' "${!key}") || continue
+        export "$key=$val"
+    done < <(sed -n 's/^[[:space:]]*\(export[[:space:]]\{1,\}\)\{0,1\}\([A-Za-z_][A-Za-z0-9_]*\)[[:space:]]*=.*/\2/p' "$envfile")
+    return 0
+}
+
+# ---------------------------------------------------------------------------
 # Environment checks
 # ---------------------------------------------------------------------------
 
@@ -21,6 +43,13 @@ _require_env() {
     # Defaults
     [[ -z "${SKILLS_DIR:-}" ]] && SKILLS_DIR="$IDENTITY_DIR/skills"
     [[ -z "${SKILLS_KERNEL_DIR:-}" ]] && SKILLS_KERNEL_DIR="$IDENTITY_DIR/kernel"
+
+    # .env fallbacks — step scripts resolve THINK_MODEL/SHELLM_MODEL from
+    # their environment BEFORE invoking llm/shellm (which load .env too
+    # late to influence the -m flag), so the keys must be filled in here.
+    _load_env_defaults "$IDENTITY_DIR/.env" || true
+    _load_env_defaults ".env" || true
+    _load_env_defaults "$HOME/.shellm/.env" || true
 
     mkdir -p "$MEM_DIR" "$SKILLS_DIR" "$SKILLS_KERNEL_DIR" "$TRAJ_DIR"
 }

--- a/web/src/shellm_web/__init__.py
+++ b/web/src/shellm_web/__init__.py
@@ -10,7 +10,8 @@ def create_app_from_env():
 
     root = Path(os.environ.get("SHELLM_WEB_ROOT", ".")).resolve()
     static = os.environ.get("SHELLM_WEB_STATIC")
-    return create_app(root, Path(static) if static else None)
+    read_only = os.environ.get("SHELLM_WEB_READONLY", "") not in ("", "0")
+    return create_app(root, Path(static) if static else None, read_only=read_only)
 
 
 __all__ = ["create_app_from_env"]

--- a/web/src/shellm_web/chat.py
+++ b/web/src/shellm_web/chat.py
@@ -1,0 +1,39 @@
+"""Chat view over the mind log: filter message steps from trajectory.jsonl."""
+
+from pathlib import Path
+
+from shellm_web.trajectory import parse_jsonl
+
+MESSAGE_TYPES = {"message", "human-msg", "agent-msg"}
+
+
+def chat_messages(traj_dir: Path, identity_name: str, tail: int = 200) -> list[dict]:
+    steps = parse_jsonl(traj_dir / "trajectory.jsonl")
+    messages = []
+    for raw in steps:
+        step_type = raw.get("type")
+        if step_type not in MESSAGE_TYPES:
+            continue
+        content = raw.get("content")
+        if not content:
+            continue
+        if step_type == "message":
+            from_name = raw.get("from") or "unknown"
+            to_name = raw.get("to") or ""
+        elif step_type == "human-msg":
+            from_name = raw.get("from") or "you"
+            to_name = identity_name
+        else:  # agent-msg
+            from_name = identity_name
+            to_name = raw.get("to") or ""
+        messages.append(
+            {
+                "ts": raw.get("ts"),
+                "step_id": raw.get("step_id"),
+                "from": from_name,
+                "to": to_name,
+                "content": content,
+                "filename": raw.get("filename"),
+            }
+        )
+    return messages[-tail:]

--- a/web/src/shellm_web/cli.py
+++ b/web/src/shellm_web/cli.py
@@ -20,14 +20,56 @@ VIEWER_DIR = WEB_DIR / "viewer"
 DEFAULT_PORT_RANGE = range(8080, 8090)
 
 
+def _port_free(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+            return True
+        except OSError:
+            return False
+
+
+def _port_owner(port: int) -> str:
+    """Best-effort 'pid 123 (cmd), started ...' for the listener on port."""
+    try:
+        out = subprocess.run(
+            ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-Fpc"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    pid = cmd = ""
+    for line in out.splitlines():
+        if line.startswith("p") and not pid:
+            pid = line[1:]
+        elif line.startswith("c") and not cmd:
+            cmd = line[1:]
+    if not pid:
+        return ""
+    started = ""
+    try:
+        started = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", pid],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    desc = f"pid {pid}" + (f" ({cmd})" if cmd else "")
+    return desc + (f", started {started}" if started else "")
+
+
 def _find_available_port(host: str, ports: range) -> int:
     for port in ports:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            try:
-                sock.bind((host, port))
-                return port
-            except OSError:
-                continue
+        if _port_free(host, port):
+            if port != ports.start:
+                owner = _port_owner(ports.start)
+                print(
+                    f"shellm-web: WARNING: port {ports.start} is taken"
+                    + (f" by {owner}" if owner else "")
+                    + f" — serving on {port} instead. Check your browser's URL.",
+                    file=sys.stderr,
+                )
+            return port
     raise SystemExit(f"No available port in {ports.start}-{ports.stop - 1}")
 
 
@@ -139,7 +181,17 @@ def main() -> None:
     root = Path(args.root).resolve()
     if not root.is_dir():
         raise SystemExit(f"Not a directory: {root}")
-    port = args.port or _find_available_port(args.host, DEFAULT_PORT_RANGE)
+    if args.port is not None:
+        if not _port_free(args.host, args.port):
+            owner = _port_owner(args.port)
+            raise SystemExit(
+                f"shellm-web: port {args.port} is already in use"
+                + (f" by {owner}" if owner else "")
+                + " — is another shellm-web still running?"
+            )
+        port = args.port
+    else:
+        port = _find_available_port(args.host, DEFAULT_PORT_RANGE)
     read_only = args.read_only or os.environ.get("SHELLM_WEB_READONLY", "") not in ("", "0")
 
     if args.dev:

--- a/web/src/shellm_web/cli.py
+++ b/web/src/shellm_web/cli.py
@@ -77,19 +77,19 @@ def _build_frontend() -> None:
     shutil.copytree(build_dir, STATIC_DIR)
 
 
-def _run_production(root: Path, host: str, port: int, rebuild: bool) -> None:
+def _run_production(root: Path, host: str, port: int, rebuild: bool, read_only: bool) -> None:
     import uvicorn
 
     from shellm_web.server import create_app
 
     if rebuild or not (STATIC_DIR / "index.html").is_file():
         _build_frontend()
-    app = create_app(root, STATIC_DIR)
+    app = create_app(root, STATIC_DIR, read_only=read_only)
     print(f"shellm-web serving {root} at http://{host}:{port}", file=sys.stderr)
     uvicorn.run(app, host=host, port=port, log_level="info")
 
 
-def _run_dev(root: Path, host: str, port: int) -> None:
+def _run_dev(root: Path, host: str, port: int, read_only: bool) -> None:
     import uvicorn
 
     runtime = _js_runtime()
@@ -102,6 +102,8 @@ def _run_dev(root: Path, host: str, port: int) -> None:
     )
     try:
         os.environ["SHELLM_WEB_ROOT"] = str(root)
+        if read_only:
+            os.environ["SHELLM_WEB_READONLY"] = "1"
         uvicorn.run(
             "shellm_web:create_app_from_env",
             host=host,
@@ -126,17 +128,24 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=None, help="Port (default: first free in 8080-8089)")
     parser.add_argument("--dev", action="store_true", help="Run vite dev server + uvicorn --reload")
     parser.add_argument("--rebuild", action="store_true", help="Force a frontend rebuild")
+    parser.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Disable control endpoints (start/stop/chat/create). "
+        "Recommended when binding beyond 127.0.0.1 until auth exists.",
+    )
     args = parser.parse_args()
 
     root = Path(args.root).resolve()
     if not root.is_dir():
         raise SystemExit(f"Not a directory: {root}")
     port = args.port or _find_available_port(args.host, DEFAULT_PORT_RANGE)
+    read_only = args.read_only or os.environ.get("SHELLM_WEB_READONLY", "") not in ("", "0")
 
     if args.dev:
-        _run_dev(root, args.host, port)
+        _run_dev(root, args.host, port, read_only)
     else:
-        _run_production(root, args.host, port, args.rebuild)
+        _run_production(root, args.host, port, args.rebuild, read_only)
 
 
 if __name__ == "__main__":

--- a/web/src/shellm_web/control.py
+++ b/web/src/shellm_web/control.py
@@ -62,13 +62,17 @@ def identity_env(identity: IdentityInfo, root: Path | None = None) -> dict[str, 
             "SHELLM_BROKER_DIR": f"{d}/.shellm/docker-broker",
             "SHELLM_CONF_DIR": f"{d}/.shellm",
             "CHATRC": f"{d}/chat/.chatrc",
-            "THINK_MODEL": info.get("think_model")
-            or os.environ.get("SHELLM_MODEL", "claude-opus-4-7"),
             "THINK_TICK_INTERVAL": info.get("interval", "0"),
             "THINK_CONTEXT_TAIL": os.environ.get("THINK_CONTEXT_TAIL", "30"),
             "PATH": f"{BIN_DIR}:{env.get('PATH', '')}",
         }
     )
+    # Pin THINK_MODEL only when something actually specifies it. A fabricated
+    # default here would shadow SHELLM_MODEL from the serve root's .env
+    # (sourced later by _ENV_WRAPPER), which the step scripts fall back to.
+    think_model = info.get("think_model") or env.get("SHELLM_MODEL")
+    if think_model:
+        env["THINK_MODEL"] = think_model
     return env
 
 

--- a/web/src/shellm_web/control.py
+++ b/web/src/shellm_web/control.py
@@ -1,0 +1,223 @@
+"""Mutations: shell out to the repo's bash CLIs (thinkers, chat, identity,
+shellm-killall) with the same environment `identity shell` would set.
+
+Process management stays in bash — this module only builds env, serializes
+concurrent mutations per identity, and maps CLI failures to HTTP errors.
+"""
+
+import os
+import subprocess
+import threading
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from shellm_web.discovery import IdentityInfo, _parse_info_txt
+
+# Repo layout: <repo>/web/src/shellm_web/control.py -> <repo>/bin
+BIN_DIR = Path(
+    os.environ.get("SHELLM_BIN_DIR") or Path(__file__).resolve().parents[3] / "bin"
+)
+
+DEFAULT_TIMEOUT = 60
+
+# Serialize start/stop per identity: cmd_stop rewrites run/active_thinkers
+# with a non-atomic grep>tmp;mv, so concurrent mutations can clobber it.
+_locks_guard = threading.Lock()
+_identity_locks: dict[str, threading.Lock] = {}
+
+
+def identity_lock(identity_id: str) -> threading.Lock:
+    with _locks_guard:
+        lock = _identity_locks.get(identity_id)
+        if lock is None:
+            lock = threading.Lock()
+            _identity_locks[identity_id] = lock
+        return lock
+
+
+def identity_env(identity: IdentityInfo, root: Path | None = None) -> dict[str, str]:
+    """Replicate the env exports of `identity shell` (bin/identity:302-325)."""
+    info = _parse_info_txt(identity.path / "info.txt")
+    d = str(identity.path)
+    root_traj = info.get("root_trajectory", "")
+    env = os.environ.copy()
+    env.update(
+        {
+            "SHELLM_WEB_SERVE_ROOT": str(root) if root else "",
+            "IDENTITY_DIR": d,
+            "IDENTITY_NAME": info.get("name", identity.path.name),
+            "MEM_DIR": f"{d}/memories",
+            "SKILLS_DIR": f"{d}/skills",
+            "SKILLS_KERNEL_DIR": f"{d}/kernel",
+            "TRAJ_DIR": f"{d}/trajectories",
+            "TRAJ_ID": root_traj,
+            "ROOT_TRAJ_ID": root_traj,
+            "THINKERS_DIR": f"{d}/thinkers",
+            "SHELLM_HOME": f"{d}/.shellm",
+            "SKILLSRC": f"{d}/skills/.skillsrc",
+            "SHELLM_TRAJ_DIR": f"{d}/trajectories",
+            "SHELLM_ENVS_DIR": f"{d}/.shellm/envs",
+            "SHELLM_WORKDIRS_DIR": f"{d}/.shellm/workdirs",
+            "SHELLM_BROKER_DIR": f"{d}/.shellm/docker-broker",
+            "SHELLM_CONF_DIR": f"{d}/.shellm",
+            "CHATRC": f"{d}/chat/.chatrc",
+            "THINK_MODEL": info.get("think_model")
+            or os.environ.get("SHELLM_MODEL", "claude-opus-4-7"),
+            "THINK_TICK_INTERVAL": info.get("interval", "0"),
+            "THINK_CONTEXT_TAIL": os.environ.get("THINK_CONTEXT_TAIL", "30"),
+            "PATH": f"{BIN_DIR}:{env.get('PATH', '')}",
+        }
+    )
+    return env
+
+
+# Source .env files before exec'ing the target CLI: the serve root's first
+# (llm/shellm load .env from cwd, and terminal sessions run from the repo
+# root), then the identity's own, so identity-specific keys win.
+_ENV_WRAPPER = (
+    "set -a; "
+    '[ -n "$SHELLM_WEB_SERVE_ROOT" ] && [ -f "$SHELLM_WEB_SERVE_ROOT/.env" ] '
+    '&& . "$SHELLM_WEB_SERVE_ROOT/.env"; '
+    '[ -f "$IDENTITY_DIR/.env" ] && . "$IDENTITY_DIR/.env"; '
+    "set +a; "
+    'exec "$0" "$@"'
+)
+
+
+def _wrap(cli: str, *args: str) -> list[str]:
+    return ["bash", "-c", _ENV_WRAPPER, str(BIN_DIR / cli), *args]
+
+
+def run_cli(
+    cmd: list[str],
+    env: dict[str, str],
+    cwd: Path,
+    *,
+    stdin_text: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            cmd,
+            env=env,
+            cwd=str(cwd),
+            input=stdin_text,
+            stdin=subprocess.DEVNULL if stdin_text is None else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            # New session so backgrounded children (the dispatcher) survive
+            # uvicorn Ctrl-C / --reload, which signal the whole process group.
+            start_new_session=True,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(
+            status_code=500,
+            detail={"message": f"{cmd[3] if len(cmd) > 3 else cmd[0]} timed out after {timeout}s"},
+        ) from exc
+
+
+def _raise_for_failure(proc: subprocess.CompletedProcess) -> None:
+    if proc.returncode == 0:
+        return
+    stderr_lines = [line for line in (proc.stderr or "").splitlines() if line.strip()]
+    message = stderr_lines[-1] if stderr_lines else f"exit code {proc.returncode}"
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "message": message,
+            "stderr": proc.stderr,
+            "exit_code": proc.returncode,
+        },
+    )
+
+
+def _result(action: str, names: list[str], proc: subprocess.CompletedProcess) -> dict:
+    return {
+        "ok": True,
+        "action": action,
+        "names": names,
+        "exit_code": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+
+
+def thinkers_start(
+    root: Path,
+    identity: IdentityInfo,
+    names: list[str],
+    no_self_trigger: bool = False,
+) -> dict:
+    args = ["start"]
+    if no_self_trigger:
+        args.append("--no-self-trigger")
+    args.extend(names)
+    with identity_lock(identity.id):
+        proc = run_cli(_wrap("thinkers", *args), identity_env(identity, root), root)
+    _raise_for_failure(proc)
+    return _result("start", names, proc)
+
+
+def thinkers_stop(root: Path, identity: IdentityInfo, names: list[str]) -> dict:
+    with identity_lock(identity.id):
+        proc = run_cli(
+            _wrap("thinkers", "stop", *names), identity_env(identity, root), root
+        )
+    _raise_for_failure(proc)
+    return _result("stop", names, proc)
+
+
+def thinkers_step(root: Path, identity: IdentityInfo, name: str) -> dict:
+    """Fire-and-forget manual trigger: cmd_step tees output to run/logs/<name>.log
+    and may run for minutes (it can call an LLM), so don't block the request."""
+    subprocess.Popen(
+        _wrap("thinkers", "step", name),
+        env=identity_env(identity, root),
+        cwd=str(root),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return {"ok": True, "action": "step", "names": [name]}
+
+
+def chat_send(root: Path, identity: IdentityInfo, content: str, from_name: str) -> dict:
+    env = identity_env(identity, root)
+    to_name = env["IDENTITY_NAME"]
+    proc = run_cli(
+        _wrap("chat", "send", "--from", from_name, "--to", to_name),
+        env,
+        root,
+        stdin_text=content,
+    )
+    _raise_for_failure(proc)
+    return {"ok": True, "from": from_name, "to": to_name}
+
+
+def identity_new(root: Path, name: str) -> dict:
+    env = os.environ.copy()
+    env["PATH"] = f"{BIN_DIR}:{env.get('PATH', '')}"
+    env["IDENTITY_DIR"] = str(root / ".identities")
+    # With IDENTITY_NAME set, bin/identity treats IDENTITY_DIR as an active
+    # identity and rebases to its parent — make sure we pass the root form.
+    env.pop("IDENTITY_NAME", None)
+    proc = run_cli([str(BIN_DIR / "identity"), "new", name], env, root)
+    _raise_for_failure(proc)
+    return {
+        "ok": True,
+        "id": f".identities~{name}",
+        "name": name,
+        "stderr": proc.stderr,
+    }
+
+
+def killall(dry_run: bool = False) -> dict:
+    env = os.environ.copy()
+    env["PATH"] = f"{BIN_DIR}:{env.get('PATH', '')}"
+    args = [str(BIN_DIR / "shellm-killall")] + (["--dry-run"] if dry_run else [])
+    proc = run_cli(args, env, BIN_DIR.parent)
+    _raise_for_failure(proc)
+    return {"ok": True, "dry_run": dry_run, "stdout": proc.stdout, "stderr": proc.stderr}

--- a/web/src/shellm_web/envfile.py
+++ b/web/src/shellm_web/envfile.py
@@ -1,0 +1,107 @@
+"""Read and edit .env files (identity config), redacting secret values.
+
+Full secret values never leave the server: the API returns a short peek
+(prefix…suffix) so keys are recognizable but not recoverable.
+"""
+
+import re
+from pathlib import Path
+
+ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+SECRET_KEY_RE = re.compile(r"KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL", re.IGNORECASE)
+# Values of these shapes can be written unquoted; anything else is
+# single-quoted so `set -a; . .env` parses it as one word.
+_BARE_VALUE_RE = re.compile(r"^[A-Za-z0-9_.:/@+=,-]*$")
+
+_LINE_RE = re.compile(
+    r"^\s*(?:export\s+)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<value>.*)$"
+)
+
+
+def _unquote(raw: str) -> str:
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
+        return raw[1:-1]
+    return raw
+
+
+def parse_env_file(path: Path) -> list[tuple[str, str]]:
+    """KEY/value pairs in file order; later duplicates win (like sourcing)."""
+    entries: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        if line.lstrip().startswith("#"):
+            continue
+        match = _LINE_RE.match(line)
+        if match:
+            entries[match.group("key")] = _unquote(match.group("value"))
+    return list(entries.items())
+
+
+def is_secret(key: str) -> bool:
+    return bool(SECRET_KEY_RE.search(key))
+
+
+def redacted_entry(key: str, value: str) -> dict:
+    """Wire form of one entry; secrets get a peek, never the full value."""
+    if not is_secret(key):
+        return {"key": key, "value": value, "secret": False}
+    if len(value) > 12:
+        peek = f"{value[:6]}…{value[-4:]}"
+    elif value:
+        peek = "••••••"
+    else:
+        peek = ""
+    return {"key": key, "value": peek, "secret": True}
+
+
+def _quote_value(value: str) -> str:
+    if _BARE_VALUE_RE.match(value):
+        return value
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+def upsert_env_var(path: Path, key: str, value: str) -> None:
+    """Replace every assignment of key (preserving comments and other lines),
+    or append one. Creates the file if missing."""
+    new_line = f"{key}={_quote_value(value)}"
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        lines = []
+    replaced = False
+    result = []
+    for line in lines:
+        match = _LINE_RE.match(line)
+        if match and match.group("key") == key and not line.lstrip().startswith("#"):
+            if not replaced:
+                result.append(new_line)
+                replaced = True
+            # drop duplicate assignments of the same key
+            continue
+        result.append(line)
+    if not replaced:
+        result.append(new_line)
+    path.write_text("".join(f"{line}\n" for line in result), encoding="utf-8")
+
+
+def delete_env_var(path: Path, key: str) -> bool:
+    """Remove every assignment of key. Returns True if anything was removed."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+    result = []
+    removed = False
+    for line in lines:
+        match = _LINE_RE.match(line)
+        if match and match.group("key") == key and not line.lstrip().startswith("#"):
+            removed = True
+            continue
+        result.append(line)
+    if removed:
+        path.write_text("".join(f"{line}\n" for line in result), encoding="utf-8")
+    return removed

--- a/web/src/shellm_web/safety.py
+++ b/web/src/shellm_web/safety.py
@@ -8,6 +8,12 @@ from fastapi import HTTPException
 BLOB_NAME_RE = re.compile(r"^[0-9a-f-]{36}-[0-9a-f]{6}\.(stdout|stderr)$")
 LOG_NAME_RE = re.compile(r"^[A-Za-z0-9_.\-]+\.log$")
 MEMORY_NAME_RE = re.compile(r"^[A-Za-z0-9_.\-]+\.md$")
+# Underscores allowed: existing thinkers (inner_monologue, ...) use them even
+# though `thinkers new` only scaffolds hyphenated names.
+THINKER_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+# Same rule `identity new` enforces.
+IDENTITY_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+CHAT_FROM_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def contained_path(base: Path, *parts: str) -> Path:

--- a/web/src/shellm_web/server.py
+++ b/web/src/shellm_web/server.py
@@ -8,8 +8,19 @@ from fastapi import FastAPI, HTTPException, Query, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
-from shellm_web import discovery, liveness, logs, safety, trajectory, tree
+from shellm_web import (
+    chat,
+    control,
+    discovery,
+    liveness,
+    logs,
+    safety,
+    thinkers,
+    trajectory,
+    tree,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +48,27 @@ def _iso(ts: float | None) -> str | None:
     return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
 
 
-def create_app(root: Path, static_dir: Path | None = None) -> FastAPI:
+class ThinkerActionBody(BaseModel):
+    names: list[str] = []
+    no_self_trigger: bool = False
+
+
+class ChatSendBody(BaseModel):
+    content: str
+    from_name: str
+
+
+class NewIdentityBody(BaseModel):
+    name: str
+
+
+class KillallBody(BaseModel):
+    dry_run: bool = False
+
+
+def create_app(
+    root: Path, static_dir: Path | None = None, *, read_only: bool = False
+) -> FastAPI:
     root = root.resolve()
     app = FastAPI(title="shellm web viewer", version=VERSION)
     app.add_middleware(
@@ -48,13 +79,25 @@ def create_app(root: Path, static_dir: Path | None = None) -> FastAPI:
         allow_headers=["*"],
     )
 
+    def _require_controls() -> None:
+        if read_only:
+            raise HTTPException(status_code=403, detail="Server is read-only")
+
+    def _checked_thinker_names(identity: discovery.IdentityInfo, names: list[str]) -> None:
+        installed = {d.name for d in thinkers.list_thinker_dirs(identity.path)}
+        for name in names:
+            if not safety.THINKER_NAME_RE.match(name):
+                raise HTTPException(status_code=422, detail=f"Invalid thinker name: {name}")
+            if name not in installed:
+                raise HTTPException(status_code=404, detail=f"Thinker not found: {name}")
+
     @app.get("/api/health")
     def health() -> dict:
         return {"status": "ok"}
 
     @app.get("/api/config")
     def config() -> dict:
-        return {"root": str(root), "version": VERSION}
+        return {"root": str(root), "version": VERSION, "controls_enabled": not read_only}
 
     @app.get("/api/identities")
     def identities() -> list[dict]:
@@ -63,6 +106,7 @@ def create_app(root: Path, static_dir: Path | None = None) -> FastAPI:
             traj_dir = discovery.find_root_traj_dir(identity)
             jsonl = traj_dir / "trajectory.jsonl" if traj_dir else None
             status = liveness.identity_status(identity.path, jsonl)
+            summary = thinkers.thinkers_summary(identity.path)
             result.append(
                 {
                     "id": identity.id,
@@ -74,6 +118,7 @@ def create_app(root: Path, static_dir: Path | None = None) -> FastAPI:
                     "live": status["live"],
                     "last_activity_ts": _iso(status["mindlog_mtime"]),
                     "step_count": _count_steps(jsonl) if jsonl else 0,
+                    **summary,
                 }
             )
         result.sort(key=lambda item: item["last_activity_ts"] or "", reverse=True)
@@ -217,6 +262,76 @@ def create_app(root: Path, static_dir: Path | None = None) -> FastAPI:
         if not memory_path.is_file():
             raise HTTPException(status_code=404, detail="Memory not found")
         return {"name": name, "content": memory_path.read_text(encoding="utf-8", errors="replace")}
+
+    @app.get("/api/identities/{identity_id}/thinkers")
+    def identity_thinkers(identity_id: str) -> dict:
+        identity = _identity_or_404(root, identity_id)
+        result = thinkers.thinkers_status(identity.path)
+        for entry in result["thinkers"]:
+            entry["log_mtime"] = _iso(entry["log_mtime"])
+        result["identity"] = {"id": identity.id, "name": identity.name}
+        return result
+
+    @app.post("/api/identities/{identity_id}/thinkers/start")
+    def thinkers_start(identity_id: str, body: ThinkerActionBody) -> dict:
+        _require_controls()
+        identity = _identity_or_404(root, identity_id)
+        if not thinkers.list_thinker_dirs(identity.path):
+            raise HTTPException(status_code=409, detail="Identity has no thinkers")
+        _checked_thinker_names(identity, body.names)
+        return control.thinkers_start(root, identity, body.names, body.no_self_trigger)
+
+    @app.post("/api/identities/{identity_id}/thinkers/stop")
+    def thinkers_stop(identity_id: str, body: ThinkerActionBody) -> dict:
+        _require_controls()
+        identity = _identity_or_404(root, identity_id)
+        _checked_thinker_names(identity, body.names)
+        return control.thinkers_stop(root, identity, body.names)
+
+    @app.post("/api/identities/{identity_id}/thinkers/{name}/step", status_code=202)
+    def thinkers_step(identity_id: str, name: str) -> dict:
+        _require_controls()
+        identity = _identity_or_404(root, identity_id)
+        _checked_thinker_names(identity, [name])
+        return control.thinkers_step(root, identity, name)
+
+    @app.get("/api/identities/{identity_id}/chat")
+    def identity_chat(
+        identity_id: str, tail: int = Query(default=200, ge=1, le=2000)
+    ) -> dict:
+        identity = _identity_or_404(root, identity_id)
+        traj_dir = _root_traj_dir_or_404(identity)
+        status = liveness.identity_status(identity.path, traj_dir / "trajectory.jsonl")
+        return {
+            "identity": {"id": identity.id, "name": identity.name},
+            "live": status["live"],
+            "messages": chat.chat_messages(traj_dir, identity.name, tail),
+        }
+
+    @app.post("/api/identities/{identity_id}/chat")
+    def identity_chat_send(identity_id: str, body: ChatSendBody) -> dict:
+        _require_controls()
+        identity = _identity_or_404(root, identity_id)
+        if not body.content.strip():
+            raise HTTPException(status_code=422, detail="Empty message")
+        if not safety.CHAT_FROM_RE.match(body.from_name):
+            raise HTTPException(status_code=422, detail="Invalid sender name")
+        return control.chat_send(root, identity, body.content, body.from_name)
+
+    @app.post("/api/identities", status_code=201)
+    def create_identity(body: NewIdentityBody) -> dict:
+        _require_controls()
+        if not safety.IDENTITY_NAME_RE.match(body.name):
+            raise HTTPException(
+                status_code=422,
+                detail="Invalid identity name (use lowercase alphanumeric + hyphens)",
+            )
+        return control.identity_new(root, body.name)
+
+    @app.post("/api/killall")
+    def api_killall(body: KillallBody) -> dict:
+        _require_controls()
+        return control.killall(body.dry_run)
 
     # Static frontend (registered last so /api wins)
     if static_dir and static_dir.exists():

--- a/web/src/shellm_web/server.py
+++ b/web/src/shellm_web/server.py
@@ -298,10 +298,16 @@ def create_app(
     def thinkers_start(identity_id: str, body: ThinkerActionBody) -> dict:
         _require_controls()
         identity = _identity_or_404(root, identity_id)
-        if not thinkers.list_thinker_dirs(identity.path):
+        enabled = thinkers.list_thinker_dirs(identity.path)
+        if not enabled:
             raise HTTPException(status_code=409, detail="Identity has no thinkers")
         _checked_thinker_names(identity, body.names)
-        return control.thinkers_start(root, identity, body.names, body.no_self_trigger)
+        # Expand "start all" to explicit names: the CLI's named-start path
+        # kicks each thinker once with a manual-trigger step, while its
+        # start-all path only arms the dispatcher — thinkers would then sit
+        # idle until some new trajectory step happens to arrive.
+        names = body.names or [d.name for d in enabled]
+        return control.thinkers_start(root, identity, names, body.no_self_trigger)
 
     @app.post("/api/identities/{identity_id}/thinkers/stop")
     def thinkers_stop(identity_id: str, body: ThinkerActionBody) -> dict:

--- a/web/src/shellm_web/server.py
+++ b/web/src/shellm_web/server.py
@@ -14,6 +14,7 @@ from shellm_web import (
     chat,
     control,
     discovery,
+    envfile,
     liveness,
     logs,
     safety,
@@ -66,6 +67,11 @@ class KillallBody(BaseModel):
     dry_run: bool = False
 
 
+class EnvVarBody(BaseModel):
+    key: str
+    value: str
+
+
 def create_app(
     root: Path, static_dir: Path | None = None, *, read_only: bool = False
 ) -> FastAPI:
@@ -84,12 +90,20 @@ def create_app(
             raise HTTPException(status_code=403, detail="Server is read-only")
 
     def _checked_thinker_names(identity: discovery.IdentityInfo, names: list[str]) -> None:
-        installed = {d.name for d in thinkers.list_thinker_dirs(identity.path)}
+        enabled = {d.name for d in thinkers.list_thinker_dirs(identity.path)}
+        installed = {
+            d.name for d in thinkers.list_thinker_dirs(identity.path, include_disabled=True)
+        }
         for name in names:
             if not safety.THINKER_NAME_RE.match(name):
                 raise HTTPException(status_code=422, detail=f"Invalid thinker name: {name}")
             if name not in installed:
                 raise HTTPException(status_code=404, detail=f"Thinker not found: {name}")
+            if name not in enabled:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Thinker '{name}' is disabled — enable it first",
+                )
 
     @app.get("/api/health")
     def health() -> dict:
@@ -295,6 +309,44 @@ def create_app(
         _checked_thinker_names(identity, [name])
         return control.thinkers_step(root, identity, name)
 
+    def _thinker_dir_or_404(identity: discovery.IdentityInfo, name: str) -> Path:
+        if not safety.THINKER_NAME_RE.match(name):
+            raise HTTPException(status_code=422, detail=f"Invalid thinker name: {name}")
+        for tdir in thinkers.list_thinker_dirs(identity.path, include_disabled=True):
+            if tdir.name == name:
+                return tdir
+        raise HTTPException(status_code=404, detail=f"Thinker not found: {name}")
+
+    @app.post("/api/identities/{identity_id}/thinkers/{name}/disable")
+    def thinkers_disable(identity_id: str, name: str) -> dict:
+        _require_controls()
+        identity = _identity_or_404(root, identity_id)
+        tdir = _thinker_dir_or_404(identity, name)
+        status = thinkers.thinkers_status(identity.path)
+        entry = next(t for t in status["thinkers"] if t["name"] == name)
+        stopped = False
+        if entry["state"] not in ("stopped", "disabled"):
+            control.thinkers_stop(root, identity, [name])
+            stopped = True
+        (tdir / "disabled").touch()
+        return {"ok": True, "name": name, "disabled": True, "stopped_first": stopped}
+
+    @app.post("/api/identities/{identity_id}/thinkers/{name}/enable")
+    def thinkers_enable(identity_id: str, name: str) -> dict:
+        _require_controls()
+        identity = _identity_or_404(root, identity_id)
+        tdir = _thinker_dir_or_404(identity, name)
+        (tdir / "disabled").unlink(missing_ok=True)
+        # The dispatcher builds its subscription map at startup; a thinker
+        # enabled while it runs won't receive events until a restart.
+        dispatcher_running = thinkers.thinkers_status(identity.path)["dispatcher"]["running"]
+        return {
+            "ok": True,
+            "name": name,
+            "disabled": False,
+            "needs_restart": dispatcher_running,
+        }
+
     @app.get("/api/identities/{identity_id}/chat")
     def identity_chat(
         identity_id: str, tail: int = Query(default=200, ge=1, le=2000)
@@ -332,6 +384,50 @@ def create_app(
     def api_killall(body: KillallBody) -> dict:
         _require_controls()
         return control.killall(body.dry_run)
+
+    @app.get("/api/identities/{identity_id}/env")
+    def identity_env_get(identity_id: str) -> dict:
+        identity = _identity_or_404(root, identity_id)
+        own = [
+            envfile.redacted_entry(key, value)
+            for key, value in envfile.parse_env_file(identity.path / ".env")
+        ]
+        own_keys = {entry["key"] for entry in own}
+        inherited = [
+            {**envfile.redacted_entry(key, value), "overridden": key in own_keys}
+            for key, value in envfile.parse_env_file(root / ".env")
+        ]
+        return {
+            "identity": {"id": identity.id, "name": identity.name},
+            "env": own,
+            "inherited": inherited,
+            "note": "Changes take effect the next time thinkers are started.",
+        }
+
+    @app.put("/api/identities/{identity_id}/env")
+    def identity_env_put(identity_id: str, body: EnvVarBody) -> dict:
+        _require_controls()
+        identity = _identity_or_404(root, identity_id)
+        if not envfile.ENV_KEY_RE.match(body.key):
+            raise HTTPException(
+                status_code=422,
+                detail="Invalid variable name (letters, digits, underscores)",
+            )
+        if any(ch in body.value for ch in "\n\r\x00"):
+            raise HTTPException(status_code=422, detail="Value must be a single line")
+        envfile.upsert_env_var(identity.path / ".env", body.key, body.value)
+        return {"ok": True, **envfile.redacted_entry(body.key, body.value)}
+
+    @app.delete("/api/identities/{identity_id}/env/{key}")
+    def identity_env_delete(identity_id: str, key: str) -> dict:
+        _require_controls()
+        identity = _identity_or_404(root, identity_id)
+        if not envfile.ENV_KEY_RE.match(key):
+            raise HTTPException(status_code=422, detail="Invalid variable name")
+        removed = envfile.delete_env_var(identity.path / ".env", key)
+        if not removed:
+            raise HTTPException(status_code=404, detail="Variable not found")
+        return {"ok": True, "key": key}
 
     # Static frontend (registered last so /api wins)
     if static_dir and static_dir.exists():

--- a/web/src/shellm_web/server.py
+++ b/web/src/shellm_web/server.py
@@ -1,6 +1,7 @@
 """FastAPI app factory for the shellm web viewer."""
 
 import logging
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -77,9 +78,16 @@ def create_app(
 ) -> FastAPI:
     root = root.resolve()
     app = FastAPI(title="shellm web viewer", version=VERSION)
+    # Default "*" suits local use; deployments should pin this to their
+    # public origin(s) via SHELLM_WEB_ALLOWED_ORIGINS (comma-separated).
+    allowed_origins = [
+        origin.strip()
+        for origin in os.environ.get("SHELLM_WEB_ALLOWED_ORIGINS", "*").split(",")
+        if origin.strip()
+    ]
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/web/src/shellm_web/thinkers.py
+++ b/web/src/shellm_web/thinkers.py
@@ -1,0 +1,167 @@
+"""Per-identity thinker status, mirroring `bin/thinkers` cmd_status.
+
+All state is derived from files under <identity>/run/ plus os.kill(pid, 0)
+liveness probes — the same sources the CLI reads. Note: step_pids is
+append-only and pids can be recycled by the OS, so a recycled pid may
+briefly misreport a thinker as active; this matches `thinkers status`.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from shellm_web.liveness import pid_alive
+
+
+def list_thinker_dirs(identity_dir: Path) -> list[Path]:
+    """Thinker dirs under <identity>/thinkers/: need step + subscriptions.jsonl."""
+    thinkers_root = identity_dir / "thinkers"
+    if not thinkers_root.is_dir():
+        return []
+    result = []
+    for child in sorted(thinkers_root.iterdir()):
+        if not child.is_dir() or child.name.startswith("_"):
+            continue
+        if (child / "step").is_file() and (child / "subscriptions.jsonl").is_file():
+            result.append(child)
+    return result
+
+
+def _pid_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    return True
+
+
+def _read_lines(path: Path) -> list[str]:
+    try:
+        return [line for line in path.read_text().splitlines() if line.strip()]
+    except OSError:
+        return []
+
+
+def _live_steps_by_thinker(run_dir: Path) -> dict[str, int]:
+    """Parse run/step_pids ("pid name" lines) and count live steps per thinker."""
+    counts: dict[str, int] = {}
+    for line in _read_lines(run_dir / "step_pids"):
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        pid_str, name = parts
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        if _pid_running(pid):
+            counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def _pending_by_thinker(run_dir: Path) -> dict[str, list[str]]:
+    """run/pending/<name>.<type> flags -> {name: [types]}."""
+    pending: dict[str, list[str]] = {}
+    pending_dir = run_dir / "pending"
+    if not pending_dir.is_dir():
+        return pending
+    for flag in sorted(pending_dir.iterdir()):
+        if not flag.is_file() or "." not in flag.name:
+            continue
+        name, _, step_type = flag.name.rpartition(".")
+        pending.setdefault(name, []).append(step_type)
+    return pending
+
+
+def _subscription_info(thinker_dir: Path) -> tuple[list[str], bool]:
+    """types + trigger_self from the first line of subscriptions.jsonl."""
+    try:
+        with (thinker_dir / "subscriptions.jsonl").open() as fh:
+            first = fh.readline()
+        sub = json.loads(first)
+        types = sub.get("types") or ["all"]
+        trigger_self = bool(sub.get("trigger_self", False))
+        return [str(t) for t in types], trigger_self
+    except (OSError, ValueError, AttributeError):
+        return ["all"], False
+
+
+def thinkers_status(identity_dir: Path) -> dict:
+    """Full per-identity thinker status (GET .../thinkers payload body)."""
+    run_dir = identity_dir / "run"
+    dispatcher_alive, dispatcher_pid = pid_alive(run_dir / "dispatcher.pid")
+    active_set = set(_read_lines(run_dir / "active_thinkers"))
+    live_steps = _live_steps_by_thinker(run_dir)
+    pending = _pending_by_thinker(run_dir)
+
+    thinkers = []
+    for thinker_dir in list_thinker_dirs(identity_dir):
+        name = thinker_dir.name
+        types, trigger_self = _subscription_info(thinker_dir)
+        steps_in_flight = live_steps.get(name, 0)
+
+        # Precedence mirrors cmd_status: a live per-thinker daemon pid wins,
+        # then stopped (dispatcher down or not active), then active/idle.
+        daemon_alive, daemon_pid = pid_alive(run_dir / "thinkers" / f"{name}.pid")
+        if daemon_alive:
+            state = "running"
+        elif not dispatcher_alive or name not in active_set:
+            state = "stopped"
+        elif steps_in_flight > 0:
+            state = "active"
+        else:
+            state = "idle"
+
+        log_bytes: int | None = None
+        log_mtime: float | None = None
+        log_file = run_dir / "logs" / f"{name}.log"
+        try:
+            stat = log_file.stat()
+            log_bytes = stat.st_size
+            log_mtime = stat.st_mtime
+        except OSError:
+            pass
+
+        thinkers.append(
+            {
+                "name": name,
+                "state": state,
+                "steps_in_flight": steps_in_flight,
+                "pid": daemon_pid if daemon_alive else None,
+                "types": types,
+                "trigger_self": trigger_self,
+                "pending": pending.get(name, []),
+                "log_bytes": log_bytes,
+                "log_mtime": log_mtime,
+            }
+        )
+
+    return {
+        "dispatcher": {
+            "running": dispatcher_alive,
+            "pid": dispatcher_pid if dispatcher_alive else None,
+        },
+        "active_thinkers": len(active_set),
+        "thinkers_total": len(thinkers),
+        "steps_in_flight": sum(live_steps.values()),
+        "pending_total": sum(len(v) for v in pending.values()),
+        "thinkers": thinkers,
+    }
+
+
+def thinkers_summary(identity_dir: Path) -> dict:
+    """Cheap subset merged into each GET /api/identities item."""
+    run_dir = identity_dir / "run"
+    dispatcher_alive, dispatcher_pid = pid_alive(run_dir / "dispatcher.pid")
+    thinker_names = {d.name for d in list_thinker_dirs(identity_dir)}
+    active_set = set(_read_lines(run_dir / "active_thinkers")) & thinker_names
+    live_steps = _live_steps_by_thinker(run_dir)
+    return {
+        "dispatcher": {
+            "running": dispatcher_alive,
+            "pid": dispatcher_pid if dispatcher_alive else None,
+        },
+        "thinkers_total": len(thinker_names),
+        "thinkers_active": len(active_set) if dispatcher_alive else 0,
+        "steps_in_flight": sum(live_steps.values()) if dispatcher_alive else 0,
+    }

--- a/web/src/shellm_web/thinkers.py
+++ b/web/src/shellm_web/thinkers.py
@@ -13,7 +13,14 @@ from pathlib import Path
 from shellm_web.liveness import pid_alive
 
 
-def list_thinker_dirs(identity_dir: Path) -> list[Path]:
+def is_disabled(thinker_dir: Path) -> bool:
+    """Marker file the CLI honors too: touch <thinker>/disabled."""
+    return (thinker_dir / "disabled").is_file()
+
+
+def list_thinker_dirs(
+    identity_dir: Path, include_disabled: bool = False
+) -> list[Path]:
     """Thinker dirs under <identity>/thinkers/: need step + subscriptions.jsonl."""
     thinkers_root = identity_dir / "thinkers"
     if not thinkers_root.is_dir():
@@ -21,6 +28,8 @@ def list_thinker_dirs(identity_dir: Path) -> list[Path]:
     result = []
     for child in sorted(thinkers_root.iterdir()):
         if not child.is_dir() or child.name.startswith("_"):
+            continue
+        if not include_disabled and is_disabled(child):
             continue
         if (child / "step").is_file() and (child / "subscriptions.jsonl").is_file():
             result.append(child)
@@ -95,15 +104,18 @@ def thinkers_status(identity_dir: Path) -> dict:
     pending = _pending_by_thinker(run_dir)
 
     thinkers = []
-    for thinker_dir in list_thinker_dirs(identity_dir):
+    for thinker_dir in list_thinker_dirs(identity_dir, include_disabled=True):
         name = thinker_dir.name
         types, trigger_self = _subscription_info(thinker_dir)
         steps_in_flight = live_steps.get(name, 0)
 
-        # Precedence mirrors cmd_status: a live per-thinker daemon pid wins,
-        # then stopped (dispatcher down or not active), then active/idle.
+        # Precedence mirrors cmd_status: disabled marker wins, then a live
+        # per-thinker daemon pid, then stopped (dispatcher down or not
+        # active), then active/idle.
         daemon_alive, daemon_pid = pid_alive(run_dir / "thinkers" / f"{name}.pid")
-        if daemon_alive:
+        if is_disabled(thinker_dir):
+            state = "disabled"
+        elif daemon_alive:
             state = "running"
         elif not dispatcher_alive or name not in active_set:
             state = "stopped"
@@ -136,13 +148,15 @@ def thinkers_status(identity_dir: Path) -> dict:
             }
         )
 
+    enabled_count = sum(1 for t in thinkers if t["state"] != "disabled")
     return {
         "dispatcher": {
             "running": dispatcher_alive,
             "pid": dispatcher_pid if dispatcher_alive else None,
         },
-        "active_thinkers": len(active_set),
-        "thinkers_total": len(thinkers),
+        "active_thinkers": len(active_set) if dispatcher_alive else 0,
+        "thinkers_total": enabled_count,
+        "thinkers_disabled": len(thinkers) - enabled_count,
         "steps_in_flight": sum(live_steps.values()),
         "pending_total": sum(len(v) for v in pending.values()),
         "thinkers": thinkers,

--- a/web/tests/test_thinkers_and_control.py
+++ b/web/tests/test_thinkers_and_control.py
@@ -1,0 +1,315 @@
+"""Thinker status computation and control-endpoint tests."""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from shellm_web import control, thinkers
+from shellm_web.server import create_app
+
+ROOT_TRAJ = "eeeeeeee-5555-4555-8555-555555555555"
+
+
+def _make_thinker(identity: Path, name: str, types: list[str] | None = None) -> None:
+    tdir = identity / "thinkers" / name
+    tdir.mkdir(parents=True)
+    step = tdir / "step"
+    step.write_text("#!/usr/bin/env bash\ncat >/dev/null\n")
+    step.chmod(step.stat().st_mode | stat.S_IXUSR)
+    sub = {"types": types} if types else {}
+    (tdir / "subscriptions.jsonl").write_text(json.dumps(sub) + "\n")
+
+
+@pytest.fixture
+def control_identity(tmp_path: Path) -> Path:
+    """Root dir containing one identity with two thinkers and a mind log."""
+    identity = tmp_path / ".identities" / "ctl"
+    identity.mkdir(parents=True)
+    (identity / "info.txt").write_text(
+        f"name=ctl\ncreated=2026-07-14T00:00:00\nroot_trajectory={ROOT_TRAJ}\n"
+        "think_model=test-model\n"
+    )
+    traj_dir = identity / "trajectories" / "eeeeeeee-root"
+    traj_dir.mkdir(parents=True)
+    (traj_dir / "trajectory.jsonl").write_text(
+        json.dumps({"type": "trajectory", "step_id": ROOT_TRAJ, "ts": "t0"}) + "\n"
+        + json.dumps(
+            {
+                "type": "message",
+                "step_id": "m1",
+                "content": "hi ctl",
+                "from": "nick",
+                "to": "ctl",
+                "ts": "t1",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": "message",
+                "step_id": "m2",
+                "content": "hi nick",
+                "from": "ctl",
+                "to": "nick",
+                "ts": "t2",
+            }
+        )
+        + "\n"
+    )
+    _make_thinker(identity, "alpha", ["message"])
+    _make_thinker(identity, "beta_two")
+    (identity / "thinkers" / "_lib").mkdir()
+    return identity
+
+
+# ---------------------------------------------------------------------------
+# Status computation
+# ---------------------------------------------------------------------------
+
+
+def test_status_never_started(control_identity: Path):
+    status = thinkers.thinkers_status(control_identity)
+    assert status["dispatcher"] == {"running": False, "pid": None}
+    assert status["thinkers_total"] == 2
+    assert {t["name"] for t in status["thinkers"]} == {"alpha", "beta_two"}
+    assert all(t["state"] == "stopped" for t in status["thinkers"])
+    alpha = next(t for t in status["thinkers"] if t["name"] == "alpha")
+    assert alpha["types"] == ["message"]
+
+
+def test_status_running_mix(control_identity: Path):
+    run = control_identity / "run"
+    (run / "pending").mkdir(parents=True)
+    (run / "dispatcher.pid").write_text(str(os.getpid()))
+    (run / "active_thinkers").write_text("alpha\n")
+    # one live step (our own pid), one dead
+    (run / "step_pids").write_text(f"{os.getpid()} alpha\n999999 alpha\n")
+    (run / "pending" / "alpha.message").write_text("{}")
+
+    status = thinkers.thinkers_status(control_identity)
+    assert status["dispatcher"]["running"] is True
+    alpha = next(t for t in status["thinkers"] if t["name"] == "alpha")
+    beta = next(t for t in status["thinkers"] if t["name"] == "beta_two")
+    assert alpha["state"] == "active"
+    assert alpha["steps_in_flight"] == 1
+    assert alpha["pending"] == ["message"]
+    assert beta["state"] == "stopped"  # not in active_thinkers
+    assert status["steps_in_flight"] == 1
+    assert status["pending_total"] == 1
+
+
+def test_status_dead_dispatcher(control_identity: Path):
+    run = control_identity / "run"
+    run.mkdir()
+    (run / "dispatcher.pid").write_text("999999")
+    (run / "active_thinkers").write_text("alpha\nbeta_two\n")
+    status = thinkers.thinkers_status(control_identity)
+    assert status["dispatcher"]["running"] is False
+    assert all(t["state"] == "stopped" for t in status["thinkers"])
+    summary = thinkers.thinkers_summary(control_identity)
+    assert summary["thinkers_active"] == 0
+
+
+# ---------------------------------------------------------------------------
+# API
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(control_identity: Path) -> TestClient:
+    return TestClient(create_app(control_identity.parent.parent))
+
+
+@pytest.fixture
+def stub_bin(tmp_path: Path, monkeypatch) -> Path:
+    """Fake CLI dir; each stub dumps env + argv to <stub>/calls.txt."""
+    stub = tmp_path / "stub-bin"
+    stub.mkdir()
+    monkeypatch.setattr(control, "BIN_DIR", stub)
+    return stub
+
+
+def _write_stub(stub: Path, name: str, exit_code: int = 0, stderr: str = "") -> None:
+    script = stub / name
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        "{\n"
+        f'  echo "CLI={name}"\n'
+        '  echo "ARGS=$*"\n'
+        '  echo "IDENTITY_DIR=$IDENTITY_DIR"\n'
+        '  echo "TRAJ_ID=$TRAJ_ID"\n'
+        '  echo "THINK_MODEL=$THINK_MODEL"\n'
+        '  echo "PATH=$PATH"\n'
+        '  echo "PWD=$PWD"\n'
+        '  echo "APIKEY=$ANTHROPIC_API_KEY"\n'
+        '  echo "STDIN=$(cat)"\n'
+        f"}} >> {stub}/calls.txt\n"
+        + (f"echo {json.dumps(stderr)} >&2\n" if stderr else "")
+        + f"exit {exit_code}\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+
+
+def _calls(stub: Path) -> str:
+    return (stub / "calls.txt").read_text()
+
+
+def test_identities_include_summary(client: TestClient):
+    items = client.get("/api/identities").json()
+    assert len(items) == 1
+    assert items[0]["dispatcher"] == {"running": False, "pid": None}
+    assert items[0]["thinkers_total"] == 2
+    assert items[0]["thinkers_active"] == 0
+
+
+def test_thinkers_endpoint(client: TestClient, control_identity: Path):
+    identity_id = ".identities~ctl"
+    body = client.get(f"/api/identities/{identity_id}/thinkers").json()
+    assert body["identity"]["name"] == "ctl"
+    assert body["thinkers_total"] == 2
+
+
+def test_start_invokes_cli_with_env(client: TestClient, stub_bin: Path):
+    _write_stub(stub_bin, "thinkers")
+    resp = client.post(
+        "/api/identities/.identities~ctl/thinkers/start", json={"names": ["alpha"]}
+    )
+    assert resp.status_code == 200, resp.text
+    calls = _calls(stub_bin)
+    assert "ARGS=start alpha" in calls
+    assert "/.identities/ctl" in calls
+    assert f"TRAJ_ID={ROOT_TRAJ}" in calls
+    assert "THINK_MODEL=test-model" in calls
+    assert f"PATH={stub_bin}:" in calls
+
+
+def test_start_sources_root_env_file(
+    client: TestClient, stub_bin: Path, control_identity: Path, monkeypatch
+):
+    """The serve root's .env supplies API keys (llm reads .env from cwd, and
+    terminal sessions run from the repo root) — the web-launched CLI must see
+    it too. The identity's own .env wins over the root's."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    root = control_identity.parent.parent
+    (root / ".env").write_text("ANTHROPIC_API_KEY=root-key\n")
+    _write_stub(stub_bin, "thinkers")
+    client.post("/api/identities/.identities~ctl/thinkers/start", json={})
+    calls = _calls(stub_bin)
+    assert "APIKEY=root-key" in calls
+    assert f"PWD={root}" in calls
+
+    (control_identity / ".env").write_text("ANTHROPIC_API_KEY=identity-key\n")
+    client.post("/api/identities/.identities~ctl/thinkers/start", json={})
+    assert "APIKEY=identity-key" in _calls(stub_bin)
+
+
+def test_start_conflict_maps_to_409(client: TestClient, stub_bin: Path):
+    _write_stub(
+        stub_bin,
+        "thinkers",
+        exit_code=1,
+        stderr="thinkers: error: Dispatcher already running (PID 42). Use `thinkers stop` first.",
+    )
+    resp = client.post("/api/identities/.identities~ctl/thinkers/start", json={})
+    assert resp.status_code == 409
+    assert "Dispatcher already running" in resp.json()["detail"]["message"]
+
+
+def test_name_validation(client: TestClient, stub_bin: Path):
+    _write_stub(stub_bin, "thinkers")
+    bad = client.post(
+        "/api/identities/.identities~ctl/thinkers/start", json={"names": ["../evil"]}
+    )
+    assert bad.status_code == 422
+    ghost = client.post(
+        "/api/identities/.identities~ctl/thinkers/stop", json={"names": ["ghost"]}
+    )
+    assert ghost.status_code == 404
+    assert not (stub_bin / "calls.txt").exists()
+
+
+def test_step_trigger_fires(client: TestClient, stub_bin: Path):
+    _write_stub(stub_bin, "thinkers")
+    resp = client.post("/api/identities/.identities~ctl/thinkers/alpha/step")
+    assert resp.status_code == 202
+    # fire-and-forget: wait for the stub to write
+    import time
+
+    for _ in range(50):
+        if (stub_bin / "calls.txt").exists():
+            break
+        time.sleep(0.05)
+    assert "ARGS=step alpha" in _calls(stub_bin)
+
+
+def test_chat_get(client: TestClient):
+    body = client.get("/api/identities/.identities~ctl/chat").json()
+    contents = [m["content"] for m in body["messages"]]
+    assert contents == ["hi ctl", "hi nick"]
+    assert body["messages"][0]["from"] == "nick"
+
+
+def test_chat_send_pipes_stdin(client: TestClient, stub_bin: Path):
+    _write_stub(stub_bin, "chat")
+    resp = client.post(
+        "/api/identities/.identities~ctl/chat",
+        json={"content": "hello there", "from_name": "nick"},
+    )
+    assert resp.status_code == 200, resp.text
+    calls = _calls(stub_bin)
+    assert "ARGS=send --from nick --to ctl" in calls
+    assert "STDIN=hello there" in calls
+
+
+def test_chat_send_validation(client: TestClient, stub_bin: Path):
+    _write_stub(stub_bin, "chat")
+    resp = client.post(
+        "/api/identities/.identities~ctl/chat",
+        json={"content": "  ", "from_name": "nick"},
+    )
+    assert resp.status_code == 422
+    resp = client.post(
+        "/api/identities/.identities~ctl/chat",
+        json={"content": "hi", "from_name": "nick; rm -rf"},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_identity(client: TestClient, stub_bin: Path, control_identity: Path):
+    _write_stub(stub_bin, "identity")
+    resp = client.post("/api/identities", json={"name": "newbie"})
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["id"] == ".identities~newbie"
+    calls = _calls(stub_bin)
+    assert "ARGS=new newbie" in calls
+    root = control_identity.parent.parent
+    assert f"IDENTITY_DIR={root}/.identities" in calls
+
+    bad = client.post("/api/identities", json={"name": "Bad Name"})
+    assert bad.status_code == 422
+
+
+def test_killall(client: TestClient, stub_bin: Path):
+    _write_stub(stub_bin, "shellm-killall")
+    resp = client.post("/api/killall", json={"dry_run": True})
+    assert resp.status_code == 200
+    assert "ARGS=--dry-run" in _calls(stub_bin)
+
+
+def test_read_only_blocks_mutations(control_identity: Path):
+    ro_client = TestClient(create_app(control_identity.parent.parent, read_only=True))
+    assert ro_client.get("/api/config").json()["controls_enabled"] is False
+    for path, body in [
+        ("/api/identities/.identities~ctl/thinkers/start", {}),
+        ("/api/identities/.identities~ctl/thinkers/stop", {}),
+        ("/api/identities/.identities~ctl/thinkers/alpha/step", None),
+        ("/api/identities/.identities~ctl/chat", {"content": "x", "from_name": "n"}),
+        ("/api/identities", {"name": "x"}),
+        ("/api/killall", {}),
+    ]:
+        resp = ro_client.post(path, json=body)
+        assert resp.status_code == 403, path

--- a/web/tests/test_thinkers_and_control.py
+++ b/web/tests/test_thinkers_and_control.py
@@ -300,6 +300,128 @@ def test_killall(client: TestClient, stub_bin: Path):
     assert "ARGS=--dry-run" in _calls(stub_bin)
 
 
+def test_disabled_marker_states(control_identity: Path):
+    (control_identity / "thinkers" / "beta_two" / "disabled").touch()
+    status = thinkers.thinkers_status(control_identity)
+    beta = next(t for t in status["thinkers"] if t["name"] == "beta_two")
+    assert beta["state"] == "disabled"
+    assert status["thinkers_total"] == 1
+    assert status["thinkers_disabled"] == 1
+    summary = thinkers.thinkers_summary(control_identity)
+    assert summary["thinkers_total"] == 1
+
+
+def test_enable_disable_endpoints(client: TestClient, control_identity: Path, stub_bin: Path):
+    _write_stub(stub_bin, "thinkers")
+    marker = control_identity / "thinkers" / "beta_two" / "disabled"
+
+    # disable a stopped thinker: marker written, no CLI stop needed
+    resp = client.post("/api/identities/.identities~ctl/thinkers/beta_two/disable")
+    assert resp.status_code == 200
+    assert resp.json()["stopped_first"] is False
+    assert marker.is_file()
+    assert not (stub_bin / "calls.txt").exists()
+
+    # starting or stepping a disabled thinker is a 409 with a clear message
+    resp = client.post(
+        "/api/identities/.identities~ctl/thinkers/start", json={"names": ["beta_two"]}
+    )
+    assert resp.status_code == 409
+    assert "disabled" in resp.json()["detail"]
+
+    # enable removes the marker; dispatcher down -> no restart hint
+    resp = client.post("/api/identities/.identities~ctl/thinkers/beta_two/enable")
+    assert resp.status_code == 200
+    assert resp.json()["needs_restart"] is False
+    assert not marker.is_file()
+
+    # disabling an idle thinker (dispatcher up + active) stops it via the CLI
+    run = control_identity / "run"
+    run.mkdir(exist_ok=True)
+    (run / "dispatcher.pid").write_text(str(os.getpid()))
+    (run / "active_thinkers").write_text("beta_two\n")
+    resp = client.post("/api/identities/.identities~ctl/thinkers/beta_two/disable")
+    assert resp.status_code == 200
+    assert resp.json()["stopped_first"] is True
+    assert "ARGS=stop beta_two" in _calls(stub_bin)
+    assert marker.is_file()
+
+    # enabling while the dispatcher runs flags the restart requirement
+    resp = client.post("/api/identities/.identities~ctl/thinkers/beta_two/enable")
+    assert resp.json()["needs_restart"] is True
+
+
+def test_env_endpoints(client: TestClient, control_identity: Path):
+    identity_env = control_identity / ".env"
+    identity_env.write_text(
+        "# identity secrets\n"
+        "ANTHROPIC_API_KEY=sk-ant-abc123456789xyzw\n"
+        "SHELLM_MODEL=claude-opus-4-7\n"
+    )
+    root_env = control_identity.parent.parent / ".env"
+    root_env.write_text("OPENAI_API_KEY=sk-oai-9876543210abcdef\nLANG=C\n")
+
+    body = client.get("/api/identities/.identities~ctl/env").json()
+    by_key = {entry["key"]: entry for entry in body["env"]}
+    # secret: redacted peek only, never the full value
+    assert by_key["ANTHROPIC_API_KEY"]["secret"] is True
+    assert by_key["ANTHROPIC_API_KEY"]["value"] == "sk-ant…xyzw"
+    assert "abc123456789" not in str(body)
+    # non-secret: full value
+    assert by_key["SHELLM_MODEL"] == {
+        "key": "SHELLM_MODEL",
+        "value": "claude-opus-4-7",
+        "secret": False,
+    }
+    inherited = {entry["key"]: entry for entry in body["inherited"]}
+    assert inherited["OPENAI_API_KEY"]["secret"] is True
+    assert inherited["OPENAI_API_KEY"]["overridden"] is False
+
+    # upsert: update existing + add new (value with spaces gets quoted)
+    resp = client.put(
+        "/api/identities/.identities~ctl/env",
+        json={"key": "ANTHROPIC_API_KEY", "value": "sk-ant-new456789012pqrs"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["value"] == "sk-ant…pqrs"
+    client.put(
+        "/api/identities/.identities~ctl/env",
+        json={"key": "GREETING", "value": "hello world"},
+    )
+    text = identity_env.read_text()
+    assert "# identity secrets" in text  # comments preserved
+    assert "ANTHROPIC_API_KEY=sk-ant-new456789012pqrs" in text
+    assert "GREETING='hello world'" in text
+    assert text.count("ANTHROPIC_API_KEY") == 1
+
+    # invalid key / multiline value
+    assert (
+        client.put(
+            "/api/identities/.identities~ctl/env",
+            json={"key": "BAD-KEY", "value": "x"},
+        ).status_code
+        == 422
+    )
+    assert (
+        client.put(
+            "/api/identities/.identities~ctl/env",
+            json={"key": "OK", "value": "a\nb"},
+        ).status_code
+        == 422
+    )
+
+    # delete
+    assert (
+        client.delete("/api/identities/.identities~ctl/env/GREETING").status_code
+        == 200
+    )
+    assert "GREETING" not in identity_env.read_text()
+    assert (
+        client.delete("/api/identities/.identities~ctl/env/GREETING").status_code
+        == 404
+    )
+
+
 def test_read_only_blocks_mutations(control_identity: Path):
     ro_client = TestClient(create_app(control_identity.parent.parent, read_only=True))
     assert ro_client.get("/api/config").json()["controls_enabled"] is False
@@ -307,9 +429,20 @@ def test_read_only_blocks_mutations(control_identity: Path):
         ("/api/identities/.identities~ctl/thinkers/start", {}),
         ("/api/identities/.identities~ctl/thinkers/stop", {}),
         ("/api/identities/.identities~ctl/thinkers/alpha/step", None),
+        ("/api/identities/.identities~ctl/thinkers/alpha/disable", None),
+        ("/api/identities/.identities~ctl/thinkers/alpha/enable", None),
         ("/api/identities/.identities~ctl/chat", {"content": "x", "from_name": "n"}),
         ("/api/identities", {"name": "x"}),
         ("/api/killall", {}),
     ]:
         resp = ro_client.post(path, json=body)
         assert resp.status_code == 403, path
+    assert (
+        ro_client.put(
+            "/api/identities/.identities~ctl/env", json={"key": "K", "value": "v"}
+        ).status_code
+        == 403
+    )
+    assert (
+        ro_client.delete("/api/identities/.identities~ctl/env/K").status_code == 403
+    )

--- a/web/tests/test_thinkers_and_control.py
+++ b/web/tests/test_thinkers_and_control.py
@@ -422,6 +422,22 @@ def test_env_endpoints(client: TestClient, control_identity: Path):
     )
 
 
+def test_cors_allowlist_from_env(control_identity: Path, monkeypatch):
+    monkeypatch.setenv("SHELLM_WEB_ALLOWED_ORIGINS", "https://agents.example.com")
+    pinned = TestClient(create_app(control_identity.parent.parent))
+    allowed = pinned.get("/api/health", headers={"Origin": "https://agents.example.com"})
+    assert allowed.headers.get("access-control-allow-origin") == "https://agents.example.com"
+    denied = pinned.get("/api/health", headers={"Origin": "https://evil.example.com"})
+    assert "access-control-allow-origin" not in denied.headers
+
+    # default "*": any origin is allowed (starlette echoes the origin when
+    # credentials are enabled rather than sending a literal *)
+    monkeypatch.delenv("SHELLM_WEB_ALLOWED_ORIGINS")
+    open_client = TestClient(create_app(control_identity.parent.parent))
+    resp = open_client.get("/api/health", headers={"Origin": "https://anywhere.example"})
+    assert resp.headers.get("access-control-allow-origin") == "https://anywhere.example"
+
+
 def test_read_only_blocks_mutations(control_identity: Path):
     ro_client = TestClient(create_app(control_identity.parent.parent, read_only=True))
     assert ro_client.get("/api/config").json()["controls_enabled"] is False

--- a/web/tests/test_thinkers_and_control.py
+++ b/web/tests/test_thinkers_and_control.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shlex
 import stat
 from pathlib import Path
 
@@ -135,6 +136,10 @@ def stub_bin(tmp_path: Path, monkeypatch) -> Path:
 
 def _write_stub(stub: Path, name: str, exit_code: int = 0, stderr: str = "") -> None:
     script = stub / name
+    # shlex.quote, not json.dumps: double quotes leave `backticks` in the
+    # message live as command substitution — a stderr string mentioning
+    # `thinkers stop` would fork-bomb the stub.
+    stderr_line = f"echo {shlex.quote(stderr)} >&2\n" if stderr else ""
     script.write_text(
         "#!/usr/bin/env bash\n"
         "{\n"
@@ -148,7 +153,7 @@ def _write_stub(stub: Path, name: str, exit_code: int = 0, stderr: str = "") -> 
         '  echo "APIKEY=$ANTHROPIC_API_KEY"\n'
         '  echo "STDIN=$(cat)"\n'
         f"}} >> {stub}/calls.txt\n"
-        + (f"echo {json.dumps(stderr)} >&2\n" if stderr else "")
+        + stderr_line
         + f"exit {exit_code}\n"
     )
     script.chmod(script.stat().st_mode | stat.S_IXUSR)

--- a/web/viewer/app/app.css
+++ b/web/viewer/app/app.css
@@ -23,6 +23,8 @@
 
 html {
   min-height: 100%;
+  /* Keep layout width stable whether or not a scrollbar is present */
+  scrollbar-gutter: stable;
 }
 
 html,

--- a/web/viewer/app/components/identity-tabs.tsx
+++ b/web/viewer/app/components/identity-tabs.tsx
@@ -9,6 +9,7 @@ const TABS = [
   { key: "thinkers", label: "Thinkers", path: "/thinkers" },
   { key: "chat", label: "Chat", path: "/chat" },
   { key: "memories", label: "Memories", path: "/memories" },
+  { key: "config", label: "Config", path: "/config" },
 ] as const;
 
 /** Header row shared by the identity sub-pages: breadcrumb + tab links. */
@@ -28,7 +29,7 @@ export function IdentityTabs({
   const displayName = name ?? identityId.split("~").pop() ?? identityId;
 
   return (
-    <div className="mb-4 flex flex-wrap items-center gap-3">
+    <div className="sticky top-12 z-40 -mx-4 mb-4 flex flex-wrap items-center gap-3 border-b bg-background/95 px-4 py-2 backdrop-blur">
       <Link to="/" className="text-sm text-muted-foreground hover:underline">
         identities
       </Link>

--- a/web/viewer/app/components/identity-tabs.tsx
+++ b/web/viewer/app/components/identity-tabs.tsx
@@ -7,6 +7,7 @@ const TABS = [
   { key: "timeline", label: "Timeline", path: "" },
   { key: "mindlog", label: "Mind log", path: "/mindlog" },
   { key: "thinkers", label: "Thinkers", path: "/thinkers" },
+  { key: "chat", label: "Chat", path: "/chat" },
   { key: "memories", label: "Memories", path: "/memories" },
 ] as const;
 

--- a/web/viewer/app/components/navbar.tsx
+++ b/web/viewer/app/components/navbar.tsx
@@ -32,7 +32,7 @@ export function Navbar() {
     <header className="sticky top-0 z-50 border-b border-border bg-background">
       <div className="flex h-12 items-center justify-between px-4">
         <Link to="/" className="font-mono text-sm font-semibold tracking-tight">
-          shellmWOOOO
+          shellm
         </Link>
         <ThemeToggle />
       </div>

--- a/web/viewer/app/components/navbar.tsx
+++ b/web/viewer/app/components/navbar.tsx
@@ -32,7 +32,7 @@ export function Navbar() {
     <header className="sticky top-0 z-50 border-b border-border bg-background">
       <div className="flex h-12 items-center justify-between px-4">
         <Link to="/" className="font-mono text-sm font-semibold tracking-tight">
-          shellm
+          shellmWOOOO
         </Link>
         <ThemeToggle />
       </div>

--- a/web/viewer/app/components/navbar.tsx
+++ b/web/viewer/app/components/navbar.tsx
@@ -32,7 +32,7 @@ export function Navbar() {
     <header className="sticky top-0 z-50 border-b border-border bg-background">
       <div className="flex h-12 items-center justify-between px-4">
         <Link to="/" className="font-mono text-sm font-semibold tracking-tight">
-          shellm<span className="text-muted-foreground"> · mind log viewer</span>
+          shellm
         </Link>
         <ThemeToggle />
       </div>

--- a/web/viewer/app/components/thinker-controls.tsx
+++ b/web/viewer/app/components/thinker-controls.tsx
@@ -1,0 +1,115 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Play, Square } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "~/components/ui/button";
+import {
+  fetchConfig,
+  startThinkers,
+  stopThinkers,
+  stepThinker,
+} from "~/lib/api";
+import type { ControlResult } from "~/lib/types";
+
+/** True when the server allows mutations (read-only deployments hide controls). */
+export function useControlsEnabled(): boolean {
+  const { data } = useQuery({
+    queryKey: ["config"],
+    queryFn: fetchConfig,
+    staleTime: Infinity,
+  });
+  return data?.controls_enabled ?? false;
+}
+
+export function useThinkerMutation(identityId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      action,
+      names,
+    }: {
+      action: "start" | "stop" | "step";
+      names: string[];
+    }): Promise<ControlResult> => {
+      if (action === "step") return stepThinker(identityId, names[0]);
+      if (action === "start") return startThinkers(identityId, names);
+      return stopThinkers(identityId, names);
+    },
+    onSuccess: (result) => {
+      const target = result.names.length ? result.names.join(", ") : "all thinkers";
+      if (result.action === "step") {
+        toast.success(`Triggered ${target} — output lands in its log`);
+      } else {
+        // The CLI reports progress on stderr; last line is the most useful.
+        const lines = (result.stderr ?? "").split("\n").filter(Boolean);
+        toast.success(
+          `${result.action === "start" ? "Started" : "Stopped"} ${target}`,
+          { description: lines[lines.length - 1] }
+        );
+      }
+      for (const key of ["thinkers", "status", "logs", "dispatch", "chat"]) {
+        queryClient.invalidateQueries({ queryKey: [key, identityId] });
+      }
+      queryClient.invalidateQueries({ queryKey: ["identities"] });
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+}
+
+/** Start/stop pair for one thinker (names=[name]) or the whole identity (names=[]). */
+export function StartStopButtons({
+  identityId,
+  names,
+  running,
+  startDisabled,
+  startDisabledReason,
+}: {
+  identityId: string;
+  names: string[];
+  running: boolean;
+  startDisabled?: boolean;
+  startDisabledReason?: string;
+}) {
+  const enabled = useControlsEnabled();
+  const mutation = useThinkerMutation(identityId);
+  if (!enabled) return null;
+
+  const isAll = names.length === 0;
+  const label = isAll ? "all" : names.join(", ");
+
+  if (running) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={mutation.isPending}
+        onClick={() => {
+          if (
+            isAll &&
+            !window.confirm(
+              "Stop all thinkers? In-flight steps will be killed."
+            )
+          ) {
+            return;
+          }
+          mutation.mutate({ action: "stop", names });
+        }}
+      >
+        <Square className="size-3" />
+        {isAll ? "Stop all" : "Stop"}
+      </Button>
+    );
+  }
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={mutation.isPending || startDisabled}
+      title={startDisabled ? startDisabledReason : `Start ${label}`}
+      onClick={() => mutation.mutate({ action: "start", names })}
+    >
+      <Play className="size-3" />
+      {isAll ? "Start all" : "Start"}
+    </Button>
+  );
+}

--- a/web/viewer/app/lib/api.ts
+++ b/web/viewer/app/lib/api.ts
@@ -1,13 +1,17 @@
 import type {
+  ChatLog,
   Config,
+  ControlResult,
   DispatchEvent,
   Identity,
   IdentityStatus,
+  KillallResult,
   LogInfo,
   LogTail,
   MemoryInfo,
   Mindlog,
   SubTrajectory,
+  ThinkersStatus,
   TreeNode,
 } from "~/lib/types";
 
@@ -17,6 +21,28 @@ async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`);
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!response.ok) {
+    // Control endpoints put the CLI's message in detail.message; plain
+    // FastAPI errors put a string in detail.
+    let message = `${response.status} ${response.statusText}`;
+    try {
+      const data = await response.json();
+      if (typeof data?.detail === "string") message = data.detail;
+      else if (data?.detail?.message) message = data.detail.message;
+    } catch {
+      // keep default message
+    }
+    throw new Error(message);
   }
   return response.json() as Promise<T>;
 }
@@ -87,6 +113,65 @@ export function fetchMemory(
   return getJson(
     `/api/identities/${encodeURIComponent(identityId)}/memories/${encodeURIComponent(name)}`
   );
+}
+
+export function fetchThinkers(identityId: string): Promise<ThinkersStatus> {
+  return getJson(`/api/identities/${encodeURIComponent(identityId)}/thinkers`);
+}
+
+export function startThinkers(
+  identityId: string,
+  names: string[] = []
+): Promise<ControlResult> {
+  return postJson(
+    `/api/identities/${encodeURIComponent(identityId)}/thinkers/start`,
+    { names }
+  );
+}
+
+export function stopThinkers(
+  identityId: string,
+  names: string[] = []
+): Promise<ControlResult> {
+  return postJson(
+    `/api/identities/${encodeURIComponent(identityId)}/thinkers/stop`,
+    { names }
+  );
+}
+
+export function stepThinker(
+  identityId: string,
+  name: string
+): Promise<ControlResult> {
+  return postJson(
+    `/api/identities/${encodeURIComponent(identityId)}/thinkers/${encodeURIComponent(name)}/step`,
+    {}
+  );
+}
+
+export function fetchChat(identityId: string, tail = 200): Promise<ChatLog> {
+  return getJson(
+    `/api/identities/${encodeURIComponent(identityId)}/chat?tail=${tail}`
+  );
+}
+
+export function sendChat(
+  identityId: string,
+  content: string,
+  fromName: string
+): Promise<{ ok: boolean; from: string; to: string }> {
+  return postJson(`/api/identities/${encodeURIComponent(identityId)}/chat`, {
+    content,
+    from_name: fromName,
+  });
+}
+
+export function createIdentity(name: string): Promise<{ id: string; name: string }> {
+  return postJson("/api/identities", { name });
+}
+
+export function killAll(dryRun: boolean): Promise<KillallResult> {
+  return postJson("/api/killall", { dry_run: dryRun });
 }
 
 export const IN_PROGRESS_POLL_MS = 2000;

--- a/web/viewer/app/lib/api.ts
+++ b/web/viewer/app/lib/api.ts
@@ -3,7 +3,9 @@ import type {
   Config,
   ControlResult,
   DispatchEvent,
+  EnvEntry,
   Identity,
+  IdentityEnv,
   IdentityStatus,
   KillallResult,
   LogInfo,
@@ -25,11 +27,15 @@ async function getJson<T>(path: string): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-async function postJson<T>(path: string, body: unknown): Promise<T> {
+async function sendJson<T>(
+  method: string,
+  path: string,
+  body: unknown
+): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {
-    method: "POST",
+    method,
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body ?? {}),
+    body: body === undefined ? undefined : JSON.stringify(body),
   });
   if (!response.ok) {
     // Control endpoints put the CLI's message in detail.message; plain
@@ -45,6 +51,10 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
     throw new Error(message);
   }
   return response.json() as Promise<T>;
+}
+
+function postJson<T>(path: string, body: unknown): Promise<T> {
+  return sendJson("POST", path, body ?? {});
 }
 
 export function fetchConfig(): Promise<Config> {
@@ -149,6 +159,17 @@ export function stepThinker(
   );
 }
 
+export function setThinkerEnabled(
+  identityId: string,
+  name: string,
+  enabled: boolean
+): Promise<{ ok: boolean; name: string; disabled: boolean; needs_restart?: boolean }> {
+  return postJson(
+    `/api/identities/${encodeURIComponent(identityId)}/thinkers/${encodeURIComponent(name)}/${enabled ? "enable" : "disable"}`,
+    {}
+  );
+}
+
 export function fetchChat(identityId: string, tail = 200): Promise<ChatLog> {
   return getJson(
     `/api/identities/${encodeURIComponent(identityId)}/chat?tail=${tail}`
@@ -172,6 +193,33 @@ export function createIdentity(name: string): Promise<{ id: string; name: string
 
 export function killAll(dryRun: boolean): Promise<KillallResult> {
   return postJson("/api/killall", { dry_run: dryRun });
+}
+
+export function fetchIdentityEnv(identityId: string): Promise<IdentityEnv> {
+  return getJson(`/api/identities/${encodeURIComponent(identityId)}/env`);
+}
+
+export function putEnvVar(
+  identityId: string,
+  key: string,
+  value: string
+): Promise<EnvEntry> {
+  return sendJson(
+    "PUT",
+    `/api/identities/${encodeURIComponent(identityId)}/env`,
+    { key, value }
+  );
+}
+
+export function deleteEnvVar(
+  identityId: string,
+  key: string
+): Promise<{ ok: boolean; key: string }> {
+  return sendJson(
+    "DELETE",
+    `/api/identities/${encodeURIComponent(identityId)}/env/${encodeURIComponent(key)}`,
+    undefined
+  );
 }
 
 export const IN_PROGRESS_POLL_MS = 2000;

--- a/web/viewer/app/lib/types.ts
+++ b/web/viewer/app/lib/types.ts
@@ -3,6 +3,12 @@
 export interface Config {
   root: string;
   version: string;
+  controls_enabled: boolean;
+}
+
+export interface DispatcherStatus {
+  running: boolean;
+  pid: number | null;
 }
 
 export interface Identity {
@@ -15,6 +21,65 @@ export interface Identity {
   live: boolean;
   last_activity_ts: string | null;
   step_count: number;
+  dispatcher: DispatcherStatus;
+  thinkers_total: number;
+  thinkers_active: number;
+  steps_in_flight: number;
+}
+
+export type ThinkerState = "stopped" | "idle" | "active" | "running";
+
+export interface ThinkerInfo {
+  name: string;
+  state: ThinkerState;
+  steps_in_flight: number;
+  pid: number | null;
+  types: string[];
+  trigger_self: boolean;
+  pending: string[];
+  log_bytes: number | null;
+  log_mtime: string | null;
+}
+
+export interface ThinkersStatus {
+  identity: { id: string; name: string };
+  dispatcher: DispatcherStatus;
+  active_thinkers: number;
+  thinkers_total: number;
+  steps_in_flight: number;
+  pending_total: number;
+  thinkers: ThinkerInfo[];
+}
+
+export interface ControlResult {
+  ok: boolean;
+  action: string;
+  names: string[];
+  exit_code?: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface ChatMessage {
+  ts: string | null;
+  step_id: string | null;
+  from: string;
+  to: string;
+  content: string;
+  filename: string | null;
+}
+
+export interface ChatLog {
+  identity: { id: string; name: string };
+  live: boolean;
+  messages: ChatMessage[];
+}
+
+export interface KillallResult {
+  ok: boolean;
+  dry_run: boolean;
+  stdout: string;
+  stderr: string;
 }
 
 export interface IdentityStatus {

--- a/web/viewer/app/lib/types.ts
+++ b/web/viewer/app/lib/types.ts
@@ -27,7 +27,7 @@ export interface Identity {
   steps_in_flight: number;
 }
 
-export type ThinkerState = "stopped" | "idle" | "active" | "running";
+export type ThinkerState = "stopped" | "idle" | "active" | "running" | "disabled";
 
 export interface ThinkerInfo {
   name: string;
@@ -46,6 +46,7 @@ export interface ThinkersStatus {
   dispatcher: DispatcherStatus;
   active_thinkers: number;
   thinkers_total: number;
+  thinkers_disabled: number;
   steps_in_flight: number;
   pending_total: number;
   thinkers: ThinkerInfo[];
@@ -73,6 +74,20 @@ export interface ChatLog {
   identity: { id: string; name: string };
   live: boolean;
   messages: ChatMessage[];
+}
+
+export interface EnvEntry {
+  key: string;
+  value: string; // full value for non-secrets, redacted peek for secrets
+  secret: boolean;
+  overridden?: boolean; // inherited entries only
+}
+
+export interface IdentityEnv {
+  identity: { id: string; name: string };
+  env: EnvEntry[];
+  inherited: EnvEntry[];
+  note: string;
 }
 
 export interface KillallResult {

--- a/web/viewer/app/routes.ts
+++ b/web/viewer/app/routes.ts
@@ -6,5 +6,6 @@ export default [
   route("i/:identityId/mindlog", "routes/identity.tsx"),
   route("i/:identityId/t/:trajId", "routes/sub-traj.tsx"),
   route("i/:identityId/thinkers", "routes/thinkers.tsx"),
+  route("i/:identityId/chat", "routes/chat.tsx"),
   route("i/:identityId/memories", "routes/memories.tsx"),
 ] satisfies RouteConfig;

--- a/web/viewer/app/routes.ts
+++ b/web/viewer/app/routes.ts
@@ -8,4 +8,5 @@ export default [
   route("i/:identityId/thinkers", "routes/thinkers.tsx"),
   route("i/:identityId/chat", "routes/chat.tsx"),
   route("i/:identityId/memories", "routes/memories.tsx"),
+  route("i/:identityId/config", "routes/config.tsx"),
 ] satisfies RouteConfig;

--- a/web/viewer/app/routes/chat.tsx
+++ b/web/viewer/app/routes/chat.tsx
@@ -1,0 +1,193 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { SendHorizontal } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useParams } from "react-router";
+import { toast } from "sonner";
+
+import { IdentityTabs } from "~/components/identity-tabs";
+import {
+  StartStopButtons,
+  useControlsEnabled,
+} from "~/components/thinker-controls";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { LoadingDots } from "~/components/ui/loading-dots";
+import {
+  fetchChat,
+  fetchIdentityStatus,
+  fetchThinkers,
+  sendChat,
+} from "~/lib/api";
+import type { ChatMessage } from "~/lib/types";
+import { cn } from "~/lib/utils";
+
+export function meta() {
+  return [{ title: "shellm · chat" }];
+}
+
+const MY_NAME_KEY = "shellm-chat-from";
+
+function myNameDefault(): string {
+  if (typeof window === "undefined") return "you";
+  return window.localStorage.getItem(MY_NAME_KEY) || "you";
+}
+
+function messageTime(ts: string | null): string {
+  if (!ts) return "";
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) return ts;
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function Bubble({ message, mine }: { message: ChatMessage; mine: boolean }) {
+  return (
+    <div className={cn("flex", mine ? "justify-end" : "justify-start")}>
+      <div
+        className={cn(
+          "max-w-[75%] rounded-lg px-3 py-2",
+          mine ? "bg-primary text-primary-foreground" : "border bg-card"
+        )}
+      >
+        <div
+          className={cn(
+            "mb-0.5 flex items-baseline gap-2 font-mono text-[10px]",
+            mine ? "text-primary-foreground/70" : "text-muted-foreground"
+          )}
+        >
+          <span>
+            {message.from} → {message.to || "?"}
+          </span>
+          <span>{messageTime(message.ts)}</span>
+        </div>
+        {message.filename && (
+          <div className="mb-1 font-mono text-[10px] opacity-70">
+            📎 {message.filename}
+          </div>
+        )}
+        <div className="whitespace-pre-wrap break-words text-sm">
+          {message.content}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ChatPage() {
+  const { identityId = "" } = useParams();
+  const controlsEnabled = useControlsEnabled();
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState("");
+  const [myName, setMyName] = useState(myNameDefault);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const { data: status } = useQuery({
+    queryKey: ["status", identityId],
+    queryFn: () => fetchIdentityStatus(identityId),
+    refetchInterval: 2000,
+  });
+  const live = status?.live ?? false;
+
+  const { data: chat, isLoading } = useQuery({
+    queryKey: ["chat", identityId],
+    queryFn: () => fetchChat(identityId),
+    refetchInterval: 2000,
+  });
+
+  const { data: thinkerStatus } = useQuery({
+    queryKey: ["thinkers", identityId],
+    queryFn: () => fetchThinkers(identityId),
+    refetchInterval: 5000,
+  });
+  const dispatcherRunning = thinkerStatus?.dispatcher.running ?? true;
+
+  const messages = chat?.messages ?? [];
+  const messageCount = messages.length;
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: "end" });
+  }, [messageCount]);
+
+  const sendMutation = useMutation({
+    mutationFn: (content: string) => sendChat(identityId, content, myName),
+    onSuccess: () => {
+      setDraft("");
+      queryClient.invalidateQueries({ queryKey: ["chat", identityId] });
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const identityName = chat?.identity.name ?? identityId.split("~").pop();
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col px-4">
+      <IdentityTabs identityId={identityId} live={live} active="chat" />
+
+      {controlsEnabled && !dispatcherRunning && (
+        <div className="mb-3 flex items-center gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+          <span>
+            Thinkers are stopped — {identityName} won't see or answer messages.
+          </span>
+          <div className="ml-auto">
+            <StartStopButtons identityId={identityId} names={[]} running={false} />
+          </div>
+        </div>
+      )}
+
+      <div className="flex min-h-[40vh] flex-col gap-2 overflow-y-auto rounded-lg border bg-background p-4 max-h-[65vh]">
+        {isLoading ? (
+          <div className="flex justify-center py-10">
+            <LoadingDots />
+          </div>
+        ) : messages.length === 0 ? (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            No messages yet. Say hello.
+          </div>
+        ) : (
+          messages.map((message, idx) => (
+            <Bubble
+              key={message.step_id ?? idx}
+              message={message}
+              mine={message.from === myName}
+            />
+          ))
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {controlsEnabled && (
+        <form
+          className="mt-3 flex items-center gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const content = draft.trim();
+            if (content && !sendMutation.isPending) sendMutation.mutate(content);
+          }}
+        >
+          <Input
+            value={myName}
+            onChange={(event) => {
+              setMyName(event.target.value);
+              window.localStorage.setItem(MY_NAME_KEY, event.target.value);
+            }}
+            title="Your name (the from field on messages)"
+            className="h-9 w-24 font-mono text-xs"
+          />
+          <Input
+            autoFocus
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder={`Message ${identityName}…`}
+            className="h-9 flex-1"
+          />
+          <Button
+            type="submit"
+            size="sm"
+            disabled={sendMutation.isPending || !draft.trim()}
+          >
+            <SendHorizontal className="size-3.5" />
+            Send
+          </Button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/web/viewer/app/routes/chat.tsx
+++ b/web/viewer/app/routes/chat.tsx
@@ -118,8 +118,9 @@ export default function ChatPage() {
   const identityName = chat?.identity.name ?? identityId.split("~").pop();
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col px-4">
+    <div className="mx-auto w-full max-w-7xl px-4">
       <IdentityTabs identityId={identityId} live={live} active="chat" />
+      <div className="mx-auto flex w-full max-w-3xl flex-col">
 
       {controlsEnabled && !dispatcherRunning && (
         <div className="mb-3 flex items-center gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
@@ -188,6 +189,7 @@ export default function ChatPage() {
           </Button>
         </form>
       )}
+      </div>
     </div>
   );
 }

--- a/web/viewer/app/routes/config.tsx
+++ b/web/viewer/app/routes/config.tsx
@@ -1,0 +1,336 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { KeyRound, Pencil, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { useParams } from "react-router";
+import { toast } from "sonner";
+
+import { IdentityTabs } from "~/components/identity-tabs";
+import { useControlsEnabled } from "~/components/thinker-controls";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { LoadingDots } from "~/components/ui/loading-dots";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+import {
+  deleteEnvVar,
+  fetchIdentityEnv,
+  fetchIdentityStatus,
+  putEnvVar,
+} from "~/lib/api";
+import type { EnvEntry } from "~/lib/types";
+
+export function meta() {
+  return [{ title: "shellm · config" }];
+}
+
+function useEnvMutations(identityId: string) {
+  const queryClient = useQueryClient();
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["env", identityId] });
+  const save = useMutation({
+    mutationFn: ({ key, value }: { key: string; value: string }) =>
+      putEnvVar(identityId, key, value),
+    onSuccess: (entry) => {
+      toast.success(`Saved ${entry.key}`);
+      invalidate();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+  const remove = useMutation({
+    mutationFn: (key: string) => deleteEnvVar(identityId, key),
+    onSuccess: (result) => {
+      toast.success(`Removed ${result.key}`);
+      invalidate();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+  return { save, remove };
+}
+
+function ValueDisplay({ entry }: { entry: EnvEntry }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 font-mono text-xs">
+      {entry.secret && (
+        <KeyRound className="size-3 shrink-0 text-muted-foreground" />
+      )}
+      {entry.value || <span className="text-muted-foreground">(empty)</span>}
+    </span>
+  );
+}
+
+function EnvRow({
+  identityId,
+  entry,
+}: {
+  identityId: string;
+  entry: EnvEntry;
+}) {
+  const controlsEnabled = useControlsEnabled();
+  const { save, remove } = useEnvMutations(identityId);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  return (
+    <TableRow>
+      <TableCell className="font-mono text-xs font-medium">{entry.key}</TableCell>
+      <TableCell>
+        {editing ? (
+          <form
+            className="flex items-center gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              save.mutate(
+                { key: entry.key, value: draft },
+                { onSuccess: () => setEditing(false) }
+              );
+            }}
+          >
+            <Input
+              autoFocus
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              placeholder={
+                entry.secret ? "enter new value (replaces current)" : entry.value
+              }
+              className="h-8 flex-1 font-mono text-xs"
+            />
+            <Button type="submit" size="sm" disabled={save.isPending}>
+              Save
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setEditing(false)}
+            >
+              Cancel
+            </Button>
+          </form>
+        ) : (
+          <ValueDisplay entry={entry} />
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        {controlsEnabled && !editing && (
+          <div className="flex justify-end gap-1">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              title={`Edit ${entry.key}`}
+              onClick={() => {
+                setDraft(entry.secret ? "" : entry.value);
+                setEditing(true);
+              }}
+            >
+              <Pencil className="size-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              title={`Remove ${entry.key}`}
+              disabled={remove.isPending}
+              onClick={() => {
+                if (window.confirm(`Remove ${entry.key} from this identity's .env?`))
+                  remove.mutate(entry.key);
+              }}
+            >
+              <Trash2 className="size-3" />
+            </Button>
+          </div>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function AddVarForm({
+  identityId,
+  prefillKey,
+  onDone,
+}: {
+  identityId: string;
+  prefillKey: string;
+  onDone: () => void;
+}) {
+  const { save } = useEnvMutations(identityId);
+  const [key, setKey] = useState(prefillKey);
+  const [value, setValue] = useState("");
+
+  return (
+    <form
+      className="flex items-center gap-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!key.trim()) return;
+        save.mutate(
+          { key: key.trim(), value },
+          {
+            onSuccess: () => {
+              setKey("");
+              setValue("");
+              onDone();
+            },
+          }
+        );
+      }}
+    >
+      <Input
+        value={key}
+        onChange={(event) => setKey(event.target.value)}
+        placeholder="VARIABLE_NAME"
+        pattern="[A-Za-z_][A-Za-z0-9_]*"
+        title="letters, digits, underscores"
+        className="h-8 w-56 font-mono text-xs"
+      />
+      <Input
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        placeholder="value"
+        className="h-8 flex-1 font-mono text-xs"
+      />
+      <Button type="submit" size="sm" disabled={save.isPending || !key.trim()}>
+        <Plus className="size-3" />
+        Add
+      </Button>
+    </form>
+  );
+}
+
+export default function ConfigPage() {
+  const { identityId = "" } = useParams();
+  const controlsEnabled = useControlsEnabled();
+  const [prefillKey, setPrefillKey] = useState("");
+
+  const { data: status } = useQuery({
+    queryKey: ["status", identityId],
+    queryFn: () => fetchIdentityStatus(identityId),
+    refetchInterval: 5000,
+  });
+
+  const { data: env, isLoading } = useQuery({
+    queryKey: ["env", identityId],
+    queryFn: () => fetchIdentityEnv(identityId),
+  });
+
+  if (isLoading || !env) {
+    return (
+      <div className="flex justify-center py-20">
+        <LoadingDots />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4">
+      <IdentityTabs
+        identityId={identityId}
+        live={status?.live ?? false}
+        active="config"
+      />
+      <div className="mx-auto w-full max-w-4xl">
+
+      <section className="mb-8">
+        <div className="mb-2 flex items-baseline gap-3">
+          <h2 className="font-mono text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            identity .env
+          </h2>
+          <span className="text-[11px] text-muted-foreground">{env.note}</span>
+        </div>
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-64">Variable</TableHead>
+                <TableHead>Value</TableHead>
+                <TableHead className="w-24 text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {env.env.length === 0 && (
+                <TableRow>
+                  <TableCell
+                    colSpan={3}
+                    className="py-6 text-center text-sm text-muted-foreground"
+                  >
+                    No identity-specific variables yet.
+                  </TableCell>
+                </TableRow>
+              )}
+              {env.env.map((entry) => (
+                <EnvRow key={entry.key} identityId={identityId} entry={entry} />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+        {controlsEnabled && (
+          <div className="mt-3">
+            <AddVarForm
+              key={prefillKey}
+              identityId={identityId}
+              prefillKey={prefillKey}
+              onDone={() => setPrefillKey("")}
+            />
+          </div>
+        )}
+      </section>
+
+      <section>
+        <div className="mb-2 flex items-baseline gap-3">
+          <h2 className="font-mono text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            inherited from serve root .env
+          </h2>
+          <span className="text-[11px] text-muted-foreground">
+            Applies to every identity; add a variable above to override it here.
+          </span>
+        </div>
+        <div className="rounded-lg border">
+          <Table>
+            <TableBody>
+              {env.inherited.length === 0 && (
+                <TableRow>
+                  <TableCell className="py-6 text-center text-sm text-muted-foreground">
+                    No .env at the serve root.
+                  </TableCell>
+                </TableRow>
+              )}
+              {env.inherited.map((entry) => (
+                <TableRow key={entry.key}>
+                  <TableCell className="w-64 font-mono text-xs">
+                    {entry.key}
+                  </TableCell>
+                  <TableCell>
+                    <ValueDisplay entry={entry} />
+                    {entry.overridden && (
+                      <Badge variant="outline" className="ml-2 text-[10px]">
+                        overridden
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="w-24 text-right">
+                    {controlsEnabled && !entry.overridden && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setPrefillKey(entry.key)}
+                      >
+                        Override
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </section>
+      </div>
+    </div>
+  );
+}

--- a/web/viewer/app/routes/home.tsx
+++ b/web/viewer/app/routes/home.tsx
@@ -1,13 +1,19 @@
-import { useQuery } from "@tanstack/react-query";
-import { Link } from "react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus, Skull } from "lucide-react";
+import { useState } from "react";
+import { Link, useNavigate } from "react-router";
+import { toast } from "sonner";
 
+import { StartStopButtons, useControlsEnabled } from "~/components/thinker-controls";
 import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
 import {
   Empty,
   EmptyDescription,
   EmptyHeader,
   EmptyTitle,
 } from "~/components/ui/empty";
+import { Input } from "~/components/ui/input";
 import { LoadingDots } from "~/components/ui/loading-dots";
 import {
   Table,
@@ -17,7 +23,7 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/ui/table";
-import { fetchIdentities } from "~/lib/api";
+import { createIdentity, fetchIdentities, killAll } from "~/lib/api";
 import type { Identity } from "~/lib/types";
 
 export function meta() {
@@ -49,7 +55,111 @@ function LiveBadge({ live }: { live: boolean }) {
   );
 }
 
+function DispatcherCell({ identity }: { identity: Identity }) {
+  if (identity.dispatcher?.running) {
+    return (
+      <span className="font-mono text-xs text-green-700 dark:text-green-400">
+        ● PID {identity.dispatcher.pid}
+      </span>
+    );
+  }
+  return <span className="text-xs text-muted-foreground">stopped</span>;
+}
+
+function NewIdentityForm() {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: createIdentity,
+    onSuccess: (created) => {
+      toast.success(`Created identity ${created.name}`);
+      queryClient.invalidateQueries({ queryKey: ["identities"] });
+      setOpen(false);
+      setName("");
+      navigate(`/i/${encodeURIComponent(created.id)}/thinkers`);
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  if (!open) {
+    return (
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        <Plus className="size-3" />
+        New identity
+      </Button>
+    );
+  }
+  return (
+    <form
+      className="flex items-center gap-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (name.trim()) mutation.mutate(name.trim());
+      }}
+    >
+      <Input
+        autoFocus
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+        placeholder="lowercase-name"
+        pattern="[a-z0-9][a-z0-9-]*"
+        title="lowercase alphanumeric + hyphens"
+        className="h-8 w-44 font-mono text-xs"
+      />
+      <Button type="submit" size="sm" disabled={mutation.isPending || !name.trim()}>
+        Create
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen(false)}
+      >
+        Cancel
+      </Button>
+    </form>
+  );
+}
+
+function KillAllButton() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: killAll,
+    onSuccess: (result) => {
+      const summary = result.stdout.trim() || "No shellm processes found.";
+      if (result.dry_run) {
+        if (window.confirm(`${summary}\n\nProceed with kill?`)) {
+          mutation.mutate(false);
+          return;
+        }
+        toast.info("Kill-all cancelled");
+      } else {
+        toast.success("Kill-all complete", { description: summary });
+        queryClient.invalidateQueries();
+      }
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  return (
+    <Button
+      variant="destructive"
+      size="sm"
+      disabled={mutation.isPending}
+      title="Kill every shellm process on this machine (dispatchers, agents, thinker steps)"
+      onClick={() => mutation.mutate(true)}
+    >
+      <Skull className="size-3" />
+      Kill all
+    </Button>
+  );
+}
+
 export default function Home() {
+  const controlsEnabled = useControlsEnabled();
   const { data: identities, isLoading } = useQuery({
     queryKey: ["identities"],
     queryFn: fetchIdentities,
@@ -64,72 +174,109 @@ export default function Home() {
     );
   }
 
-  if (!identities || identities.length === 0) {
-    return (
-      <Empty>
-        <EmptyHeader>
-          <EmptyTitle>No identities found</EmptyTitle>
-          <EmptyDescription>
-            No directories with an info.txt containing root_trajectory= were
-            found under the serve root.
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
-    );
-  }
-
   const groups = new Map<string, Identity[]>();
-  for (const identity of identities) {
+  for (const identity of identities ?? []) {
     const list = groups.get(identity.group) ?? [];
     list.push(identity);
     groups.set(identity.group, list);
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl space-y-8 px-4">
-      {[...groups.entries()].map(([group, members]) => (
-        <section key={group}>
-          <h2 className="mb-2 font-mono text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            {group}
-          </h2>
-          <div className="rounded-lg border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Identity</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead>Last activity</TableHead>
-                  <TableHead className="text-right">Steps</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {members.map((identity) => (
-                  <TableRow key={identity.id} className="cursor-pointer">
-                    <TableCell>
-                      <Link
-                        to={`/i/${encodeURIComponent(identity.id)}`}
-                        className="flex items-center gap-2 font-mono font-medium hover:underline"
-                      >
-                        {identity.name}
-                        <LiveBadge live={identity.live} />
-                      </Link>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {identity.created ?? "—"}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {relativeTime(identity.last_activity_ts)}
-                    </TableCell>
-                    <TableCell className="text-right font-mono tabular-nums">
-                      {identity.step_count}
-                    </TableCell>
+    <div className="mx-auto w-full max-w-6xl space-y-8 px-4">
+      {controlsEnabled && (
+        <div className="flex items-center justify-between">
+          <NewIdentityForm />
+          <KillAllButton />
+        </div>
+      )}
+      {!identities || identities.length === 0 ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>No identities found</EmptyTitle>
+            <EmptyDescription>
+              No directories with an info.txt containing root_trajectory= were
+              found under the serve root.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        [...groups.entries()].map(([group, members]) => (
+          <section key={group}>
+            <h2 className="mb-2 font-mono text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              {group}
+            </h2>
+            <div className="rounded-lg border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Identity</TableHead>
+                    <TableHead>Dispatcher</TableHead>
+                    <TableHead>Thinkers</TableHead>
+                    <TableHead className="text-right">In flight</TableHead>
+                    <TableHead>Last activity</TableHead>
+                    <TableHead className="text-right">Steps</TableHead>
+                    {controlsEnabled && (
+                      <TableHead className="text-right">Actions</TableHead>
+                    )}
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        </section>
-      ))}
+                </TableHeader>
+                <TableBody>
+                  {members.map((identity) => (
+                    <TableRow key={identity.id}>
+                      <TableCell>
+                        <Link
+                          to={`/i/${encodeURIComponent(identity.id)}`}
+                          className="flex items-center gap-2 font-mono font-medium hover:underline"
+                        >
+                          {identity.name}
+                          <LiveBadge live={identity.live} />
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <DispatcherCell identity={identity} />
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-muted-foreground">
+                        {identity.thinkers_total > 0
+                          ? `${identity.thinkers_active}/${identity.thinkers_total} active`
+                          : "—"}
+                      </TableCell>
+                      <TableCell
+                        className={
+                          "text-right font-mono tabular-nums" +
+                          (identity.steps_in_flight > 0
+                            ? " font-semibold text-green-700 dark:text-green-400"
+                            : " text-muted-foreground")
+                        }
+                      >
+                        {identity.steps_in_flight}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {relativeTime(identity.last_activity_ts)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono tabular-nums">
+                        {identity.step_count}
+                      </TableCell>
+                      {controlsEnabled && (
+                        <TableCell className="text-right">
+                          {identity.thinkers_total > 0 && (
+                            <div className="flex justify-end">
+                              <StartStopButtons
+                                identityId={identity.id}
+                                names={[]}
+                                running={identity.dispatcher?.running ?? false}
+                              />
+                            </div>
+                          )}
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </section>
+        ))
+      )}
     </div>
   );
 }

--- a/web/viewer/app/routes/identity.tsx
+++ b/web/viewer/app/routes/identity.tsx
@@ -168,7 +168,7 @@ export default function IdentityPage() {
 
         <div className="flex gap-4">
           <aside className="hidden w-52 shrink-0 md:block">
-            <div className="sticky top-16 max-h-[calc(100vh-5rem)] space-y-4 overflow-y-auto pb-4">
+            <div className="sticky top-28 max-h-[calc(100vh-8rem)] space-y-4 overflow-y-auto pb-4">
               <div>
                 <h3 className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                   Step types

--- a/web/viewer/app/routes/memories.tsx
+++ b/web/viewer/app/routes/memories.tsx
@@ -57,7 +57,7 @@ export default function MemoriesPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4">
+    <div className="mx-auto w-full max-w-7xl px-4">
       <IdentityTabs identityId={identityId} live={live} active="memories" />
       {!memories || memories.length === 0 ? (
         <Empty>

--- a/web/viewer/app/routes/sub-traj.tsx
+++ b/web/viewer/app/routes/sub-traj.tsx
@@ -132,7 +132,7 @@ export default function SubTrajPage() {
 
         <div className="flex gap-4">
           <aside className="hidden w-52 shrink-0 md:block">
-            <div className="sticky top-16 max-h-[calc(100vh-5rem)] overflow-y-auto pb-4">
+            <div className="sticky top-28 max-h-[calc(100vh-8rem)] overflow-y-auto pb-4">
               <ForkTree
                 identityId={identityId}
                 currentTrajId={traj.traj_id}

--- a/web/viewer/app/routes/thinkers.tsx
+++ b/web/viewer/app/routes/thinkers.tsx
@@ -1,9 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
+import { Zap } from "lucide-react";
 import { useState } from "react";
 import { useParams } from "react-router";
 
 import { IdentityTabs } from "~/components/identity-tabs";
+import {
+  StartStopButtons,
+  useControlsEnabled,
+  useThinkerMutation,
+} from "~/components/thinker-controls";
 import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
 import {
   Empty,
   EmptyDescription,
@@ -11,14 +18,24 @@ import {
   EmptyTitle,
 } from "~/components/ui/empty";
 import { LoadingDots } from "~/components/ui/loading-dots";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import {
   fetchDispatch,
   fetchIdentityStatus,
   fetchLog,
   fetchLogs,
+  fetchThinkers,
   pollWhileLive,
 } from "~/lib/api";
+import type { ThinkerInfo, ThinkerState } from "~/lib/types";
 import { cn } from "~/lib/utils";
 
 export function meta() {
@@ -27,6 +44,182 @@ export function meta() {
 
 function kb(bytes: number): string {
   return bytes >= 1024 ? `${(bytes / 1024).toFixed(1)} KB` : `${bytes} B`;
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "—";
+  const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+const STATE_STYLES: Record<ThinkerState, string> = {
+  stopped: "bg-muted text-muted-foreground",
+  idle: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  active: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+  running:
+    "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300",
+};
+
+function StateBadge({ thinker }: { thinker: ThinkerInfo }) {
+  let label: string = thinker.state;
+  if (thinker.state === "active") label = `active (${thinker.steps_in_flight})`;
+  if (thinker.state === "running" && thinker.pid != null)
+    label = `running (PID ${thinker.pid})`;
+  return <Badge className={STATE_STYLES[thinker.state]}>{label}</Badge>;
+}
+
+function ThinkerRow({
+  identityId,
+  thinker,
+  dispatcherRunning,
+}: {
+  identityId: string;
+  thinker: ThinkerInfo;
+  dispatcherRunning: boolean;
+}) {
+  const controlsEnabled = useControlsEnabled();
+  const mutation = useThinkerMutation(identityId);
+  const stopped = thinker.state === "stopped";
+  return (
+    <TableRow>
+      <TableCell className="font-mono font-medium">{thinker.name}</TableCell>
+      <TableCell>
+        <StateBadge thinker={thinker} />
+      </TableCell>
+      <TableCell>
+        <div className="flex flex-wrap gap-1">
+          {thinker.types.map((type) => (
+            <Badge key={type} variant="outline" className="text-[10px]">
+              {type}
+            </Badge>
+          ))}
+        </div>
+      </TableCell>
+      <TableCell>
+        {thinker.pending.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {thinker.pending.map((type) => (
+              <Badge
+                key={type}
+                className="bg-amber-100 text-[10px] text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+              >
+                {type}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </TableCell>
+      <TableCell className="font-mono text-[11px] text-muted-foreground">
+        {thinker.log_bytes != null
+          ? `${kb(thinker.log_bytes)} · ${relativeTime(thinker.log_mtime)}`
+          : "—"}
+      </TableCell>
+      <TableCell className="text-right">
+        {controlsEnabled && (
+          <div className="flex justify-end gap-1">
+            <StartStopButtons
+              identityId={identityId}
+              names={[thinker.name]}
+              running={!stopped && dispatcherRunning}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              title="Fire this thinker's step once (manual trigger)"
+              disabled={mutation.isPending}
+              onClick={() =>
+                mutation.mutate({ action: "step", names: [thinker.name] })
+              }
+            >
+              <Zap className="size-3" />
+              step
+            </Button>
+          </div>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function StatusPanel({ identityId }: { identityId: string }) {
+  const { data: status } = useQuery({
+    queryKey: ["thinkers", identityId],
+    queryFn: () => fetchThinkers(identityId),
+    refetchInterval: 2000,
+  });
+
+  if (!status) {
+    return (
+      <div className="flex justify-center py-10">
+        <LoadingDots />
+      </div>
+    );
+  }
+
+  const dispatcherRunning = status.dispatcher.running;
+  return (
+    <div className="mb-6 space-y-3">
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border bg-card px-4 py-3">
+        <span className="text-sm font-medium">Dispatcher</span>
+        {dispatcherRunning ? (
+          <Badge className={STATE_STYLES.active}>
+            running (PID {status.dispatcher.pid})
+          </Badge>
+        ) : (
+          <Badge className={STATE_STYLES.stopped}>stopped</Badge>
+        )}
+        <span className="font-mono text-xs text-muted-foreground">
+          {status.active_thinkers}/{status.thinkers_total} thinkers active ·{" "}
+          {status.steps_in_flight} step(s) in flight
+          {status.pending_total > 0 && ` · ${status.pending_total} pending`}
+        </span>
+        <div className="ml-auto">
+          <StartStopButtons
+            identityId={identityId}
+            names={[]}
+            running={dispatcherRunning}
+            startDisabled={dispatcherRunning}
+            startDisabledReason="Dispatcher already running — start thinkers individually or stop first"
+          />
+        </div>
+      </div>
+      {status.thinkers.length === 0 ? (
+        <div className="py-4 text-center text-sm text-muted-foreground">
+          No thinkers installed for this identity.
+        </div>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Thinker</TableHead>
+                <TableHead>State</TableHead>
+                <TableHead>Subscribes to</TableHead>
+                <TableHead>Pending</TableHead>
+                <TableHead>Log</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {status.thinkers.map((thinker) => (
+                <ThinkerRow
+                  key={thinker.name}
+                  identityId={identityId}
+                  thinker={thinker}
+                  dispatcherRunning={dispatcherRunning}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
 }
 
 function LogView({
@@ -173,6 +366,7 @@ export default function ThinkersPage() {
   return (
     <div className="mx-auto w-full max-w-6xl px-4">
       <IdentityTabs identityId={identityId} live={live} active="thinkers" />
+      <StatusPanel identityId={identityId} />
       {!logs || logs.length === 0 ? (
         <Empty>
           <EmptyHeader>

--- a/web/viewer/app/routes/thinkers.tsx
+++ b/web/viewer/app/routes/thinkers.tsx
@@ -1,7 +1,8 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Zap } from "lucide-react";
 import { useState } from "react";
 import { useParams } from "react-router";
+import { toast } from "sonner";
 
 import { IdentityTabs } from "~/components/identity-tabs";
 import {
@@ -34,6 +35,7 @@ import {
   fetchLogs,
   fetchThinkers,
   pollWhileLive,
+  setThinkerEnabled,
 } from "~/lib/api";
 import type { ThinkerInfo, ThinkerState } from "~/lib/types";
 import { cn } from "~/lib/utils";
@@ -63,6 +65,7 @@ const STATE_STYLES: Record<ThinkerState, string> = {
   active: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
   running:
     "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300",
+  disabled: "border border-dashed bg-transparent text-muted-foreground",
 };
 
 function StateBadge({ thinker }: { thinker: ThinkerInfo }) {
@@ -84,9 +87,30 @@ function ThinkerRow({
 }) {
   const controlsEnabled = useControlsEnabled();
   const mutation = useThinkerMutation(identityId);
+  const queryClient = useQueryClient();
+  const toggleMutation = useMutation({
+    mutationFn: (enabled: boolean) =>
+      setThinkerEnabled(identityId, thinker.name, enabled),
+    onSuccess: (result) => {
+      if (result.disabled) {
+        toast.success(`Disabled ${result.name} — "Start all" will skip it`);
+      } else if (result.needs_restart) {
+        toast.success(`Enabled ${result.name}`, {
+          description:
+            "The running dispatcher won't see its subscriptions — stop and start thinkers to pick it up.",
+        });
+      } else {
+        toast.success(`Enabled ${result.name}`);
+      }
+      queryClient.invalidateQueries({ queryKey: ["thinkers", identityId] });
+      queryClient.invalidateQueries({ queryKey: ["identities"] });
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+  const disabled = thinker.state === "disabled";
   const stopped = thinker.state === "stopped";
   return (
-    <TableRow>
+    <TableRow className={disabled ? "opacity-60" : undefined}>
       <TableCell className="font-mono font-medium">{thinker.name}</TableCell>
       <TableCell>
         <StateBadge thinker={thinker} />
@@ -122,22 +146,40 @@ function ThinkerRow({
       <TableCell className="text-right">
         {controlsEnabled && (
           <div className="flex justify-end gap-1">
-            <StartStopButtons
-              identityId={identityId}
-              names={[thinker.name]}
-              running={!stopped && dispatcherRunning}
-            />
+            {!disabled && (
+              <>
+                <StartStopButtons
+                  identityId={identityId}
+                  names={[thinker.name]}
+                  running={!stopped && dispatcherRunning}
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  title="Fire this thinker's step once (manual trigger)"
+                  disabled={mutation.isPending}
+                  onClick={() =>
+                    mutation.mutate({ action: "step", names: [thinker.name] })
+                  }
+                >
+                  <Zap className="size-3" />
+                  step
+                </Button>
+              </>
+            )}
             <Button
               variant="ghost"
               size="sm"
-              title="Fire this thinker's step once (manual trigger)"
-              disabled={mutation.isPending}
-              onClick={() =>
-                mutation.mutate({ action: "step", names: [thinker.name] })
+              className="text-muted-foreground"
+              title={
+                disabled
+                  ? `Enable ${thinker.name}`
+                  : `Disable ${thinker.name} — "Start all" and the dispatcher will skip it`
               }
+              disabled={toggleMutation.isPending}
+              onClick={() => toggleMutation.mutate(disabled)}
             >
-              <Zap className="size-3" />
-              step
+              {disabled ? "Enable" : "Disable"}
             </Button>
           </div>
         )}
@@ -177,6 +219,7 @@ function StatusPanel({ identityId }: { identityId: string }) {
           {status.active_thinkers}/{status.thinkers_total} thinkers active ·{" "}
           {status.steps_in_flight} step(s) in flight
           {status.pending_total > 0 && ` · ${status.pending_total} pending`}
+          {status.thinkers_disabled > 0 && ` · ${status.thinkers_disabled} disabled`}
         </span>
         <div className="ml-auto">
           <StartStopButtons
@@ -364,7 +407,7 @@ export default function ThinkersPage() {
     .filter((name) => name !== "dispatcher.log");
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4">
+    <div className="mx-auto w-full max-w-7xl px-4">
       <IdentityTabs identityId={identityId} live={live} active="thinkers" />
       <StatusPanel identityId={identityId} />
       {!logs || logs.length === 0 ? (


### PR DESCRIPTION
## Summary

- Web dash becomes a control plane: start/stop thinkers, chat with identities, etc
- One-command deploy: 
  - Terraform for an EC2 box (no open ports)
  - Cloudflare tunnel + Access email-OTP allowlist
  - systemd unit, setup/update scripts, runbook
- Secrets: box .env (API keys + SHELLM_MODEL) lives in a single AWS SSM SecureString parameter 
- Core: thinker steps now resolve SHELLM_MODEL/keys from `.env` fallbacks instead of silently defaulting to claude-opus when the var isn't exported (`thinkers/_lib/common.sh`)
- Core: thinkers can be disabled via a disabled marker file (`bin/thinkers`)