### PR TITLE
web: default chat sender to the CLI's chatrc default_send_from

### DIFF
--- a/web/src/shellm_web/server.py
+++ b/web/src/shellm_web/server.py
@@ -95,6 +95,21 @@ def _count_steps(jsonl: Path) -> int:
         return 0
 
 
+def _chatrc_default_from(root: Path) -> str | None:
+    """The CLI's `default_send_from`, so the web UI can share its default
+    sender. Mirrors bin/chat: `$CHATRC` (default `./.chatrc`) relative to the
+    directory CLI calls run in, which is the serve root."""
+    chatrc = Path(os.environ["CHATRC"]) if os.environ.get("CHATRC") else root / ".chatrc"
+    try:
+        for line in chatrc.read_text().splitlines():
+            if line.startswith("default_send_from="):
+                value = line.split("=", 1)[1].strip()
+                return value or None
+    except OSError:
+        pass
+    return None
+
+
 def _iso(ts: float | None) -> str | None:
     if ts is None:
         return None
@@ -205,6 +220,7 @@ def create_app(
             "version": VERSION,
             "controls_enabled": not read_only,
             "self_update_enabled": self_update_enabled,
+            "default_send_from": _chatrc_default_from(root),
             **git_info,
         }
 

--- a/web/viewer/app/lib/types.ts
+++ b/web/viewer/app/lib/types.ts
@@ -5,6 +5,7 @@ export interface Config {
   version: string;
   controls_enabled: boolean;
   self_update_enabled: boolean;
+  default_send_from: string | null;
   git_commit: string | null;
   git_branch: string | null;
 }

--- a/web/viewer/app/routes/chat.tsx
+++ b/web/viewer/app/routes/chat.tsx
@@ -14,6 +14,7 @@ import { Input } from "~/components/ui/input";
 import { LoadingDots } from "~/components/ui/loading-dots";
 import {
   fetchChat,
+  fetchConfig,
   fetchIdentityStatus,
   fetchThinkers,
   sendChat,
@@ -27,9 +28,12 @@ export function meta() {
 
 const MY_NAME_KEY = "shellm-chat-from";
 
-function myNameDefault(): string {
-  if (typeof window === "undefined") return "you";
-  return window.localStorage.getItem(MY_NAME_KEY) || "you";
+// A name the user explicitly chose here (persisted), or "" if they never have.
+// When empty, we fall back to the server's CLI default (chatrc
+// default_send_from) once config loads — matching what `chat send` would use.
+function storedName(): string {
+  if (typeof window === "undefined") return "";
+  return window.localStorage.getItem(MY_NAME_KEY) || "";
 }
 
 function messageTime(ts: string | null): string {
@@ -77,8 +81,29 @@ export default function ChatPage() {
   const controlsEnabled = useControlsEnabled();
   const queryClient = useQueryClient();
   const [draft, setDraft] = useState("");
-  const [myName, setMyName] = useState(myNameDefault);
+  const [myName, setMyName] = useState(storedName);
   const bottomRef = useRef<HTMLDivElement>(null);
+
+  // Seed the from-field default from the CLI (chatrc default_send_from) unless
+  // the user has already picked a name. Runs once, so clearing the field later
+  // to retype doesn't get auto-refilled out from under them.
+  const { data: config } = useQuery({
+    queryKey: ["config"],
+    queryFn: fetchConfig,
+    staleTime: Infinity,
+  });
+  const seededDefault = useRef(false);
+  useEffect(() => {
+    if (seededDefault.current) return;
+    if (storedName()) {
+      seededDefault.current = true;
+      return;
+    }
+    if (config) {
+      setMyName(config.default_send_from || "you");
+      seededDefault.current = true;
+    }
+  }, [config]);
 
   const { data: status } = useQuery({
     queryKey: ["status", identityId],


### PR DESCRIPTION
## Summary

The web chat UI hardcoded the sender ("from") field to `"you"`. This reads the CLI's `default_send_from` from `.chatrc` — the same value `chat send` uses — and defaults the web UI's sender to it, so the two stay consistent.

- `server.py` — new `_chatrc_default_from()` reads `default_send_from=` from `.chatrc` (`$CHATRC` or `./.chatrc`) and adds it to the `/config` response.
- `types.ts` — adds `default_send_from: string | null` to `Config`.
- `chat.tsx` — seeds the sender-name field from the server default on first load, **unless** the user has already picked a name locally (persisted in `localStorage`), so clearing the field to retype doesn't get auto-refilled.

Net ~46 lines across 3 files. (Extracted from a preserved WIP branch; the stale design-doc edits that were alongside it were dropped.)

## Test plan

- [ ] Set `default_send_from=<name>` in `.chatrc`, open the web chat with no prior local name → the "from" field shows `<name>`.
- [ ] With a name already chosen in the UI, it is not overwritten by the chatrc default.
- [ ] No `.chatrc` / no `default_send_from` → falls back to `"you"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)