### PR TITLE
Verify shellm tools aren't shadowed by system binaries on PATH

### DIFF
--- a/bin/thinkers
+++ b/bin/thinkers
@@ -848,12 +848,45 @@ _append_wake_gap_note() {
         | traj append --traj_dir "$TRAJ_DIR" "${traj_file#"$TRAJ_DIR"/}" >/dev/null 2>&1 || true
 }
 
+# Guard against shadowed tools. The shellm CLIs live together next to this
+# script, so our own resolved location is the canonical bin dir. Prepend it (so
+# our tools beat same-named system binaries — macOS ships /usr/sbin/chat,
+# /usr/bin/view, ...), then VERIFY each critical tool on PATH actually resolves
+# to OUR copy. Fail loudly rather than silently running the wrong program — the
+# /usr/sbin/chat shadow silently broke every chat reply on 2026-08-14.
+_ensure_shellm_bins() {
+    local self bindir
+    self=$(command -v thinkers 2>/dev/null) || self="$0"
+    bindir=$(cd "$(dirname "$(realpath "$self" 2>/dev/null)")" 2>/dev/null && pwd) || return 0
+
+    # Prepend our dir unless it's already first (a later copy still loses to a
+    # system dir, so presence isn't enough — it must be first).
+    [[ "$PATH" == "$bindir:"* ]] || { PATH="$bindir:$PATH"; export PATH; }
+
+    local tool resolved want bad=()
+    for tool in chat traj llm mem context skills recap focus identity thinkers; do
+        [[ -x "$bindir/$tool" ]] || continue          # only tools we actually ship
+        resolved=$(command -v "$tool" 2>/dev/null) || resolved=""
+        want=$(realpath "$bindir/$tool" 2>/dev/null)
+        if [[ -z "$resolved" || "$(realpath "$resolved" 2>/dev/null)" != "$want" ]]; then
+            bad+=("$tool -> ${resolved:-<not found on PATH>}")
+        fi
+    done
+    if (( ${#bad[@]} )); then
+        printf 'thinkers: error: these tools on PATH are NOT the shellm ones next to this command (%s):\n' "$bindir" >&2
+        printf '  %s\n' "${bad[@]}" >&2
+        printf 'A system binary is shadowing them. Put %s ahead of system dirs (e.g. /usr/sbin) in PATH.\n' "$bindir" >&2
+        exit 1
+    fi
+}
+
 # ---------------------------------------------------------------------------
 # Subcommands
 # ---------------------------------------------------------------------------
 
 cmd_start() {
     _require_env
+    _ensure_shellm_bins
 
     # Parse start-specific flags
     while [[ $# -gt 0 ]]; do

--- a/install.sh
+++ b/install.sh
@@ -208,9 +208,32 @@ _install_thinkers() {
 
 # PATH: make sure the tools are reachable — for this process (so --init can
 # chain into shellm-init) and, with consent, for future shells.
+# A same-named system binary in a dir BEFORE $PREFIX silently shadows the tool
+# we just installed (macOS ships /usr/sbin/chat, /usr/bin/view). Verify each
+# installed tool actually resolves to OUR copy; warn if not. Install still
+# succeeded — PATH order is the user's to fix — so this warns, never fails.
+_warn_shadowed() {
+    local tool resolved shadowed=()
+    for tool in "${TOOLS[@]}"; do
+        [[ -x "$PREFIX/$tool" ]] || continue
+        resolved=$(command -v "$tool" 2>/dev/null) || resolved=""
+        if [[ -n "$resolved" ]] \
+           && [[ "$(realpath "$resolved" 2>/dev/null)" != "$(realpath "$PREFIX/$tool" 2>/dev/null)" ]]; then
+            shadowed+=("$tool → $resolved")
+        fi
+    done
+    [[ "${#shadowed[@]}" -eq 0 ]] && return 0
+    echo
+    echo "Warning: $PREFIX is on your PATH but behind a dir with same-named"
+    echo "binaries, so these tools are shadowed by other programs:"
+    printf '  %s\n' "${shadowed[@]}"
+    echo "Move $PREFIX ahead of the system dirs (e.g. /usr/sbin) in your shell rc:"
+    echo "  export PATH=\"$PREFIX:\$PATH\""
+}
+
 _ensure_path() {
     case ":$PATH:" in
-        *":$PREFIX:"*) return 0 ;;
+        *":$PREFIX:"*) _warn_shadowed; return 0 ;;
     esac
     export PATH="$PREFIX:$PATH"
     local path_line="export PATH=\"$PREFIX:\$PATH\"" rc="" reply=""


### PR DESCRIPTION
## Why
macOS ships `/usr/sbin/chat` (the PPP tool) and `/usr/bin/view` (vim). When a system dir precedes the shellm bin dir on PATH, `chat`/`view` silently resolve to the *wrong* program. On 2026-08-14 this made every monolith/responder `chat reply` fail silently — bobby *saw* the messages (the responder fired) but no reply ever went out, because `chat reply` was invoking `/usr/sbin/chat`.

Checking PATH *ordering* is fragile; instead, both layers here **resolve each tool and compare it to the copy we expect** (`realpath`).

## Two complementary layers
- **`thinkers` (runtime guard):** at `thinkers start`, prepend our own bin dir (so our tools win over earlier system dirs), then verify each critical tool on PATH `realpath`s to our copy — `exit 1` with a clear error if one is still shadowed. Self-heals the dispatcher and every step process it spawns. *(Verified live: bobby started under the broken PATH order and self-healed — replies delivered.)*
- **`install.sh` (install-time warning):** when `$PREFIX` is already on PATH, verify each installed tool resolves to the copy just installed; **warn** (install succeeded — PATH order is the user's to fix), naming each shadow and how to reorder PATH. This covers contexts the runtime guard can't: your interactive shell, the chat TUI, the web control plane, cron.

## Testing
- `bash -n` clean on both.
- Shadow detection unit-tested: a system-style `chat` earlier in PATH is flagged; correct order passes.
- The `thinkers` guard exercised end-to-end against the real `/usr/sbin/chat` shadow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)