### PR TITLE
TUI: bind Ctrl+D to delete-char; chat skill prose cleanup

### DIFF
--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -15,10 +15,10 @@ There is a CLI tool called `chat` that is used for me and others to send message
 
 ## Trajectory step types
 
-A step in my trajectory with "type":"message" is message to or from me. I know who it is from and to by looking at the step's "to" and "from" fields.
+A step in my trajectory with `"type":"message"` is a message to or from me. I know who it is from and to by looking at the step's `to` and `from` fields.
 
-A `message` in my trajectory `to` me (i.e., my name) is someone talking TO me.
-A `message` in my trajectory `from` me (i.e., my name) is something I already said.
+A `message` in my trajectory `to` me, i.e. my name, is someone talking to me.
+A `message` in my trajectory `from` me, i.e. my name, is something I already said.
 
 ## Replying to humans
 
@@ -36,4 +36,4 @@ IMPORTANT: if I use `chat send` it sends a message to myself, so I must NEVER us
 
 ## When to reply
 
-I should reply when I see a `message` that seems directed at me or asks me a question. I keep my replies natural and conversational. Or if I have some reason to talk to the person even if they haven't spoken to me recently (e.g., if i need to ask them for help, or if I want to share something relevant to them given my past history and interactions with them.
+I should reply when I see a `message` that seems directed at me or asks me a question. I keep my replies natural and conversational. I can also start a conversation if I have a reason to talk to the person, such as asking for help or sharing something relevant to them.

--- a/tui/shellm/src/main.rs
+++ b/tui/shellm/src/main.rs
@@ -321,7 +321,8 @@ fn help_text() -> Vec<String> {
         "  (traj)      tail -n 5          -> traj tail -n 5".into(),
         "".into(),
         "Keys:".into(),
-        "  Ctrl+C/D       Exit".into(),
+        "  Ctrl+C         Exit (press twice)".into(),
+        "  Ctrl+D         Delete char at cursor (exit if input empty)".into(),
         "  Shift+Enter    Newline in input".into(),
         "  Up/Down        Command history (from top/bottom line)".into(),
         "  Enter (empty)  Return to live view after a command (thinkers/traj)".into(),
@@ -411,7 +412,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("Slash commands (available in any mode):");
                 println!("  /chat  /thinkers  /traj  /identities  /help\n");
                 println!("Keys:");
-                println!("  Ctrl+C/D       Exit");
+                println!("  Ctrl+C         Exit (press twice)");
+                println!("  Ctrl+D         Delete char at cursor (exit if input empty)");
                 println!("  Shift+Enter    Newline in input");
                 println!("  PageUp/Down    Scroll output");
                 println!("  Ctrl+G         Toggle mouse (scroll vs. text select)");
@@ -855,6 +857,17 @@ async fn run(
                         let len = app.input.chars().count();
                         if app.cursor < len {
                             app.cursor += 1;
+                        }
+                    }
+                    KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        // Readline delete-char; EOF (exit) on empty input
+                        if app.input.is_empty() {
+                            break;
+                        }
+                        let len = app.input.chars().count();
+                        if app.cursor < len {
+                            let pos = byte_pos(&app.input, app.cursor);
+                            app.input.remove(pos);
                         }
                     }
                     KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {


### PR DESCRIPTION
## Summary
- **Ctrl+D in the TUI** now follows the readline convention: deletes the character at the cursor, and exits (EOF) only when the input is empty. Previously Ctrl+D was documented as exit but not actually bound. Help text (`/help` and `--help`) updated to describe the real bindings, including the double-press Ctrl+C quit.
- **chat skill**: minor prose cleanup — fixes an unclosed parenthetical and tightens the message-type wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)