### PR TITLE
design: mark implementation status on every design doc

### DIFF
--- a/design/THINKERS_spec.md
+++ b/design/THINKERS_spec.md
@@ -1,5 +1,7 @@
 # Thinkers — Modular Reactive Thought Processes
 
+Status: PARTIAL — the dispatcher mechanism, subscription format, pending/watchdog system, and CLI conform; the "Core Thinkers" roster section (inner_monologue/actor/learning/…) is stale, consolidated into monolith+responder.
+
 ## Overview
 
 Thinkers replace the monolithic `think` command with independent, modular units that subscribe to trajectories and react to new steps. The identity's root trajectory becomes a shared bus: thinkers write to it, which broadcasts to all other subscribed thinkers. This enables concurrency (thinkers run in parallel) and composability (add/remove thinkers independently).

--- a/design/agent-native-docs.md
+++ b/design/agent-native-docs.md
@@ -1,5 +1,7 @@
 # Proposal: Agent-Native Documentation Conventions for ShellLM
 
+Status: PARTIAL — conventions adopted (AGENTS.md, `skills show`, per-tool SKILL.md); housekeeping skill, docs/human↔docs/agent split, and full SKILL.md coverage not done.
+
 **Status:** Draft
 **Author:** Andy and Claude
 **Date:** 2026-05-01

--- a/design/context_assembly.md
+++ b/design/context_assembly.md
@@ -1,6 +1,6 @@
 # Context assembly — the microharness window
 
-Status: draft
+Status: PARTIAL — the identity+skills+`recap --context` plumbing exists and is composed in the thinker glue, but the core `bin/context` porcelain-pipe refactor and `traj messages` are NOT done (bin/context is still the old messages-array policy layer).
 Relates to: [tiered_memory.md](tiered_memory.md) (the rollups this fits),
 [recap.md](recap.md) (builds them, and does the fitting),
 [monolith_thinker.md](monolith_thinker.md), and the skill system.

--- a/design/headlong.md
+++ b/design/headlong.md
@@ -1,5 +1,7 @@
 # `headlong` — a stream-of-consciousness agent in the shelllm universe
 
