### PR TITLE
fix some pinned claude dependencies

### DIFF
--- a/bin/llm
+++ b/bin/llm
@@ -149,9 +149,10 @@ fi
 
 [[ -z "$LLM_PROMPT" && -z "$LLM_MESSAGES" ]] && die "No prompt or messages provided"
 
-# Default model
+# Default model: the system-wide SHELLM_MODEL when set (so keyless callers
+# like `mem search` follow the configured provider), else claude-sonnet.
 if [[ -z "$LLM_MODEL" ]]; then
-    LLM_MODEL="claude-sonnet-4-5-20250929"
+    LLM_MODEL="${SHELLM_MODEL:-claude-sonnet-4-5-20250929}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/bin/mem
+++ b/bin/mem
@@ -162,7 +162,10 @@ $(cat "$f")
 "
     done
 
-    llm -s "You are a semantic search engine for memory files. Each memory has a filename header (=== filename ===), YAML frontmatter (summary, type), and a body. Return ONLY the filenames and summaries of semantically matching memories, one per line. If nothing matches, say 'No matches found.'" \
+    # Utility call: use the cheap model class when one is configured
+    # shellcheck disable=SC2086
+    llm ${SHELLM_FAST_MODEL:+-m "$SHELLM_FAST_MODEL"} \
+        -s "You are a semantic search engine for memory files. Each memory has a filename header (=== filename ===), YAML frontmatter (summary, type), and a body. Return ONLY the filenames and summaries of semantically matching memories, one per line. If nothing matches, say 'No matches found.'" \
         "Search these memories for: ${query}
 
 ${memories}"

--- a/bin/shellm
+++ b/bin/shellm
@@ -144,8 +144,11 @@ Options:
   --print-system-prompt Print the system prompt and exit
 
 Environment:
-  ANTHROPIC_API_KEY        Required. Your Anthropic API key.
+  <PROVIDER>_API_KEY      Key for SHELLM_MODEL's provider (ANTHROPIC_API_KEY
+                          for claude-*, OPENROUTER_API_KEY for vendor/model, ...)
   SHELLM_MODEL            Model to use
+  SHELLM_FAST_MODEL       Cheap model class for utility calls (summaries,
+                          mem search); defaults to SHELLM_MODEL's provider
   SHELLM_MAX_ITERATIONS   Max loop iterations
   SHELLM_MAX_TOKENS       Max tokens per response
   SHELLM_EFFORT           Thinking effort level (low/medium/high/xhigh/max)
@@ -1533,7 +1536,17 @@ generate_run_summary() {
     shift 5
     local file_paths=("$@")
 
-    local summary_model="${SHELLM_SUMMARY_MODEL:-claude-haiku-4-5-20251001}"
+    # Summaries want a cheap model. Resolution: explicit SHELLM_SUMMARY_MODEL,
+    # then the fast class (SHELLM_FAST_MODEL), then haiku when the run is on
+    # Anthropic, else stay on the run's own provider (a claude-* fallback
+    # would need an ANTHROPIC_API_KEY non-Anthropic deployments don't have).
+    local summary_model="${SHELLM_SUMMARY_MODEL:-${SHELLM_FAST_MODEL:-}}"
+    if [[ -z "$summary_model" ]]; then
+        case "$SHELLM_MODEL" in
+            claude-*) summary_model="claude-haiku-4-5-20251001" ;;
+            *)        summary_model="$SHELLM_MODEL" ;;
+        esac
+    fi
 
     # Read stdin content if available
     local stdin_content=""

