### PR TITLE
Design: minimal native macOS chat client

### DIFF
--- a/design/macos_client.md
+++ b/design/macos_client.md
@@ -1,0 +1,103 @@
+# Shellm.app — minimal native macOS chat client
+
+A menu-bar chat client for talking to a shellm agent, whether the identity
+runs locally or on a remote box (e.g. the EC2 instance behind
+chat.shellm.net). Design goal: the most minimal possible native client —
+one Swift file, zero dependencies, no new server work.
+
+## What it talks to
+
+The existing `shellm-web` HTTP API (`web/src/shellm_web/server.py`) — the
+same API the phone PWA uses. It is identical for local
+(`http://localhost:8080`) and remote (`https://chat.shellm.net`):
+
+| Call | Purpose |
+|---|---|
+| `GET /api/identities` | list identities → auto-pick or let user choose |
+| `GET /api/identities/{id}/chat?tail=200&with=<you>` | returns `{live, messages[], outcomes{}}` |
+| `POST /api/identities/{id}/chat` body `{content, from_name}` | send a message |
+
+Messages arrive by **polling** (2s interval) — the PWA's model too; the
+server has no chat SSE/websocket and `chat_view` is cheap.
+
+`outcomes` maps each sent message's step_id to `replied` / `no-reply` /
+`failed`. A sent message with *no* outcome yet is exactly what the server
+docstring calls "a truthful typing indicator" — the client gets a real
+"thinking…" state for free.
+
+## The one real design problem: Cloudflare Access
+
+chat.shellm.net is not just an open port. Per `deploy/DEPLOY.md`, the app
+is auth-free on `127.0.0.1:8080` behind a Cloudflare Tunnel, and **all
+auth lives in Cloudflare Access** (SSO / email OTP). A URLSession client
+can't do that browser login dance. The minimal, standard fix is a
+Cloudflare **service token**:
+
+1. Zero Trust dashboard → create a service token (yields a Client ID +
+   Secret pair).
+2. Add a "Service Auth" policy on the chat.shellm.net Access application
+   allowing that token.
+3. The app sends two static headers on every request:
+   `CF-Access-Client-Id` and `CF-Access-Client-Secret`.
+
+That's two optional text fields in the app's settings, left empty when
+pointing at localhost. No OAuth flows. The secret should live in Keychain
+rather than UserDefaults (~10 extra lines).
+
+## App shape
+
+**SwiftUI `MenuBarExtra`** (macOS 13+), window style — a chat panel that
+drops down from the menu bar. Minimal form factor for "talk to my agent":
+always reachable, no dock presence, no window management, and only ~4
+lines more than a plain window. Zero third-party dependencies.
+
+One Swift file, ~350 lines, five pieces:
+
+1. **`Config`** — `@AppStorage`-backed: server URL, your name
+   (`from_name`, the `.chatrc default_send_from` analog), identity id
+   (blank = first from `/api/identities`), CF token pair. A picker for
+   the known servers (`http://localhost:8080`, `https://chat.shellm.net`).
+2. **`API`** (~60 lines) — two `Codable` structs mirroring the JSON
+   above, `fetchChat()` and `send()` with async/await, CF headers
+   injected when configured.
+3. **`ChatModel: ObservableObject`** (~80 lines) — a poll `Task` loop;
+   re-publish only when the message list actually changed; derives
+   `agentThinking` from unanswered outcomes; sets the live dot from the
+   response's `live` field.
+4. **`ChatView`** (~120 lines) — scrollback of sender-colored lines
+   (agent green, you blue, mirroring the TUI), auto-scroll to bottom,
+   `TextField.onSubmit` to send, red/green live dot in the header.
+5. **Notifications** (~25 lines, the only "feature") —
+   `UNUserNotificationCenter` local notification when a new agent→you
+   message lands while the panel is closed. Replaces the PWA's web-push
+   without touching the server's push endpoints.
+
+## Build without Xcode
+
+A `Makefile` + `Info.plist` producing `Shellm.app` via `swiftc` — no
+`.xcodeproj`, keeping it genuinely minimal and matching the repo's style
+(`tui/` gets a native sibling: `macos/`).
+
+Layout:
+
+```
+macos/Shellm/
+  main.swift      # the whole app
+  Info.plist
+  Makefile        # `make app` → Shellm.app
+```
+
+ATS note: `https://chat.shellm.net` and `http://localhost` both pass App
+Transport Security defaults; only a non-localhost plain-http server would
+need an `Info.plist` exception, so none is included.
+
+## Deliberately left out
+
+Sub-trajectory browsing, mindlog, thinker controls, message pagination,
+multiple simultaneous conversations — all exist in the API but the PWA
+already covers them. This client is send + read + notify.
+
+The zero-code baseline it competes with: Safari's File → Add to Dock on
+chat.shellm.net gives a dock-icon web app with working push. The native
+client's actual wins are localhost support, service-token auth (no cookie
+expiry re-logins), and the menu-bar form factor.


### PR DESCRIPTION
Design doc for a minimal native macOS client to chat with a shellm identity, running locally or on a remote box (chat.shellm.net).

Key points:
- **No server changes** — reuses the existing `shellm-web` chat API (`GET/POST /api/identities/{id}/chat`), same as the phone PWA, with 2s polling and the `outcomes` map as a truthful typing indicator.
- **Cloudflare Access** is the one real design problem for a native client: solved with a Zero Trust service token sent as `CF-Access-Client-Id`/`CF-Access-Client-Secret` headers; empty for localhost.
- **App shape**: SwiftUI `MenuBarExtra`, one Swift file (~350 lines), zero dependencies, local notifications instead of web push.
- **Build**: `swiftc` + Makefile + Info.plist under `macos/Shellm/` — no Xcode project, mirroring how `tui/` lives in the repo.
- Explicit non-goals (mindlog, thinker controls, etc. stay in the PWA) and an honest comparison against the zero-code Safari Add-to-Dock baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)