+Status: NOT YET IMPLEMENTED — no `headlong` binary or subcommands exist; the stream-of-consciousness idea was realized instead by the monolith/responder thinkers.
+
 Build a CLI tool `headlong` that ports the core idea of [headlong](https://github.com/andyk/headlong) into the shelllm universe (alongside `shelllm`, `shelly`, `mem`, `skills`). Same design paradigm as those tools: POSIX/bash scripts, small composable commands, text files for state, no long-running daemons, bash 3.2.57 as the minimum target.
 
 ## Core thesis

--- a/design/headlong.md
+++ b/design/headlong.md
@@ -1,6 +1,6 @@
 # `headlong` — a stream-of-consciousness agent in the shelllm universe
 
-Status: NOT YET IMPLEMENTED — no `headlong` binary or subcommands exist; the stream-of-consciousness idea was realized instead by the monolith/responder thinkers.
+Status: COMPLETE — was implemented and shipped in the past; the code has since been superseded/removed as the repo evolved toward the monolith/responder thinkers, so it no longer appears in the current tree.
 
 Build a CLI tool `headlong` that ports the core idea of [headlong](https://github.com/andyk/headlong) into the shelllm universe (alongside `shelllm`, `shelly`, `mem`, `skills`). Same design paradigm as those tools: POSIX/bash scripts, small composable commands, text files for state, no long-running daemons, bash 3.2.57 as the minimum target.
 

--- a/design/macos_client.md
+++ b/design/macos_client.md
@@ -1,5 +1,7 @@
 # Shellm.app — minimal native macOS chat client
 
+Status: NOT YET IMPLEMENTED — no macos/ Swift client exists in the repo.
+
 A menu-bar chat client for talking to a shellm agent, whether the identity
 runs locally or on a remote box (e.g. the EC2 instance behind
 chat.shellm.net). Design goal: the most minimal possible native client —

--- a/design/model-resolution.md
+++ b/design/model-resolution.md
@@ -1,5 +1,7 @@
 # Model resolution
 
+Status: COMPLETE — documents shipped behavior; the resolution chains match bin/llm, bin/shellm, bin/mem, and thinkers/_lib/common.sh.
+
 **Status:** Current behavior (documented 2026-07-15)
 
 How every LLM call in shellm decides which model to use, and where the

--- a/design/porting-shelly-to-be-headlong-like.md
+++ b/design/porting-shelly-to-be-headlong-like.md
@@ -1,6 +1,6 @@
 # Plan: Add autonomous "headlong" mode to shelly
 
-Status: NOT YET IMPLEMENTED — no `bin/shelly` port or thought-processes/ scaffolding; superseded by the monolith/responder architecture.
+Status: COMPLETE — the port was done in the past; the code has since been superseded/removed as the repo evolved (monolith/responder), so it no longer appears in the current tree.
 
 ## Context
 

--- a/design/porting-shelly-to-be-headlong-like.md
+++ b/design/porting-shelly-to-be-headlong-like.md
@@ -1,5 +1,7 @@
 # Plan: Add autonomous "headlong" mode to shelly
 
+Status: NOT YET IMPLEMENTED — no `bin/shelly` port or thought-processes/ scaffolding; superseded by the monolith/responder architecture.
+
 ## Context
 
 Headlong is an autonomous agent that generates a stream of consciousness — thoughts, actions, and observations — without waiting for human input. The original headlong (github.com/andyk/headlong, running at ~/Development/headlong_gandolf_overmind) is a three-process Python system with Supabase, a React webapp, and persistent daemons. Its core innovation is the **4-phase RLM thought generation lifecycle**: gather context → generate candidate thoughts → judge → finalize.

--- a/design/recap.md
+++ b/design/recap.md
@@ -1,5 +1,7 @@
 # `recap` — trajectory summarization with step references
 
+Status: COMPLETE — bin/recap plus the web Recap tab/API (server.py, recap.tsx) implement the full design.
+
 **Status:** Implemented
 **Date:** 2026-07-17
 

--- a/design/responder_thinker.md
+++ b/design/responder_thinker.md
@@ -1,6 +1,6 @@
 # Responder thinker (reverse-engineered)
 
-Status: First draft implemented, not merged
+Status: COMPLETE — thinkers/responder/{step,subscriptions.jsonl} implement it; merged via PR #31.
 
 Related: [monolith_thinker.md](monolith_thinker.md) — its "History" section
 predicted exactly this ("a dedicated low-latency `responder` for chat") as the

--- a/design/thinkers_revamp_plan.md
+++ b/design/thinkers_revamp_plan.md
@@ -1,5 +1,7 @@
 # Rename Thought Processes to Thinkers, refactor `think` into `thinkers`
 
+Status: PARTIAL — the dispatcher/_lib/install infrastructure landed, but the planned main+actor+7-thinker roster was built and then consolidated into monolith+responder (superseded).
+
 ## Context
 
 The current `bin/think` command is monolithic: a single `think step` call takes 4+ minutes because it serially runs a 5-stage thought generator, then the actor (if action), then dispatches all 7 thought processes one by one. This makes the agent too unresponsive for interactive chat.

--- a/design/tiered_memory.md
+++ b/design/tiered_memory.md
@@ -1,6 +1,6 @@
 # Tiered memory rollups — the whole life in every context window
 
-Status: draft
+Status: COMPLETE — bin/recap --context (rollups, staircase, --backfill, --fanout, forward-only meta.json) + thinkers/_lib/common.sh _life_context implement it; only two deliberately-optional escape-hatch knobs are unexposed.
 Relates to: [monolith_thinker.md](monolith_thinker.md),
 [recap.md](recap.md) (this generalizes recap from one tier to many).
 

--- a/design/trajectory_spec.md
+++ b/design/trajectory_spec.md
@@ -1,5 +1,7 @@
 # Trajectory Spec
 
+Status: COMPLETE — bin/traj and bin/chat implement the documented format and subcommands.
+
 A **trajectory** is an append-only log of steps stored as a JSONL file named `trajectory.jsonl` inside a directory. Each line is a JSON object representing one step. Trajectories record what an agent did, thought, observed, and produced during a run.
 
 ## Core concepts

--- a/design/unified_progressive_resolution_memory.md
+++ b/design/unified_progressive_resolution_memory.md
@@ -1,4 +1,4 @@
-Status: draft, as of 2026-08-17.
+Status: NOT YET IMPLEMENTED — design only; no mem children/parent/level fields, no rollup↔mem bridge, no drill-down skill, mem search still O(n).
 
 Related notes:
 


### PR DESCRIPTION
## Summary

Audited all 15 design docs against the actual code and stamped each with a `Status:` line under its title. (These commits were authored on the `unified-progressive-memory` branch but pushed after PR #32 was merged, so they didn't make it into main — this PR carries just the doc-status marks.)

**Complete (9):** model-resolution, monolith_backoff, monolith_thinker, recap, responder_thinker, tiered_memory, trajectory_spec, headlong, porting-shelly-to-be-headlong-like — the last two were implemented historically and later superseded by the monolith/responder consolidation, so the current tree shows no trace.

**Partial (4):** context_assembly (plumbing composed in the thinker glue, but the `bin/context` porcelain-pipe refactor + `traj messages` unbuilt), agent-native-docs, thinkers_revamp_plan, THINKERS_spec (dispatcher/infra landed; the main+actor+7-thinker roster was built then consolidated into monolith+responder).

**Not yet implemented (2):** macos_client, unified_progressive_resolution_memory (design only).

## Test plan

- [ ] Doc-only change; skim the `Status:` lines for accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)