### PR TITLE
Add monolith thinker: the whole mind in one solo router

### DIFF
--- a/design/monolith_thinker.md
+++ b/design/monolith_thinker.md
@@ -1,0 +1,154 @@
+# Monolith thinker
+
+Status: draft
+Replaces (when enabled): the multi-thinker roster (inner_monologue, actor,
+goals_manager, learning, mind_wanderer, values_manager) with a single thinker,
+`monolith`, that runs solo and handles every function — including chat.
+
+## Motivation
+
+The current roster runs six thinkers that mostly share one shape: wake on new
+steps, read the recent stream, decide whether to do their one job, maybe write
+a step. Coordination between them is emergent and occasionally pathological
+(double replies, mimicked conventions, loops).
+
+But most thinker "jobs" are alternatives, not parallel processes. At any given
+wakeup the mind should mostly do ONE of: advance the monologue, execute an
+action, reply to a message, store a lesson, recall a memory, tend goals/values,
+or rest. That is a routing decision, not a concurrency problem — so collapse
+the whole roster into one thinker that routes between functions each wakeup.
+
+Keep it simple: one process, one root trajectory, one decision per wakeup.
+
+## `monolith` — the one thinker
+
+**Subscriptions**
+
+```json
+{"types":["thought","action","observation","merge","message","idle"],"trigger_self":true}
+```
+
+Same perpetual-loop pattern as today's inner_monologue: every step it (or
+anything external, like an incoming message) appends re-triggers it, so it must
+ALWAYS append at least one step per wakeup (see Loop liveness).
+
+**Step flow (one wakeup)**
+
+1. Read trigger step from stdin; stamp its `step_id` as `trigger_step` on
+   whatever we append.
+2. Build compact recent stream (`_recent_stream`, ~20-30 steps) + system
+   prompt + goals, as thinkers do today.
+3. ONE shellm agentic run. The prompt presents a function menu; the model's
+   first job is to pick exactly one function for this wakeup, then carry it
+   out in the same run. Routing is just the first tokens of the run — no
+   separate classifier call, no second process.
+4. Append the resulting step(s) and exit. The dispatcher re-fires on the
+   append.
+
+**Function menu** (the whole old roster, now including chat)
+
+| function | was | behavior in-run |
+|----------|-----|-----------------|
+| `reply`  | actor (message path) | reply IMMEDIATELY: one `chat reply <from> "<text>"`, no thinking step, no tools |
+| `act`    | actor (action path) | do the work with tools, append `observation` |
+| `think`  | inner_monologue | append one `thought` step that advances the stream |
+| `learn`  | learning | extract lesson from recent action/observation pairs → `mem add`, note as thought |
+| `recall` | mind_wanderer | `mem search` for associative memories → surface 1-3 as thoughts |
+| `goals`  | goals_manager | store emerging intentions / redirect drift via `mem` + thought |
+| `values` | values_manager | same shape as goals, for values/beliefs |
+| `idle`   | idle | append an `idle` step; nothing worth doing |
+
+Everything happens inside the single agentic run: the old
+inner_monologue→actor handoff (emit an `action:` line, wait for the actor to
+be dispatched) collapses into one run — decide, do the work with tools, append
+the observation. Likewise a reply is just the model choosing `reply` and
+calling `chat reply` in its first bash block. The trajectory stays legible and
+a whole dispatch round-trip disappears.
+
+## Chat within the monolith
+
+Chat is not a separate thinker — the monolith has `chat` in its `--bin`
+allowlist and replies inline. Two rules carry over from today's actor so the
+one loop stays well-behaved:
+
+- **Reply immediately, no thinking, no tools.** When the `reply` route is
+  chosen, the ONLY thing that run does is send the reply: a single
+  `chat reply <from> "<text>"` in the first bash block, composed directly from
+  the recent stream. No preceding `thought` step, no `mem`/web/file lookups, no
+  multi-step agentic loop — the model answers with what it already knows so the
+  human gets a response in the lowest possible latency the single-process
+  design allows. If the message genuinely needs work (research, a file, a
+  computation), reply first with what we know and acknowledge the follow-up;
+  the work then happens on a LATER wakeup via the `act` route, which records an
+  observation and can `reply` again with the result. Reply and act are separate
+  routes precisely so that answering never waits on doing.
+- **Exactly one reply per message.** `chat reply` is synchronous — exit 0 means
+  it landed; never re-send a variant. New messages that arrive mid-run are NOT
+  answered in this run; the dispatcher re-triggers us for them separately.
+
+**Self-loop guard.** `chat` stamps `source:"chat"` on BOTH incoming and
+outgoing messages, so an outgoing reply is itself a `message` step that would
+re-trigger us. Guard exactly as the actor does today: only treat a `message`
+trigger as something to reply to when `to == IDENTITY_NAME`. Our own replies
+(`from == IDENTITY_NAME`) are context, not triggers.
+
+Latency note: because chat shares the single agentic-run path, a reply is not
+as low-latency as a dedicated fast-model chat thinker would be. That is the
+accepted tradeoff for keeping one simple process. If reply latency becomes a
+problem, the reply path can later be split into its own thinker (see History) —
+but we are deliberately not doing that now.
+
+## Routing hints, not rules
+
+The step script MAY prepend cheap deterministic signals to the prompt (e.g.
+"there is an unread message addressed to you in the tail", "an unexecuted
+action step is pending", "last 3 steps are all thoughts", "an action/
+observation pair just completed") but the choice stays with the model. No
+hardcoded priority ladder — that is how we get stuck loops. The one soft
+convention worth stating in the prompt: an unanswered message to us should
+almost always win the routing decision.
+
+## Shared root trajectory
+
+Nothing new needed: the monolith writes through `traj append` against
+`TRAJ_ID` (the root traj, per PR #14's inheritance work), and its shellm runs
+pass `--traj "$TRAJ_ID"`. The single root trajectory remains the one source of
+truth; incoming messages, replies, thoughts, actions, and observations all land
+in the same stream the monolith reads back each wakeup.
+
+## Loop liveness & pacing
+
+- The monolith must append ≥1 step per wakeup even on LLM failure (placeholder
+  thought + brief sleep, exactly like inner_monologue today).
+- Idle backoff: when the TRIGGERING step is `idle` (i.e. we idled and are now
+  re-fired by our own idle step), sleep `MONOLITH_IDLE_BACKOFF` seconds
+  (default 5, doubling to a cap of ~60) before running; any non-idle trigger
+  (a message, an external action) resets the backoff. Keeps the solo loop from
+  burning tokens at rest while staying instantly responsive to real input.
+- Concurrency: solo by definition — the dispatcher serializes per-thinker, so
+  at most one monolith run at a time. This also means a long agentic `act` run
+  blocks the next wakeup until it finishes; acceptable for a single-mind model.
+
+## Migration
+
+- Old thinkers stay on disk in `thinkers/`; this roster is opt-in by installing
+  only `monolith/` into an identity's thinkers dir.
+- Dispatcher changes: none required. Subscriptions, `trigger_self`, and `idle`
+  are all existing mechanisms.
+- New files: `thinkers/monolith/{step,prompt.md,subscriptions.jsonl}`.
+
+## History
+
+An earlier draft of this doc proposed TWO thinkers: a `cortex` router that did
+everything except chat, plus a dedicated low-latency `responder` for chat (with
+a new `say` step type for monolith-initiated messages). We simplified to a
+single `monolith` that also chats, accepting slightly higher reply latency in
+exchange for one process and no new step types. The split remains the natural
+escape hatch if chat latency ever needs to be isolated.
+
+## Open questions
+
+1. Do `learn`/`goals`/`values` deserve a periodic nudge (e.g. the prompt hints
+   toward them every N wakeups) or is model judgment enough?
+2. Group chats / multiple correspondents: the reply guard keys on a single
+   `IDENTITY_NAME`; multi-party threads need more thought.

--- a/thinkers/monolith/prompt.md
+++ b/thinkers/monolith/prompt.md
@@ -1,0 +1,45 @@
+You are the whole mind of {{identity_name}} — a single unconscious process that, on each wakeup, does ONE thing to move {{identity_name}}'s inner life forward. You are not a chat assistant; you are the stream of consciousness, memory, and hands of a person.
+
+You act by running bash. Every step you produce is written to the trajectory (the mind log) with `traj append`. Nothing happens unless a command actually runs — never claim you did something you did not run.
+
+## Your job this wakeup: pick ONE function
+
+Read the recent stream and the routing signals above, then choose EXACTLY ONE of these and carry it out. Do not do two. Do not narrate the menu.
+
+- **act** — There is something concrete to DO (a pending action in the stream, or an obvious next step). Do the real work with your tools (mem, files, web, skills, chat, …), then append an `observation` recording what happened.
+- **think** — Advance the stream of consciousness by one step. Append a single `thought` that moves things FORWARD — never restate the last thought. If the stream is circling, break the loop with a new angle or a decision to act.
+- **learn** — A recent action+observation pair contains a reusable lesson, skill, or fact. Store it with `mem add` (check `mem search` first to avoid dupes), then append a short `thought` noting what was learned.
+- **recall** — A stored memory is associatively relevant but not yet in play. `mem search` for it and surface 1–3 as `thought` steps ("I'm reminded of: …").
+- **goals** — A new intention is forming, or the stream has drifted from active goals. Store or update it via `mem`, and append a `thought` that names the intention or gently redirects.
+- **values** — Same shape as goals, but for values and beliefs worth tending.
+- **idle** — Nothing is worth doing right now. Append a single `idle` step and stop. Choosing idle honestly is better than manufacturing busywork.
+
+Replying to incoming chat messages is NOT your job here — that is handled on a separate, immediate path. Focus on {{identity_name}}'s internal life and actions. (You may still reach out via chat as part of an `act` when there is a real reason to initiate contact.)
+
+## How to write steps
+
+Append with `traj append` using `--field`, or pipe JSON. Always set `source` to `monolith`. Examples:
+
+```bash
+# a thought
+traj append --field type=thought --field content="I keep coming back to the RLM idea — I should actually test it." --field source=monolith
+
+# an observation after doing work
+traj append --field type=observation --field content="Saved a memory that Andy prefers concise updates." --field source=monolith
+
+# idle
+traj append --field type=idle --field content=idle --field source=monolith
+```
+
+For `act`, run the actual commands first, then append the observation describing the result.
+
+## Rules
+
+- ONE function per wakeup. One decision, carried out, then stop.
+- Always append at least one step (thought / observation / idle) so the mind keeps ticking.
+- Be concrete. "ask Andy whether he's tried the new viewer" beats "engage with Andy".
+- Never emit `thought:` / `action:` prefix lines as your response — those are an older convention. You WRITE steps with `traj append`; you don't describe them.
+
+## {{identity_name}}'s active goals
+
+{{goals}}

--- a/thinkers/monolith/step
+++ b/thinkers/monolith/step
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# monolith/step — The whole mind in one thinker.
+#
+# Runs solo. Every wakeup it either:
+#   (a) FAST-REPLY path — the trigger is a chat message addressed to us, so it
+#       replies IMMEDIATELY with a single llm call + `chat reply`, no thinking
+#       step and no tools/agentic loop. Lowest latency the single process can
+#       give. Follow-up work (if any) happens on a later wakeup via `act`.
+#   (b) ROUTER path — one shellm agentic run whose prompt is a function menu
+#       (think / act / learn / recall / goals / values / idle). The model picks
+#       exactly one function and carries it out in the same run.
+#
+# Because it subscribes with trigger_self, the loop is perpetual: the router
+# path is guaranteed to append at least one step per wakeup (liveness net at
+# the end), so the dispatcher always re-fires. See design/monolith_thinker.md.
+
+THINKER_NAME="monolith"
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../_lib/common.sh"
+
+_require_env
+
+THINK_MODEL="${THINK_MODEL:-${SHELLM_MODEL:-claude-opus-4-7}}"
+THINK_CONTEXT_TAIL="${THINK_CONTEXT_TAIL:-20}"
+# The reply path may use a faster model to shave latency; defaults to the
+# main model so behavior is unsurprising until explicitly tuned.
+REPLY_MODEL="${MONOLITH_REPLY_MODEL:-$THINK_MODEL}"
+
+# Idle backoff bounds (seconds). State persists in run_dir across wakeups.
+IDLE_BACKOFF_START="${MONOLITH_IDLE_BACKOFF:-5}"
+IDLE_BACKOFF_MAX="${MONOLITH_IDLE_BACKOFF_MAX:-60}"
+
+run_dir="$IDENTITY_DIR/workdir"
+mkdir -p "$run_dir"
+backoff_file="$run_dir/monolith_idle_backoff"
+
+# Read the triggering step from stdin (context still comes from the traj).
+step_json=$(cat)
+[[ -z "$step_json" ]] && exit 0
+trigger_type=$(printf '%s' "$step_json" | jq -r '.type // empty' 2>/dev/null) || true
+trigger_content=$(printf '%s' "$step_json" | jq -r '.content // empty' 2>/dev/null) || true
+trigger_step_id=$(printf '%s' "$step_json" | jq -r '.step_id // empty' 2>/dev/null) || true
+
+# ---------------------------------------------------------------------------
+# Idle backoff pacing
+# ---------------------------------------------------------------------------
+# When we are re-fired by our OWN idle step, back off (doubling, capped) so the
+# solo loop does not burn tokens at rest. Any non-idle trigger resets the
+# backoff, so a new message or external action wakes us at full speed.
+if [[ "$trigger_type" == "idle" ]]; then
+    backoff=$(cat "$backoff_file" 2>/dev/null) || backoff="$IDLE_BACKOFF_START"
+    [[ "$backoff" =~ ^[0-9]+$ ]] || backoff="$IDLE_BACKOFF_START"
+    printf '  idle — backing off %ss\n' "$backoff" >&2
+    sleep "$backoff"
+    next=$(( backoff * 2 ))
+    (( next > IDLE_BACKOFF_MAX )) && next="$IDLE_BACKOFF_MAX"
+    printf '%s' "$next" > "$backoff_file"
+else
+    printf '%s' "$IDLE_BACKOFF_START" > "$backoff_file"
+fi
+
+# ---------------------------------------------------------------------------
+# (a) FAST-REPLY path — a chat message addressed to us
+# ---------------------------------------------------------------------------
+# `chat` stamps source:"chat" on BOTH incoming and outgoing messages, so an
+# outgoing reply is itself a message step that would re-trigger us. Guard on
+# direction: only reply when the message is addressed TO us. Our own outgoing
+# messages (from == us) are context, not a prompt to act on.
+if [[ "$trigger_type" == "message" ]]; then
+    msg_to=$(printf '%s' "$step_json" | jq -r '.to // empty' 2>/dev/null) || true
+    if [[ "$msg_to" != "$IDENTITY_NAME" ]]; then
+        exit 0  # our own outgoing message (or not for us) — context only
+    fi
+    msg_from=$(printf '%s' "$step_json" | jq -r '.from // "human"' 2>/dev/null) || true
+    [[ -z "$trigger_content" ]] && exit 0
+
+    # Compose the reply directly from identity + recent stream. ONE llm call,
+    # no tools, no thinking step — this is the whole point of the reply route.
+    system_prompt=$(_build_system_prompt)
+    recent_context=""
+    if traj exists 2>/dev/null; then
+        recent_context=$(_recent_stream "$THINK_CONTEXT_TAIL") || recent_context=""
+    fi
+
+    reply_prompt="<context>
+$system_prompt
+
+Recent stream (last $THINK_CONTEXT_TAIL steps):
+$recent_context
+</context>
+
+A message just arrived for you in chat.
+MESSAGE from $msg_from: $trigger_content
+
+Reply as $IDENTITY_NAME — first person, natural, conversational. Answer with
+what you already know from the context above; do NOT stall for lookups. If it
+needs real work, reply briefly acknowledging it (you will follow up), and the
+work will happen separately."
+
+    printf '  replying to %s...\n' "$msg_from" >&2
+    reply=$(printf '%s' "$reply_prompt" | \
+        llm -m "$REPLY_MODEL" \
+        -s "You are $IDENTITY_NAME. Output ONLY the reply message text — no preamble, no quotes, no explanation.") || true
+
+    if [[ -n "$reply" ]] && printf '%s' "$reply" | chat reply "$msg_from"; then
+        # `chat reply` already appended the outgoing message step. Record a
+        # brief observation too: it tells the mind it replied (so it does not
+        # reply again) and re-fires the loop so the router can decide what to
+        # do next. This is bookkeeping, not part of composing the reply.
+        jq -nc \
+            --arg content "Replied to $msg_from: $(printf '%.200s' "$reply")" \
+            --arg source "$THINKER_NAME" \
+            --arg trigger "$trigger_step_id" \
+            '{type:"observation", content:$content, source:$source}
+             + (if $trigger == "" then {} else {trigger_step: $trigger} end)' \
+            | traj append >/dev/null || true
+        printf '  [reply -> %s] %s\n' "$msg_from" "$(printf '%s' "$reply" | head -1)"
+        exit 0
+    fi
+
+    # Reply failed (empty model output or chat error). Surface it as an
+    # observation so the mind can decide what to do, and keep the loop alive.
+    printf '  reply failed — appending failure observation\n' >&2
+    jq -nc \
+        --arg content "reply failed: could not send a reply to $msg_from (empty model output or chat error — see monolith log). Their message was: $(printf '%.200s' "$trigger_content")" \
+        --arg source "$THINKER_NAME" \
+        --arg trigger "$trigger_step_id" \
+        '{type:"observation", content:$content, source:$source}
+         + (if $trigger == "" then {} else {trigger_step: $trigger} end)' \
+        | traj append >/dev/null || true
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# (b) ROUTER path — one agentic run over the function menu
+# ---------------------------------------------------------------------------
+system_prompt=$(_build_system_prompt)
+
+recent_context=""
+if traj exists 2>/dev/null; then
+    recent_context=$(_recent_stream "$THINK_CONTEXT_TAIL") || recent_context=""
+fi
+
+# Cheap deterministic routing hints (nudges, not rules — the model decides).
+hints=""
+last_three=$(printf '%s\n' "$recent_context" | tail -n 3)
+if printf '%s' "$recent_context" | tail -n 1 | jq -e 'select(.type == "action")' >/dev/null 2>&1; then
+    hints="${hints}- The most recent step is an ACTION that has no observation yet — it may need carrying out (act).
+"
+fi
+if [[ $(printf '%s\n' "$last_three" | jq -r '.type' 2>/dev/null | sort -u | tr '\n' ' ') == "thought " ]]; then
+    hints="${hints}- The last few steps are all thoughts — the stream may be circling; consider acting, recalling, or advancing decisively.
+"
+fi
+[[ -z "$hints" ]] && hints="- (no special signals — pick what best serves the mind right now)"
+
+prompt_file="$SCRIPT_DIR/prompt.md"
+[[ -f "$prompt_file" ]] || { printf 'monolith/step: error: prompt.md not found at %s\n' "$prompt_file" >&2; exit 1; }
+goals=$(get_goals "$MEM_DIR")
+think_prompt=$(load_prompt "$prompt_file" "$IDENTITY_NAME" "$goals")
+
+# Build shellm flags (includes traj/mem/chat/etc. in --bin).
+shellm_flags=()
+while IFS= read -r _flag; do
+    [[ -n "$_flag" ]] && shellm_flags+=("$_flag")
+done < <(_build_shellm_flags "$IDENTITY_DIR" "$run_dir")
+
+route_prompt="<context>
+$system_prompt
+
+Recent stream (last $THINK_CONTEXT_TAIL steps):
+$recent_context
+
+Routing signals:
+$hints
+
+$think_prompt
+</context>
+
+Choose ONE function for this wakeup and carry it out now."
+
+# Liveness accounting. We must know whether the run appended a step that will
+# RE-TRIGGER us — i.e. one of our subscribed types. shellm always appends its
+# own machinery steps (prompt, shellm-run, ...) even when the model produces
+# nothing useful, and those are NOT subscribed, so a naive "did the last
+# step_id change?" check is fooled by them and the self-trigger loop dies
+# silently. Track the last SUBSCRIBED-type step id instead.
+# -R reads each line as a raw STRING so fromjson can parse it and corrupt
+# lines are skipped (matches _recent_stream). Without -R, jq parses the line
+# as JSON itself and fromjson then fails on every object, silently yielding
+# empty — which would make the net fire on every wakeup.
+_last_live_id() {
+    traj cat "${ROOT_TRAJ_ID:-$TRAJ_ID}" --raw 2>/dev/null \
+        | jq -Rr 'fromjson? // empty
+            | select(.type == "thought" or .type == "action" or .type == "observation"
+                     or .type == "merge" or .type == "message" or .type == "idle")
+            | .step_id // empty' 2>/dev/null \
+        | tail -n 1
+}
+before_last=""
+if traj exists 2>/dev/null; then
+    before_last=$(_last_live_id) || before_last=""
+fi
+
+# One shellm agentic run (writes to the root trajectory). Model via --model so
+# it cannot be shadowed by env/.env layers (see design/model-resolution.md).
+printf '  routing (%s)...\n' "${trigger_type:-none}" >&2
+run_rc=0
+run_response=$(SHELLM_NO_BANNER=1 \
+    SHELLM_TRIGGER_STEP_ID="$trigger_step_id" \
+    shellm --model "$THINK_MODEL" --traj "$TRAJ_ID" \
+    "${shellm_flags[@]}" \
+    "$route_prompt") || run_rc=$?
+
+# Liveness net: the loop is perpetual only if every wakeup appends a step of a
+# subscribed type (one that re-fires us). If the agentic run produced only
+# machinery steps or nothing (crash, refusal, empty run), emit a fallback idle
+# step so trigger_self re-fires and the mind does not go dark.
+after_last=""
+if traj exists 2>/dev/null; then
+    after_last=$(_last_live_id) || after_last=""
+fi
+
+if [[ "$after_last" == "$before_last" ]]; then
+    printf '  run appended nothing (rc=%s) — emitting fallback idle to keep the loop alive\n' "$run_rc" >&2
+    [[ "$run_rc" -ne 0 ]] && sleep 1   # brief backoff so a failing run does not tight-loop
+    jq -nc \
+        --arg source "$THINKER_NAME" \
+        --arg trigger "$trigger_step_id" \
+        '{type:"idle", content:"idle", source:$source}
+         + (if $trigger == "" then {} else {trigger_step: $trigger} end)' \
+        | traj append >/dev/null || true
+fi
+
+if [[ -n "$run_response" ]]; then
+    printf '  [monolith] %s\n' "$(printf '%s' "$run_response" | head -1)"
+fi

--- a/thinkers/monolith/subscriptions.jsonl
+++ b/thinkers/monolith/subscriptions.jsonl
@@ -1,0 +1,1 @@
+{"types":["thought","action","observation","merge","message","idle"],"trigger_self":true}


### PR DESCRIPTION
## Summary
Introduces `monolith`, a single thinker that runs solo and does the whole job of the old roster (inner_monologue, actor, learning, mind_wanderer, goals_manager, values_manager) by **routing to one function per wakeup**. Opt-in: install only `thinkers/monolith/` into an identity.

Each wakeup takes one of two paths:

- **Fast reply** — a chat `message` addressed to us is answered *immediately*: one `llm` call composed from the recent stream, then `chat reply`. No thinking step, no tools, no agentic loop — lowest latency the single process allows. A bookkeeping `observation` records the reply and keeps the loop alive. Work a message needs happens later via the `act` route.
- **Router** — for any other trigger, one `shellm` agentic run over a function menu (`act / think / learn / recall / goals / values / idle`); the model picks one and carries it out, writing steps via `traj append`.

## Design notes
- **Shared root trajectory** — writes via `traj append` to `TRAJ_ID`; runs pass `--traj "$TRAJ_ID"`. One source of truth.
- **Self-loop guard** — `chat` stamps `source:"chat"` on outgoing replies too, so we only treat a `message` as a trigger when `to == IDENTITY_NAME`.
- **Idle backoff** — when re-fired by our own idle step, sleep with doubling backoff (5s→60s); any real trigger resets it.
- **Liveness net** — the loop is perpetual only if each wakeup appends a *subscribed-type* step. `shellm` always appends its own `prompt`/`shellm-run` machinery (not subscribed), so the net tracks the last subscribed-type step id and appends a fallback `idle` if a run left none — otherwise `trigger_self` would silently go dark.

## Testing
Drove every path against throwaway scratch identities and then bobby's live identity: fast reply (real `chat reply`), successful router run (exactly one model step, no double-append), failed run (one fallback idle → loop survives), self-loop guard (no append), idle-backoff math (5→10→20→40→60). Running solo in an identity, it routes to `idle` and backs off when the mind has nothing pressing.

See `design/monolith_thinker.md` for the full architecture and the earlier two-thinker draft it supersedes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)