--- a/design/model-resolution.md
+++ b/design/model-resolution.md
@@ -1,0 +1,96 @@
+# Model resolution
+
+**Status:** Current behavior (documented 2026-07-15)
+
+How every LLM call in shellm decides which model to use, and where the
+environment variables that feed that decision come from. Two layers:
+
+1. **Resolution** — each call site walks a precedence chain of flags and
+   env vars until one is set.
+2. **Population** — the env vars themselves are filled in from `.env`
+   files, with different (deliberate) merge semantics per tool.
+
+There is no hard provider dependency anywhere: `bin/llm` picks the
+provider from the model name (`claude-*` → Anthropic, `vendor/model` →
+OpenRouter, `gpt-*`/`o*` → OpenAI, `gemini-*` → Gemini) and each provider
+needs only its own `<PROVIDER>_API_KEY`. Hardcoded `claude-*` names below
+are last-resort defaults, reached only when nothing is configured.
+
+## The knobs
+
+| Variable | Meaning |
+|---|---|
+| `SHELLM_MODEL` | The system-wide model: agent loops and the default for everything below |
+| `SHELLM_FAST_MODEL` | Optional cheap class for utility calls (summaries, `mem search`). Set it when `SHELLM_MODEL` is expensive; skip it when it's already cheap |
+| `THINK_MODEL` | Per-thinker override (also settable per identity via `info.txt think_model=`) |
+| `SHELLM_SUMMARY_MODEL` | Run-summary override; beats `SHELLM_FAST_MODEL` |
+| `LLM_MODEL` | `bin/llm`'s own knob; equivalent to `-m` |
+
+## Resolution chains
+
+Left to right, first set value wins:
+
+| Call site | Resolution chain |
+|---|---|
+| `mem search` | `SHELLM_FAST_MODEL` → `SHELLM_MODEL` → `claude-sonnet-4-5` |
+| bare `llm` (no `-m`) | `-m` flag → `LLM_MODEL` → `SHELLM_MODEL` → `claude-sonnet-4-5` |
+| run summaries (`bin/shellm`) | `SHELLM_SUMMARY_MODEL` → `SHELLM_FAST_MODEL` → *if run is `claude-*`*: `claude-haiku-4-5` / *else*: the run's own `SHELLM_MODEL` |
+| `shellm` agent loop | `--model` flag → `SHELLM_MODEL` → `claude-opus-4-7` |
+| thinkers (all) | `THINK_MODEL` → `SHELLM_MODEL` → `claude-opus-4-7` |
+| web-started thinkers | `info.txt think_model=` → server-env `SHELLM_MODEL` → *(left unset — the step resolves as the thinker row above)* |
+| `shellm-explore` report | `--model` flag → `SHELLM_MODEL` → `claude-opus-4-7` |
+| `identity create` | `SHELLM_MODEL` → `claude-opus-4-7` |
+
+The summary chain's provider split exists so that a non-Anthropic
+deployment never falls back to a `claude-*` model it has no key for,
+while Anthropic runs keep haiku's cheap summaries.
+
+## Where the variables come from (.env population)
+
+Two merge semantics, and the difference is deliberate:
+
+- **`bin/llm` and `bin/shellm`** source the first `.env` found — cwd,
+  else `~/.shellm/.env` (first found wins entirely; no merging) — and it
+  **overwrites** already-exported vars. On a deployed box the service's
+  working directory is the app root, so `/opt/shellm/app/.env` is
+  authoritative for these tools.
+- **Thinker step scripts** (`thinkers/_lib/common.sh`) fill in only
+  *missing* vars, trying `$IDENTITY_DIR/.env` → cwd `.env` →
+  `~/.shellm/.env`. Real environment always beats files here because the
+  web control plane's env wrapper has already sourced root + identity
+  `.env` (identity wins) before the dispatcher starts — a clobbering
+  loader in the step would let the root `.env` stomp identity-level
+  overrides that were already applied.
+
+Consequences worth knowing:
+
+- A `SHELLM_MODEL=` line in cwd's `.env` silently beats an inline
+  `SHELLM_MODEL=x shellm ...` for `llm`/`shellm` (but not for thinkers).
+- Rotating an API *key* in the box's `.env` takes effect on the next LLM
+  call (`llm`/`shellm` re-source per invocation). Changing `SHELLM_MODEL`
+  needs a thinker stop/start: running dispatchers export the model they
+  started with.
+- Identity-level `.env` overrides root for thinkers — if one identity
+  mysteriously uses a different model/key, look there.
+
+## Choosing values (cost)
+
+`SHELLM_MODEL` is the persona-quality knob; `SHELLM_FAST_MODEL` is the
+cost knob. Utility traffic (summaries, memory search) is structured and
+cheap-model-tolerant; background thinkers are the volume driver and stay
+on the smart tier by default — pointing them at a cheap tier via
+`THINK_MODEL` is a per-deployment persona decision, not a code default.
+Examples:
+
+```bash
+# Anthropic, cost-conscious
+SHELLM_MODEL=claude-opus-4-7
+SHELLM_FAST_MODEL=claude-haiku-4-5
+
+# OpenRouter, everything cheap (tiers pointless)
+SHELLM_MODEL=openai/gpt-oss-120b
+
+# Mixed quality: smart actor, cheap utilities
+SHELLM_MODEL=z-ai/glm-5.2
+SHELLM_FAST_MODEL=openai/gpt-oss-120b
+```


