### PR TITLE
Monolith scheduled-wake backoff + macOS dispatcher fix + progressive-memory design

### DIFF
--- a/bin/thinkers
+++ b/bin/thinkers
@@ -1248,6 +1248,19 @@ cmd_stop() {
         die "stop: refusing — this process would die with the $IDENTITY_NAME dispatcher it is asking to stop, leaving the mind down with nothing to restart it. To restart your own mind safely (e.g. to pick up a new thinker): sudo shellm-thinkersctl restart $IDENTITY_NAME — systemd completes the restart even after this step dies with the old dispatcher. To stop another identity: bash -c 'source <identities>/<name>/activate && thinkers stop'. To really stop your own mind, pass --self."
     fi
 
+    # Kill the monolith spontaneity timer (design/monolith_backoff.md) when
+    # stopping the monolith or all thinkers — otherwise a detached sleeper
+    # survives and posts a stale monolith-wake into whatever runs next. The
+    # timer's dispatcher-token guard makes a leaked one harmless, but reap it.
+    if [[ ${#names[@]} -eq 0 ]] || printf '%s\n' "${names[@]}" | grep -qx monolith; then
+        if [[ -f "$run_dir/monolith_timer.pid" ]]; then
+            local _mtimer
+            _mtimer=$(cat "$run_dir/monolith_timer.pid" 2>/dev/null) || _mtimer=""
+            [[ -n "$_mtimer" ]] && { kill -TERM -"$_mtimer" 2>/dev/null || _kill_tree "$_mtimer" TERM || true; }
+            rm -f "$run_dir/monolith_timer.pid"
+        fi
+    fi
+
     # Default is a drain stop: deactivate (no new triggers), let in-flight
     # steps finish, escalate to kill only after --drain-timeout. --force
     # kills in-flight steps immediately (the old behavior).

--- a/bin/thinkers
+++ b/bin/thinkers
@@ -619,6 +619,8 @@ _start_dispatcher() {
             _respawn_dead_feeders
         }
         _last_tick=$SECONDS
+        _spin_mark=$SECONDS
+        _spin_count=0
 
         # Main dispatch loop: read tagged step lines from the fifo with a
         # 1s timeout so the loop keeps ticking while the trajectory is
@@ -643,15 +645,30 @@ _start_dispatcher() {
                 _last_tick=$SECONDS
                 _tick
             fi
-            if (( _read_rc > 128 )); then
-                # Timeout — keep any partial line for the next pass
+            if (( _read_rc != 0 )); then
+                # `read -t` timeout return code is bash-version-specific: bash
+                # >=4 returns >128, but macOS's /bin/bash 3.2 returns 1. fd 3
+                # holds the fifo's OWN write end (exec 3<> above), so a genuine
+                # EOF is impossible — every non-zero read is a timeout. (The old
+                # `>128`-only check misread bash 3.2's rc=1 timeout as a fatal
+                # "fifo read failed" and the dispatcher died on its first idle
+                # second on macOS.) Keep any partial line and loop.
+                #
+                # Spin guard: a real -t 1 timeout takes ~1s, so at most a few
+                # per second. If non-zero reads pile up WITHIN one second the fd
+                # is actually broken (returning instantly, not timing out) —
+                # exit rather than hot-loop.
+                if (( SECONDS == _spin_mark )); then
+                    if (( ++_spin_count > 50 )); then
+                        printf '%s [dispatcher] fifo read failing fast (rc=%s) — exiting\n' "$(date -u +%FT%TZ)" "$_read_rc" >&2
+                        break
+                    fi
+                else
+                    _spin_mark=$SECONDS
+                    _spin_count=0
+                fi
                 _read_buf="${_read_buf}${_line}"
                 continue
-            elif (( _read_rc != 0 )); then
-                # Real read error/EOF — cannot happen while fd 3 holds the
-                # write end; exit like the old EOF path rather than spin.
-                printf '%s [dispatcher] fifo read failed (rc=%s) — exiting\n' "$(date -u +%FT%TZ)" "$_read_rc" >&2
-                break
             fi
             _line="${_read_buf}${_line}"
             _read_buf=""

--- a/design/monolith_backoff.md
+++ b/design/monolith_backoff.md
@@ -1,6 +1,7 @@
 # Monolith idle backoff — spend nothing while nobody's talking
 
-Status: draft (merged)
+Status: implemented (thinkers/monolith/step + subscriptions.jsonl; shipped
+default cap is 300s / 5 min, overridable per-identity via MONOLITH_BACKOFF_CAP)
 Authors: merged from two independent drafts (Claude's and Codex's). Where they
 differed, the choice and its rationale are noted inline.
 Extends: [monolith_thinker.md](monolith_thinker.md) (revises its "Loop liveness
@@ -128,7 +129,7 @@ Configuration:
 |---------|---------|---------|
 | `MONOLITH_BACKOFF_BASE` | `5` | the first *non-zero* delay, seconds (level 1) |
 | `MONOLITH_BACKOFF_FACTOR` | `2` | multiplier applied when stepping to the next level |
-| `MONOLITH_BACKOFF_CAP` | `600` | the slowest steady rate — max delay between spontaneous wakes; adjust freely (e.g. `1800` for 30 min, `3600` for an hour) |
+| `MONOLITH_BACKOFF_CAP` | `300` | the slowest steady rate — max delay between spontaneous wakes; adjust freely (e.g. `600` for 10 min, `1800` for 30 min, `3600` for an hour) |
 | `MONOLITH_BACKOFF_HOLD` | `3` | how many empty wakes to **stay at each rate** before stepping to the next, slower one |
 
 Two properties the schedule must have (this section's requirements):

--- a/design/monolith_thinker.md
+++ b/design/monolith_thinker.md
@@ -1,9 +1,15 @@
 # Monolith thinker
 
-Status: draft
+Status: implemented (runs solo as the mind), with two revisions since this
+draft: (1) chat moved to a dedicated `responder` thinker — the monolith no
+longer subscribes to `message` or runs the fast-reply path described below; an
+inbound chat reaches it as the responder's observation. (2) Loop pacing is now
+the non-blocking scheduled-wake backoff in monolith_backoff.md
+(`trigger_self:false` + a timer), not the in-loop `trigger_self:true` sleep
+described here.
 Replaces (when enabled): the multi-thinker roster (inner_monologue, actor,
 goals_manager, learning, mind_wanderer, values_manager) with a single thinker,
-`monolith`, that runs solo and handles every function — including chat.
+`monolith`, that runs solo and handles every function.
 
 ## Motivation
 

--- a/design/unified_progressive_resolution_memory.md
+++ b/design/unified_progressive_resolution_memory.md
@@ -1,0 +1,260 @@
+Status: draft, as of 2026-08-17.
+
+Related notes:
+
+- [[3. Thinkers Architecture Update - Reconciled Plan]]
+- [[1. shellm thinkers design]]
+- tiered_memory.md (shellm design/ — the episodic pyramid this generalizes)
+- recap.md (shellm design/ — the summarizer this builds on)
+
+## One-sentence plan
+
+Unify all memory types — episodic (trajectory rollups), semantic (goals, beliefs, facts) — into a single progressive-resolution structure where every entry links to both coarser summaries above and finer detail below, and teach the agent a skill for drilling through the levels.
+
+## Diagnosis
+
+Today there are two memory systems that don't know about each other:
+
+1. **`mem`** — semantic, curated. Individual markdown files with frontmatter (id, summary, type, created) and a body. Types include `memory`, `goal`, `belief`, `intention`, `value`. Retrieved by `mem search` (brute-force LLM scan). No internal structure linking entries to each other or to the trajectory.
+
+2. **Tiered rollups** — episodic, automatic. A pyramid of trajectory summaries at geometrically coarsening granularity (tier 1 = 10 steps, tier 2 = 100, tier 3 = 1000). Each rollup carries cited step-ids. Built by `recap`. No connection to semantic memories.
+
+Problems:
+
+- **Semantic memories are flat.** A belief like "meta-yielding thoughts are narration loops" has no link to the episode where it was learned, no finer-grained context, no coarser grouping with related beliefs. It's a leaf with no tree.
+- **Episodic rollups are opaque to the mind.** The staircase assembler puts them in context, but the agent can't navigate them — it can't say "zoom into that period" or "what other rollups mention this theme?" There's no skill for it, and the rollup entries don't link to their neighbors or to semantic memories that emerged from them.
+- **No cross-references.** A goal formed during episode 47 doesn't point to episode 47. A tier-2 rollup covering a week where a belief was challenged doesn't point to the belief. The two systems are parallel columns with no bridges.
+- **`mem search` is O(n) brute force.** Every query concatenates every memory and asks the LLM to find matches. No index, no hierarchy, no way to narrow before reading.
+
+## Insight: progressive resolution is already there, three times
+
+The pattern of "compressed pointer → medium summary → full detail" already appears in three places:
+
+**1. `mem` files themselves:**
+
+```
+filename                          → pointer    (1 token)
+frontmatter summary               → digest     (~10 tokens)
+markdown body                     → full text  (~100 tokens)
+```
+
+**2. Tiered rollups:**
+
+```
+tier 2 rollup                     → digest of 100 steps  (~50 tokens)
+tier 1 rollup                     → digest of 10 steps   (~50 tokens)
+raw trajectory steps              → full detail           (~10 tokens each)
+```
+
+**3. HNSW / skip lists (the algorithmic analogue):**
+
+```
+layer 2 node  → long-range links  (few, coarse)
+layer 1 node  → medium-range links
+layer 0 node  → all neighbors     (dense, fine)
+```
+
+The common shape: each level is a compressed view of the level below, and navigation works by starting coarse and drilling down. The key property HNSW has that we don't: **every node links to nodes at adjacent levels.** Our tiers link down (step-ids) but not up, and our `mem` entries don't link to tiers at all.
+
+## Unified architecture
+
+### The resolution ladder
+
+Every piece of memory — episodic or semantic — lives at a **resolution level** and carries links to both its **children** (finer detail below) and its **parent** (coarser summary above):
+
+```
+Level 3:  life arc          "my first week: bootstrapping identity and exploring tools"
+            ↕
+Level 2:  chapter/theme     "learned to manage narration loops through self-observation"
+            ↕
+Level 1:  episode/entry     "episode 47: discovered meta-yielding pattern"
+            ↕                   ↕
+Level 0:  raw steps         traj steps 470-479  |  belief mem file body
+```
+
+The `↕` arrows are the new thing. Today we have `↓` (rollups cite step-ids) but not `↑` (a step or mem entry doesn't know which rollup covers it).
+
+### Schema: the universal memory entry
+
+Every entry at every level shares a common envelope:
+
+```yaml
+---
+id: a1b2c3d4
+type: episode | belief | goal | intention | value | fact | theme | arc
+level: 1                          # resolution level (0 = raw)
+summary: "one-line digest"
+created: 2026-08-17 14:30:00
+
+# Progressive resolution links
+children:                          # finer detail below
+  - {type: step, id: "step-470"}   # raw traj step
+  - {type: step, id: "step-471"}
+  - {type: mem, id: "f3e2d1c0"}   # another mem entry
+parent:                            # coarser summary above
+  - {type: mem, id: "b4c5d6e7"}   # the theme/chapter that covers this
+
+# Provenance
+source_range: [470, 479]           # traj step range (episodic entries)
+source_traj: "c56dcbdb-root"       # which trajectory
+model: "claude-opus-4-7"
+prompt_version: 1
+---
+
+Full body text here. For episodic entries, this is the rollup summary.
+For semantic entries (beliefs, goals), this is the curated content.
+```
+
+The key additions over today's `mem` format:
+
+- **`level`** — where this entry sits in the resolution hierarchy
+- **`children`** — pointers to finer-grained entries or raw steps
+- **`parent`** — pointer to the coarser entry that subsumes this one
+- **`source_range`** / **`source_traj`** — provenance back to the raw log (even for semantic entries: "this belief was formed during steps 470-479")
+
+### How the three existing patterns map
+
+**`mem` files become level-1 entries** (or level-2 for broad goals/themes). Their filename is still the pointer (level "0.5"), their frontmatter summary is the digest, their body is the full text. The new fields (`children`, `parent`, `level`) are additive — existing mem files without them still work, they're just unlinked leaves.
+
+**Tier-1 rollups become level-1 episodic entries.** Same content, but now each rollup also carries a `parent` link to its tier-2 rollup. Tier-2 rollups are level-2 entries with `parent` links to tier-3, and so on.
+
+**The semantic-episodic bridge:** when `mem add --type belief` is called during episode 47, the new belief entry's `children` includes the step-ids from that episode, and episode 47's entry gains a `children` link to the belief. A goal formed across episodes 40-50 links to all of them; those episodes link back to it.
+
+### Navigation: the drill-down skill
+
+A new skill (`progressive-recall` or extend `recall`) teaches the agent to navigate the hierarchy:
+
+```
+Given a query, start at the coarsest level:
+1. Scan level-N summaries (few, broad) — find the 1-3 most relevant
+2. Follow their `children` links to level N-1 entries
+3. Scan those summaries — find the most relevant
+4. Repeat until reaching raw steps or mem file bodies
+5. Pull the relevant raw content into context
+```
+
+This is HNSW's search algorithm adapted to memory: start with long-range coarse pointers, progressively narrow, never scan everything at any level. Cost is O(log N) entries examined, not O(N).
+
+The skill file:
+
+```markdown
+# progressive-recall
+
+When you need to recall something from your past or find a relevant memory:
+
+1. Start broad: `mem list --level 3` (or highest available) — scan arc/theme summaries
+2. Drill: for the relevant entry, `mem children <id>` — see its finer-grained sub-entries
+3. Repeat: `mem children <id>` on the most relevant child until you reach raw steps or full mem bodies
+4. Expand: `traj cat <step-range>` to pull raw trajectory steps into context
+
+At each level, you're reading ~10 summaries, not the whole memory.
+Never scan all memories at level 0 — always start high and drill down.
+```
+
+### Linking mechanics
+
+**Downlinks (children) are created at write time.** When `recap` seals a tier-1 block, it already records the step-ids — these become `children`. When `mem add` is called, the current traj context (last N step-ids) becomes the new entry's `children.source_range`.
+
+**Uplinks (parent) are created when the parent is sealed.** When a tier-2 rollup is created from 10 tier-1 rollups, each tier-1 rollup's entry gains a `parent` link to the new tier-2 entry. Same for semantic entries: when the `learn` route creates a theme mem that groups three beliefs, those beliefs gain `parent` links.
+
+**Cross-links (semantic ↔ episodic) are created by the learning thinker.** When a belief is formed during an episode, the `learn` route:
+1. Creates the belief mem with `children` pointing to the source steps
+2. Patches the covering episode's entry to add the belief as a child
+
+This is the bridge between the two columns.
+
+### Relationship to HNSW specifically
+
+HNSW has three properties we're borrowing:
+
+1. **Hierarchical layers** — coarse at top, fine at bottom. We have this (tiers).
+2. **Navigable links at each layer** — every node links to neighbors at the same level AND to its counterpart one level up and down. We're adding the up/down links; same-level links (related beliefs, adjacent episodes) are a later refinement.
+3. **Greedy search from top** — enter at the coarsest layer, follow the best link, descend, repeat. The drill-down skill implements this.
+
+The one HNSW property we don't need: approximate nearest-neighbor guarantees. Our "queries" are natural language interpreted by an LLM at each level, not vector distances. The hierarchy just bounds how many entries the LLM has to scan at each step.
+
+## Relationship to skip lists
+
+Skip lists are the simpler 1D analogue: a sorted linked list with express lanes. Every Nth element appears in the express lane; every N²th in the super-express lane. Search starts at the top lane (few stops, big jumps) and drops down when it overshoots.
+
+Our time-ordered trajectory is exactly a sorted list. The tiered rollups are exactly the express lanes. The addition is making `mem` entries — which aren't time-ordered — also participate in the same hierarchy by linking them to their temporal context (the episode where they were created or are relevant).
+
+## Implementation plan
+
+### Phase 1: Add resolution links to mem
+
+Extend `mem add` to accept and store `level`, `children`, `parent` fields in frontmatter. Default `level` to 1. When called inside a thinker context (TRAJ_ID is set), auto-populate `children` with recent step-ids and `source_range`/`source_traj` from the current traj position.
+
+Add `mem children <id>` — prints the children of an entry (resolving step-ids via `traj cat` and mem-ids via `mem show`).
+
+Add `mem parent <id>` — prints the parent entry.
+
+Backward compatible: existing mem files without these fields continue to work as unlinked level-1 entries.
+
+### Phase 2: Bridge rollups ↔ mem
+
+When `recap` seals a tier-1 block, check if any `mem add` calls happened during that step range (by scanning mem files' `source_range`). If so, add those mem ids to the rollup's entry as children, and patch those mem files' `parent` field to point to the rollup.
+
+When the `learn` or `goals` monolith route creates a mem entry, the entry is linked to the episode covering its `source_range`.
+
+### Phase 3: Drill-down skill
+
+Create `skills/progressive-recall/SKILL.md` teaching the agent the top-down navigation pattern. Wire `mem children` and `mem parent` as the primitive operations.
+
+### Phase 4: Replace `mem search` with hierarchical scan
+
+Today `mem search` concatenates all memories and LLM-scans. Replace with: scan level-N summaries → drill relevant branches → return matches. Same interface, logarithmic cost.
+
+### Phase 5: Cross-links (same-level neighbors)
+
+Add optional `related` field to mem entries — links to other entries at the same level that are thematically connected. The `learn` route populates these when it notices recurring themes across episodes. This completes the HNSW analogy: each node has links up (parent), down (children), and sideways (related).
+
+## Design consequences
+
+### The mem file IS the node
+
+No separate index database. The mem file's frontmatter is the node metadata (id, level, links); the body is the content. `mem list --level N` is just `ls + grep level: N` in the frontmatter. The filesystem is the graph store.
+
+### Rollup entries become mem entries
+
+Today rollups live in `recap/` as JSON. In unified mode, tier-1+ rollups are also written as mem files (type: `episode`) with the standard envelope. This means `mem search`, `mem children`, `mem parent` all work on episodes too — one tool, one namespace.
+
+The JSON cache in `recap/` remains as the build cache; the mem file is the durable, navigable copy.
+
+### Backward compatibility
+
+Existing mem files are unlinked level-1 entries. Everything works; they just can't be drilled into or navigated hierarchically until someone (the `learn` route, a migration script, the agent itself) adds the link fields.
+
+### Cost model
+
+Drill-down: ~log_10(N) LLM calls to find a specific memory, each scanning ~10 summaries. For 10,000 memories: ~4 calls. For 1,000,000: ~6 calls.
+
+Building links: marginal cost at write time (a few field additions). No retroactive reindexing needed for new entries.
+
+## The 1:10:100 ratio in practice
+
+The three-level pattern you noticed in mem files is the natural fanout:
+
+```
+  1 filename           → picks this entry from thousands    (~1 token)
+ 10 frontmatter words  → enough to decide relevance         (~10 tokens)
+100 body words         → enough to act on the content       (~100 tokens)
+```
+
+This maps directly to the tiered rollup ratio:
+
+```
+  1 tier-2 rollup      → covers 100 raw steps              (~50 tokens)
+ 10 tier-1 rollups     → cover the same 100 steps at 10x   (~500 tokens)
+100 raw steps          → full detail                        (~1000 tokens)
+```
+
+The ~10x compression at each level is what makes the hierarchy work: at each drill-down step, you're expanding ~10x in detail while reading ~10 entries. The total work to reach any point is ~10 × log_10(N) entries scanned.
+
+## Open questions
+
+1. **Fanout for semantic memories.** Episodic rollups have a natural fanout of 10 (10 steps → 1 rollup). Semantic memories don't — how many beliefs cluster into a theme? Probably variable. The drill-down skill handles variable fanout fine; the question is whether the `learn` route should explicitly target ~10 children per theme.
+
+2. **When to create level-2+ semantic entries.** Tier-2 episodic rollups are created automatically when 10 tier-1 blocks seal. Semantic themes/arcs need an active decision ("these 8 beliefs form a pattern"). The `values_manager` or `goals_manager` thinker is the natural home; the trigger is "accumulated N unparented entries of this type."
+
+3. **Same-level links: explicit or emergent?** Phase 5 adds `related` links. An alternative: don't store them, let the drill-down skill discover relatedness by scanning siblings under a shared parent. Simpler, but loses the HNSW "shortcut" property.

--- a/thinkers/monolith/step
+++ b/thinkers/monolith/step
@@ -8,13 +8,19 @@ set -euo pipefail
 # model picks one function and carries it out in the same run.
 #
 # Chat replies are NOT the monolith's job — a dedicated `responder` thinker owns
-# immediate replies (see thinkers/responder/step). The monolith no longer
-# subscribes to `message`; it reasons over the conversation as context and can
-# `act` on any follow-up work a message needs.
+# immediate replies (see thinkers/responder/step). The monolith reasons over the
+# conversation as context and can `act` on any follow-up work a message needs.
 #
-# Because it subscribes with trigger_self, the loop is perpetual: the router
-# path is guaranteed to append at least one step per wakeup (liveness net at
-# the end), so the dispatcher always re-fires. See design/monolith_thinker.md.
+# PACING (see design/monolith_backoff.md). The monolith subscribes with
+# trigger_self:FALSE, so its own steps never re-fire it — that removes the
+# uncontrolled self-loop and the old in-step `sleep`. Two things drive it now:
+#   1. Reactivity — an external step (the responder's observation for a chat, or
+#      an external action/merge) fires it immediately; that is engagement.
+#   2. Spontaneity — a `monolith-wake` step posted by a detached timer this step
+#      arms on its way out (arm_wake, via an EXIT trap). The delay backs off
+#      exponentially to a cap while nothing happens, and is 0 (think again at
+#      once) while engaged or producing real work. The timer — NOT an appended
+#      step — is the liveness mechanism, so the trap must always arm.
 
 THINKER_NAME="monolith"
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
@@ -27,79 +33,136 @@ _require_env
 THINK_MODEL="${THINK_MODEL:-${SHELLM_MODEL:-claude-opus-4-7}}"
 THINK_CONTEXT_TAIL="${THINK_CONTEXT_TAIL:-20}"
 
-# Idle backoff bounds (seconds). State persists in run_dir across wakeups.
-IDLE_BACKOFF_START="${MONOLITH_IDLE_BACKOFF:-5}"
-IDLE_BACKOFF_MAX="${MONOLITH_IDLE_BACKOFF_MAX:-60}"
-
 run_dir="$IDENTITY_DIR/workdir"
 mkdir -p "$run_dir"
-backoff_file="$run_dir/monolith_idle_backoff"
 
-# Read the triggering step from stdin (context still comes from the traj).
+# ---------------------------------------------------------------------------
+# Backoff config + state (level-based; see design/monolith_backoff.md)
+# ---------------------------------------------------------------------------
+# delay(0)      = 0                              # engaged / working: no pause
+# delay(n >= 1) = min(BASE * FACTOR^(n-1), CAP)  # 5, 10, 20, … up to CAP
+# HOLD: stay at each level for HOLD empty wakes before stepping to the next.
+BACKOFF_BASE="${MONOLITH_BACKOFF_BASE:-5}"
+BACKOFF_FACTOR="${MONOLITH_BACKOFF_FACTOR:-2}"
+BACKOFF_CAP="${MONOLITH_BACKOFF_CAP:-300}"
+BACKOFF_HOLD="${MONOLITH_BACKOFF_HOLD:-3}"
+
+state_dir="$IDENTITY_DIR/run"
+mkdir -p "$state_dir"
+state_file="$state_dir/monolith_backoff_state.json"
+timer_pid_file="$state_dir/monolith_timer.pid"
+root_traj="${ROOT_TRAJ_ID:-$TRAJ_ID}"
+
+# delay in seconds for a backoff level.
+_delay_for_level() {
+    local lvl="$1" d="$BACKOFF_BASE" i=1
+    (( lvl <= 0 )) && { printf '0'; return; }
+    while (( i < lvl )); do
+        d=$(( d * BACKOFF_FACTOR ))
+        (( d >= BACKOFF_CAP )) && { d="$BACKOFF_CAP"; break; }
+        i=$(( i + 1 ))
+    done
+    (( d > BACKOFF_CAP )) && d="$BACKOFF_CAP"
+    printf '%s' "$d"
+}
+
+# Load persisted backoff state (level + dwell counter).
+level=0
+ticks_at_level=0
+if [[ -f "$state_file" ]]; then
+    level=$(jq -r '.level // 0' "$state_file" 2>/dev/null) || level=0
+    ticks_at_level=$(jq -r '.ticks_at_level // 0' "$state_file" 2>/dev/null) || ticks_at_level=0
+    [[ "$level" =~ ^[0-9]+$ ]] || level=0
+    [[ "$ticks_at_level" =~ ^[0-9]+$ ]] || ticks_at_level=0
+fi
+
+_save_state() {
+    local tmp
+    tmp=$(mktemp) || return 0
+    if jq -nc --argjson l "$level" --argjson t "$ticks_at_level" \
+        '{level:$l, ticks_at_level:$t}' > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$state_file"
+    else
+        rm -f "$tmp"
+    fi
+}
+
+# arm_wake DELAY — singleton timer. Kills any prior timer, then detaches a
+# process that sleeps DELAY and appends ONE monolith-wake step — but only if the
+# dispatcher that armed it still owns the runtime (token guard closes the
+# stop/start race). No dispatcher token → don't arm.
+arm_wake() {
+    local delay="$1"
+    [[ -f "$state_dir/dispatcher.token" ]] || return 0
+    local token
+    token=$(cat "$state_dir/dispatcher.token" 2>/dev/null) || return 0
+    [[ -n "$token" ]] || return 0
+    if [[ -f "$timer_pid_file" ]]; then
+        local _old
+        _old=$(cat "$timer_pid_file" 2>/dev/null) || _old=""
+        # Kill the whole timer group (setsid → pgid == pid) so no stale sleeper
+        # survives to post a spurious wake.
+        [[ -n "$_old" ]] && { kill -TERM -"$_old" 2>/dev/null || kill -TERM "$_old" 2>/dev/null || true; }
+    fi
+    setsid bash -c '
+        sleep "$1" || exit 0
+        [[ "$(cat "$2/dispatcher.token" 2>/dev/null)" == "$3" ]] || exit 0
+        traj append "$4" --field type=monolith-wake --field source=monolith-timer --field content=wake >/dev/null 2>&1
+    ' _ "$delay" "$state_dir" "$token" "$root_traj" &
+    echo $! > "$timer_pid_file"
+}
+
+# ---------------------------------------------------------------------------
+# Parse the triggering step
+# ---------------------------------------------------------------------------
 step_json=$(cat)
 [[ -z "$step_json" ]] && exit 0
 trigger_type=$(printf '%s' "$step_json" | jq -r '.type // empty' 2>/dev/null) || true
-trigger_content=$(printf '%s' "$step_json" | jq -r '.content // empty' 2>/dev/null) || true
+trigger_source=$(printf '%s' "$step_json" | jq -r '.source // empty' 2>/dev/null) || true
 trigger_step_id=$(printf '%s' "$step_json" | jq -r '.step_id // empty' 2>/dev/null) || true
 
 # ---------------------------------------------------------------------------
-# Idle backoff pacing
+# EXIT-trap liveness: arm the next timer on the way out. next_delay stays ""
+# for no-op wakes (leave the running timer untouched); it is set to 0 (arm an
+# immediate wake — keep thinking) or delay(level) (rest) by the handlers below.
+# The trap fires on EVERY exit, including crash/refusal paths, so the loop
+# cannot die by "appending nothing" the way trigger_self used to guard against.
 # ---------------------------------------------------------------------------
-# When we are re-fired by our OWN idle step, back off (doubling, capped) so the
-# solo loop does not burn tokens at rest. Any non-idle trigger resets the
-# backoff, so a new message or external action wakes us at full speed.
-#
-# The backoff is PRE-EMPTIBLE: we sleep in 1s slices and watch the pending
-# dir for a queued external trigger (the dispatcher queues one the moment it
-# arrives while we are busy — and sleeping counts as busy). If one is waiting,
-# this rest wakeup is moot: exit so the dispatcher fires the queued trigger
-# now, instead of the sender waiting out the remaining sleep PLUS a router run.
-# A stale pending file at worst forfeits one idle wakeup; the dispatcher's
-# liveness watchdog is the net.
-#
-# We watch message/action/observation. Since we no longer subscribe to
-# `message`, an inbound chat reaches us as the responder's *observation*
-# ("Replied to …" / "Chose not to reply …") — that is the signal that wakes
-# us on a chat, so it MUST be in the watch set or the mind sleeps through
-# every conversation until the backoff cap elapses.
-if [[ "$trigger_type" == "idle" ]]; then
-    backoff=$(cat "$backoff_file" 2>/dev/null) || backoff="$IDLE_BACKOFF_START"
-    [[ "$backoff" =~ ^[0-9]+$ ]] || backoff="$IDLE_BACKOFF_START"
-    printf '  idle — backing off %ss\n' "$backoff" >&2
-    pending_dir="$IDENTITY_DIR/run/pending"
-    slept=0
-    while (( slept < backoff )); do
-        for _pend in "$pending_dir/$THINKER_NAME".message.* "$pending_dir/$THINKER_NAME".action.* "$pending_dir/$THINKER_NAME".observation.*; do
-            if [[ -f "$_pend" ]]; then
-                printf '  backoff pre-empted after %ss (queued trigger waiting)\n' "$slept" >&2
-                exit 0
-            fi
-        done
-        sleep 1
-        slept=$(( slept + 1 ))
-    done
-    next=$(( backoff * 2 ))
-    (( next > IDLE_BACKOFF_MAX )) && next="$IDLE_BACKOFF_MAX"
-    printf '%s' "$next" > "$backoff_file"
-else
-    printf '%s' "$IDLE_BACKOFF_START" > "$backoff_file"
-fi
+next_delay=""
+trap '[[ -n "$next_delay" ]] && arm_wake "$next_delay"' EXIT
+
+# Classify the wake. With trigger_self:false the dispatcher already filters our
+# own steps, so these are all external — but stay defensive.
+case "$trigger_type" in
+    message)
+        # We do not subscribe to message (responder owns chat). Defensive no-op;
+        # leave the running timer alone.
+        exit 0
+        ;;
+    observation|action|merge)
+        if [[ "$trigger_source" == "$THINKER_NAME" ]]; then
+            exit 0   # our own step — should not arrive; no-op, leave timer
+        fi
+        wake_mode="reactive"     # an external event — engage
+        ;;
+    monolith-wake)
+        wake_mode="spontaneous"  # scheduled self-check — classify by work done
+        ;;
+    *)
+        # idle / manual-trigger / initial start wake / watchdog / unknown: treat
+        # as a spontaneity/bootstrap wake so the timer loop (re)starts from here.
+        wake_mode="spontaneous"
+        ;;
+esac
+
+# Liveness fallback: from here on we WILL run, so guarantee the trap arms a
+# timer even if this run dies early under `set -e` (arming the timer, not an
+# appended step, is what keeps the trigger_self:false loop alive). The proper
+# decision at the end overrides next_delay before a clean exit.
+next_delay=$(_delay_for_level "$level")
 
 # ---------------------------------------------------------------------------
-# (a) CHAT is the responder thinker's job — the monolith never replies.
-# ---------------------------------------------------------------------------
-# A dedicated `responder` thinker owns immediate chat replies (see
-# thinkers/responder/step). The monolith must not reply too, or the two race
-# to double-reply. We no longer subscribe to `message`; this guard is just
-# defensive. A genuine inbound message still reaches the mind — the responder's
-# reply/observation re-fires us — and the router can then `act` on any real
-# follow-up work the message needs.
-if [[ "$trigger_type" == "message" ]]; then
-    exit 0
-fi
-
-# ---------------------------------------------------------------------------
-# (b) ROUTER path — one agentic run over the function menu
+# ROUTER path — one agentic run over the function menu
 # ---------------------------------------------------------------------------
 system_prompt=$(_build_system_prompt)
 
@@ -161,38 +224,32 @@ $think_prompt
 
 Choose ONE function for this wakeup and carry it out now."
 
-# Liveness accounting. We must know whether the run appended a step that will
-# RE-TRIGGER us — i.e. one of our subscribed types. shellm always appends its
-# own machinery steps (prompt, shellm-run, ...) even when the model produces
-# nothing useful, and those are NOT subscribed, so a naive "did the last
-# step_id change?" check is fooled by them and the self-trigger loop dies
-# silently. Track the last SUBSCRIBED-type step id instead.
-# -R reads each line as a raw STRING so fromjson can parse it and corrupt
-# lines are skipped (matches _recent_stream). Without -R, jq parses the line
-# as JSON itself and fromjson then fails on every object, silently yielding
-# empty — which would make the net fire on every wakeup.
-_last_live_id() {
-    traj cat "${ROOT_TRAJ_ID:-$TRAJ_ID}" --raw 2>/dev/null \
+# Work probe: compare the last REAL-WORK step id before/after the run. Real work
+# is thought/action/observation/merge/message (NOT idle — a fallback idle is not
+# progress). Drives the backoff classification below.
+# -R reads each line as a raw STRING so fromjson can parse it and corrupt lines
+# are skipped (matches _recent_stream). Without -R, jq parses the line as JSON
+# itself and fromjson then fails on every object, silently yielding empty.
+_last_work_id() {
+    traj cat "$root_traj" --raw 2>/dev/null \
         | jq -Rr 'fromjson? // empty
             | select(.type == "thought" or .type == "action" or .type == "observation"
-                     or .type == "merge" or .type == "message" or .type == "idle")
+                     or .type == "merge" or .type == "message")
             | .step_id // empty' 2>/dev/null \
         | tail -n 1
 }
-before_last=""
+before_work=""
 if traj exists 2>/dev/null; then
-    before_last=$(_last_live_id) || before_last=""
+    before_work=$(_last_work_id) || before_work=""
 fi
 
-# shellm writes its run header's step_id here, so the fallback idle can carry
-# run_id and the timeline can pair it with the run that went quiet. Exact even
-# when concurrent runs interleave in the root trajectory; empty file means the
-# run died before appending its header.
+# shellm writes its run header's step_id here, so a fallback idle can carry
+# run_id and the timeline can pair it with the run that went quiet.
 run_id_file=$(mktemp)
 
 # One shellm agentic run (writes to the root trajectory). Model via --model so
 # it cannot be shadowed by env/.env layers (see design/model-resolution.md).
-printf '  routing (%s)...\n' "${trigger_type:-none}" >&2
+printf '  routing (%s / %s)...\n' "${trigger_type:-none}" "$wake_mode" >&2
 run_rc=0
 run_response=$(SHELLM_NO_BANNER=1 \
     SHELLM_TRIGGER_STEP_ID="$trigger_step_id" \
@@ -201,20 +258,18 @@ run_response=$(SHELLM_NO_BANNER=1 \
     "${shellm_flags[@]}" \
     "$route_prompt") || run_rc=$?
 
-# Liveness net: the loop is perpetual only if every wakeup appends a step of a
-# subscribed type (one that re-fires us). If the agentic run produced only
-# machinery steps or nothing (crash, refusal, empty run), emit a fallback idle
-# step so trigger_self re-fires and the mind does not go dark.
-after_last=""
+after_work=""
 if traj exists 2>/dev/null; then
-    after_last=$(_last_live_id) || after_last=""
+    after_work=$(_last_work_id) || after_work=""
 fi
+did_work=0
+[[ "$after_work" != "$before_work" ]] && did_work=1
 
-if [[ "$after_last" == "$before_last" ]]; then
-    printf '  run appended nothing (rc=%s) — emitting fallback idle to keep the loop alive\n' "$run_rc" >&2
-    [[ "$run_rc" -ne 0 ]] && sleep 1   # brief backoff so a failing run does not tight-loop
-    # Stamp the idle with the run that produced nothing (empty when the run
-    # died before appending its header — then the idle stays unpinned).
+# For observability, still append a fallback idle when a run produced no work
+# (crash/refusal/empty). Under trigger_self:false this idle does NOT drive the
+# loop — the EXIT trap's arm_wake does — it just marks the quiet wake.
+if [[ "$did_work" -eq 0 ]]; then
+    printf '  run produced no work (rc=%s) — marking idle; timer keeps the loop alive\n' "$run_rc" >&2
     idle_run_id=$(cat "$run_id_file" 2>/dev/null) || idle_run_id=""
     jq -nc \
         --arg source "$THINKER_NAME" \
@@ -226,6 +281,28 @@ if [[ "$after_last" == "$before_last" ]]; then
         | traj append >/dev/null || true
 fi
 rm -f "$run_id_file"
+
+# ---------------------------------------------------------------------------
+# Backoff decision — sets next_delay for the EXIT trap.
+# ---------------------------------------------------------------------------
+if [[ "$wake_mode" == "reactive" || "$did_work" -eq 1 ]]; then
+    # Engaged, or the run did real work → reset to no pause; think again at once.
+    level=0
+    ticks_at_level=0
+    next_delay=0
+else
+    # Empty spontaneous wake → dwell at this rate, then descend one level.
+    ticks_at_level=$(( ticks_at_level + 1 ))
+    if (( ticks_at_level >= BACKOFF_HOLD )); then
+        # Step to the next (slower) level unless already resting at the cap.
+        if (( $(_delay_for_level "$level") < BACKOFF_CAP )); then
+            level=$(( level + 1 ))
+        fi
+        ticks_at_level=0
+    fi
+    next_delay=$(_delay_for_level "$level")
+fi
+_save_state
 
 if [[ -n "$run_response" ]]; then
     printf '  [monolith] %s\n' "$(printf '%s' "$run_response" | head -1)"

--- a/thinkers/monolith/subscriptions.jsonl
+++ b/thinkers/monolith/subscriptions.jsonl
@@ -1,1 +1,1 @@
-{"types":["thought","action","observation","merge","idle"],"trigger_self":true}
+{"types":["observation","action","merge","monolith-wake"],"trigger_self":false}


### PR DESCRIPTION
## Summary

This branch began as the progressive-resolution-memory **design doc** and now also carries a monolith **backoff implementation** and a macOS **dispatcher fix**. Four commits:

### 1. Monolith non-blocking scheduled-wake backoff — `e8c3086` (implementation)
Implements `design/monolith_backoff.md` so an idle mind costs almost nothing and never pins the thinker slot.
- `subscriptions.jsonl` → `trigger_self:false`; wakes **reactively** on the responder's `observation` (how a chat reaches the mind post-split) plus external `action`/`merge`, and **spontaneously** on a `monolith-wake` step posted by a detached, dispatcher-token-guarded `arm_wake` timer.
- The monolith's own steps no longer re-fire it — removes the self-loop and the old in-step `sleep`, freeing the slot during idle so a long cap is cheap.
- Level-based backoff: `delay(0)=0` while engaged/working; `5,10,20,…` doubling to `MONOLITH_BACKOFF_CAP` (default **300s / 5 min**), with `MONOLITH_BACKOFF_HOLD` dwell before each descent. Reactive/real-work wakes reset to level 0. Per-identity overridable.
- An `EXIT` trap arms the next timer on every exit (incl. crash/refusal), so the timer — not an appended step — is the liveness net. `cmd_stop` reaps the timer.

### 2. Dispatcher bash-3.2 fix — `cf4779d` (fixes every macOS identity)
Independent robustness fix uncovered while testing the above. The dispatcher's self-ticking fifo read loop opens the fifo `exec 3<>` (so `read` can't EOF) and treats a non-zero read as a timeout — but only recognized bash ≥4's timeout code (`>128`). **macOS's `/bin/bash` is GNU bash 3.2.57, where `read -t` returns `1` on timeout**, so the loop hit the "fatal EOF" branch and the dispatcher exited on its first idle second (it only survived a startup race). Now any non-zero read is treated as a timeout, with a same-second spin guard for a genuinely broken fd. Portable across bash 3.2 and 4+.

### 3. Progressive-resolution-memory design doc — `1fe505f` (design only)
Unifies all memory — episodic (trajectory rollups) and semantic (goals, beliefs, facts) — into one progressive-resolution structure.
- Every entry carries bidirectional links: `children` (finer detail) and `parent` (coarser summary).
- Top-down drill navigation (HNSW/skip-list style): scan ~10 coarse summaries, drill into the best, repeat — O(log N) vs today's O(N) `mem search`.
- Builds on the tiered rollup pyramid (`tiered_memory.md`); extends `mem` files with `level`/`children`/`parent`; bridges episodic ↔ semantic. Phases: (1) resolution links on mem, (2) rollups↔mem bridge, (3) drill-down skill, (4) hierarchical search, (5) same-level cross-links. **Not yet implemented.**

### 4. Design-doc status updates — `36b7738`
`monolith_backoff.md` and `monolith_thinker.md` marked implemented (with notes on the responder split and backoff revisions).

## Test plan

- **Backoff (verified live on cleo):** dispatcher stays up, `arm_wake` timer posts `monolith-wake`, the monolith fires both spontaneously (timer) and reactively (responder observation), and backoff state persists and climbs toward the cap; a chat resets it to level 0.
- **bash-3.2 fix:** dispatcher previously died in <3s on every start on macOS; now stays up. Timeout-return-code behavior confirmed under `/bin/bash` 3.2 (`read -t` returns 1).
- [ ] Progressive-memory design review — schema, linking mechanics, open questions (semantic fanout, auto-theme-grouping, explicit vs emergent cross-links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