### PR DESCRIPTION
to get openrouter working

## Summary

Removes the hidden Anthropic couplings so a deployed box can run entirely
on OpenRouter (or any provider) with no code changes — config is one SSM
parameter. Found while standing up a gpt-oss-120b box.

- **Model resolution (`bin/`, `thinkers/`, `web/`)**: call sites that
  ignored `SHELLM_MODEL` now honor it (table below); thinker steps load
  `.env` fallbacks (identity → cwd → `~/.shellm`, never clobbering
  explicit env); web control plane no longer pins a fabricated
  `THINK_MODEL` into dispatcher env
- **`SHELLM_FAST_MODEL`** (new, opt-in): cheap model tier for utility
  calls — run summaries and `mem search` — for when `SHELLM_MODEL` is
  expensive
- **Deploy**: `anthropic_api_key` tfvar removed; the SSM parameter
  (`/shellm/env`) is now the only secrets path and also carries
  `SHELLM_MODEL`; README documents update/rotation (user-data runs once
  per instance — rebuild or re-fetch in place)
- **shellm-web**: explicit `--port` in use fails fast naming the owning
  pid; auto-selection warns when it skips a taken 8080 instead of
  silently serving elsewhere
- **Docs**: `design/model-resolution.md` — resolution chains, `.env`
  merge semantics, cost guidance

## Model resolution: before → after

Ultimate fallbacks when nothing is configured are unchanged; what changed
is that `SHELLM_MODEL` is now actually honored:

| Call site | Before | After |
|---|---|---|
| `mem search`, keyless `llm` | always `claude-sonnet`, even with `SHELLM_MODEL` set | `SHELLM_FAST_MODEL` → `SHELLM_MODEL` → `claude-sonnet` |
| Run summaries | always `claude-haiku` (hard error without an Anthropic key) | `SHELLM_SUMMARY_MODEL` → `SHELLM_FAST_MODEL` → haiku on `claude-*` runs, else the run's own model |
| Web-started thinkers | `claude-opus` pinned whenever the server process env lacked `SHELLM_MODEL`; `.env` ignored | `info.txt think_model` → server-env `SHELLM_MODEL` → `.env` via step scripts → `claude-opus` |
| CLI-started thinkers | env vars only; silent `claude-opus` if `SHELLM_MODEL` wasn't exported | `THINK_MODEL` → `SHELLM_MODEL` (both fillable from identity/cwd/`~/.shellm` `.env`) → `claude-opus` |
| `SHELLM_FAST_MODEL` | — | new, opt-in; unset = zero effect |

One intentional behavior change for configured setups: with
`SHELLM_MODEL=claude-opus-*` set, `mem search` now uses opus instead of
sonnet — set `SHELLM_FAST_MODEL=claude-haiku-4-5` to keep utility calls
cheap.
