### PR TITLE
Improve the Memories dashboard

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -70,7 +70,8 @@ still honored.
 - **Thinkers** (`/i/<identity>/thinkers`) — per-thinker status,
   dispatcher.log parsed into dispatch events, and a tail of each
   `run/logs/*.log`, with start/stop controls.
-- **Memories** (`/i/<identity>/memories`) — the identity's memory files.
+- **Memories** (`/i/<identity>/memories`) — searchable, type-filtered memory
+  cards with frontmatter summaries and dates, plus the full Markdown reader.
 - **Health** (`/i/<identity>/health`) — reply latency, stalls, and LLM
   provider health inferred from the mind log.
 - **Config** (`/i/<identity>/config`) — the identity's `.env` (model,

--- a/web/design/future-work.md
+++ b/web/design/future-work.md
@@ -63,8 +63,6 @@ self-contained changes.
 
 ## Features not yet built
 
-- **Memories frontmatter**: the list endpoint returns names only; parse YAML
-  frontmatter (date/type/slug) for grouping and sorting like `mem list`.
 - **Workdir browser**: a read-only file tree of the identity's `workdir/`
   (what the agent actually made). Harbor's viewer has a file-browser pattern
   (`@pierre/trees`) that could be cribbed if wanted.

--- a/web/src/headlong_web/memories.py
+++ b/web/src/headlong_web/memories.py
@@ -1,0 +1,129 @@
+"""Read the identity's file-backed memories for the dashboard.
+
+The ``mem`` CLI writes a deliberately small YAML-frontmatter shape.  Keep
+the viewer parser equally small: it understands top-level scalar fields and
+falls back to filename metadata for legacy files.  A malformed memory should
+never make the whole Memories page unavailable.
+"""
+
+import re
+from datetime import datetime
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+
+_DATED_NAME_RE = re.compile(
+    r"^(?P<stamp>\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2})"
+    r"(?:_(?P<id>[0-9a-f]{8}))?_(?P<slug>.+)$"
+)
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    """Return top-level scalar fields from a leading frontmatter block."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    try:
+        end = next(
+            i
+            for i, line in enumerate(lines[1:], start=1)
+            if line.strip() == "---"
+        )
+    except StopIteration:
+        return {}
+
+    fields: dict[str, str] = {}
+    for line in lines[1:end]:
+        # Ignore lists, nested mappings, comments, and malformed lines.  The
+        # fields consumed below are all scalars in files produced by bin/mem.
+        if line[:1].isspace() or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        fields[key] = value
+    return fields
+
+
+def _filename_fields(path: Path) -> tuple[str | None, str, str | None]:
+    base = path.stem
+    match = _DATED_NAME_RE.match(base)
+    if not match:
+        return None, base, None
+    stamp = match.group("stamp")
+    try:
+        created = datetime.strptime(stamp, "%Y-%m-%d-%H-%M-%S").strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+    except ValueError:
+        created = None
+    return match.group("id"), match.group("slug"), created
+
+
+@lru_cache(maxsize=4096)
+def _cached_fields(path_str: str, mtime_ns: int, size: int) -> dict[str, str]:
+    """Parse frontmatter once per file version.
+
+    The list endpoint polls while an identity is live.  Keying on stat data
+    avoids rereading hundreds of unchanged files every two seconds.
+    """
+    del mtime_ns, size  # used only as cache-key version stamps
+    try:
+        text = Path(path_str).read_text(encoding="utf-8", errors="replace")
+        return _frontmatter(text)
+    except OSError:
+        return {}
+
+
+def memory_info(path: Path) -> dict[str, Any]:
+    """Build the list-endpoint representation for one memory file."""
+    stat = path.stat()
+    fields = _cached_fields(str(path), stat.st_mtime_ns, stat.st_size)
+    filename_id, slug, filename_created = _filename_fields(path)
+    created = fields.get("created")
+    if created:
+        try:
+            datetime.fromisoformat(created.replace("Z", "+00:00"))
+        except ValueError:
+            created = None
+    return {
+        "name": path.name,
+        "mtime": stat.st_mtime,
+        "id": fields.get("id") or filename_id,
+        "summary": fields.get("summary") or None,
+        "type": fields.get("type") or "memory",
+        "created": created or filename_created,
+        "slug": slug,
+    }
+
+
+def _sort_key(info: dict[str, Any]) -> tuple[float, str]:
+    created = info.get("created")
+    if isinstance(created, str):
+        try:
+            parsed = datetime.fromisoformat(created.replace("Z", "+00:00"))
+            timestamp = parsed.timestamp()
+            return timestamp, info["name"]
+        except (ValueError, OverflowError):
+            pass
+    return float(info["mtime"]), info["name"]
+
+
+def list_memories(identity_dir: Path) -> list[dict[str, Any]]:
+    mem_dir = identity_dir / "memories"
+    if not mem_dir.is_dir():
+        return []
+    result = []
+    for path in mem_dir.glob("*.md"):
+        try:
+            result.append(memory_info(path))
+        except OSError:
+            # A file may disappear while a live identity is updating it.
+            continue
+    result.sort(key=_sort_key, reverse=True)
+    return result

--- a/web/src/headlong_web/server.py
+++ b/web/src/headlong_web/server.py
@@ -30,6 +30,7 @@ from headlong_web import (
     liveness,
     llm_health,
     logs,
+    memories,
     openrouter,
     push,
     safety,
@@ -530,13 +531,7 @@ def create_app(
     @app.get("/api/identities/{identity_id}/memories")
     def identity_memories(identity_id: str) -> list[dict]:
         identity = _identity_or_404(root, identity_id)
-        mem_dir = identity.path / "memories"
-        if not mem_dir.is_dir():
-            return []
-        result = []
-        for path in sorted(mem_dir.glob("*.md"), reverse=True):
-            result.append({"name": path.name, "mtime": path.stat().st_mtime})
-        return result
+        return memories.list_memories(identity.path)
 
     @app.get("/api/identities/{identity_id}/memories/{name}")
     def identity_memory(identity_id: str, name: str) -> dict:

--- a/web/tests/test_memories_api.py
+++ b/web/tests/test_memories_api.py
@@ -1,0 +1,131 @@
+"""Memory metadata parsing and API tests."""
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from headlong_web import memories
+from headlong_web.server import create_app
+
+
+def _identity_root(tmp_path: Path) -> tuple[Path, Path]:
+    identity = tmp_path / ".identities" / "keeper"
+    identity.mkdir(parents=True)
+    root_traj = "aaaaaaaa-1111-4111-8111-111111111111"
+    (identity / "info.txt").write_text(
+        f"name=keeper\ncreated=2026-08-01T00:00:00\nroot_trajectory={root_traj}\n"
+    )
+    traj_dir = identity / "trajectories" / "aaaaaaaa-root"
+    traj_dir.mkdir(parents=True)
+    (traj_dir / "trajectory.jsonl").write_text(
+        json.dumps({"type": "trajectory", "step_id": root_traj, "ts": "t0"}) + "\n"
+    )
+    (identity / "memories").mkdir()
+    return tmp_path, identity
+
+
+def test_memory_info_reads_frontmatter_and_filename(tmp_path: Path):
+    path = tmp_path / "2026-08-20-12-34-56_deadbeef_use-a-small-parser.md"
+    path.write_text(
+        "---\n"
+        "id: deadbeef\n"
+        'summary: "Use a small parser: keep the format legible"\n'
+        "type: lesson\n"
+        "created: '2026-08-20 12:34:56'\n"
+        "updated:\n"
+        "  - 2026-08-21 09:00:00\n"
+        "---\n\nBody\n"
+    )
+
+    info = memories.memory_info(path)
+
+    assert info["id"] == "deadbeef"
+    assert info["summary"] == "Use a small parser: keep the format legible"
+    assert info["type"] == "lesson"
+    assert info["created"] == "2026-08-20 12:34:56"
+    assert info["slug"] == "use-a-small-parser"
+
+
+def test_memory_info_falls_back_for_legacy_and_plain_names(tmp_path: Path):
+    legacy = tmp_path / "2026-08-19-10-20-30_old-format.md"
+    legacy.write_text("A memory without frontmatter.\n")
+    plain = tmp_path / "lessons.md"
+    plain.write_text("---\ntype:\ncreated: not-a-date\n---\n")
+
+    legacy_info = memories.memory_info(legacy)
+    plain_info = memories.memory_info(plain)
+
+    assert legacy_info | {"mtime": 0} == {
+        "name": legacy.name,
+        "mtime": 0,
+        "id": None,
+        "summary": None,
+        "type": "memory",
+        "created": "2026-08-19 10:20:30",
+        "slug": "old-format",
+    }
+    assert plain_info["slug"] == "lessons"
+    assert plain_info["type"] == "memory"
+    assert plain_info["created"] is None
+
+
+def test_unclosed_frontmatter_is_treated_as_plain_markdown(tmp_path: Path):
+    path = tmp_path / "unclosed.md"
+    path.write_text("---\nsummary: This block never closes\nBody text\n")
+
+    info = memories.memory_info(path)
+
+    assert info["summary"] is None
+    assert info["type"] == "memory"
+
+
+def test_memories_endpoint_returns_metadata_sorted_by_created(tmp_path: Path):
+    root, identity = _identity_root(tmp_path)
+    mem_dir = identity / "memories"
+    (mem_dir / "older.md").write_text(
+        "---\nsummary: Older note\ntype: note\ncreated: 2026-08-10 09:00:00\n---\n"
+    )
+    (mem_dir / "newer.md").write_text(
+        "---\nid: abc12345\nsummary: New preference\ntype: preference\n"
+        "created: 2026-08-20 09:00:00\n---\n"
+    )
+
+    response = TestClient(create_app(root)).get(
+        "/api/identities/.identities~keeper/memories"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["name"] for item in payload] == ["newer.md", "older.md"]
+    assert payload[0] | {"mtime": 0} == {
+        "name": "newer.md",
+        "mtime": 0,
+        "id": "abc12345",
+        "summary": "New preference",
+        "type": "preference",
+        "created": "2026-08-20 09:00:00",
+        "slug": "newer",
+    }
+
+
+def test_memories_endpoint_handles_missing_directory(tmp_path: Path):
+    root, _identity = _identity_root(tmp_path)
+    (root / ".identities" / "keeper" / "memories").rmdir()
+
+    response = TestClient(create_app(root)).get(
+        "/api/identities/.identities~keeper/memories"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_memory_metadata_cache_refreshes_when_file_changes(tmp_path: Path):
+    path = tmp_path / "memory.md"
+    path.write_text("---\nsummary: First\n---\n")
+    assert memories.memory_info(path)["summary"] == "First"
+
+    path.write_text("---\nsummary: A longer second value\n---\n")
+
+    assert memories.memory_info(path)["summary"] == "A longer second value"

--- a/web/viewer/app/components/identity-tabs.tsx
+++ b/web/viewer/app/components/identity-tabs.tsx
@@ -42,13 +42,13 @@ export function IdentityTabs({
       <span className="text-muted-foreground">/</span>
       <h1 className="font-mono text-lg font-semibold">{displayName}</h1>
       <ActivityBadge identityId={identityId} live={live} />
-      <nav className="ml-auto flex items-center gap-1 rounded-lg border p-0.5">
+      <nav className="ml-auto flex max-w-full items-center gap-1 overflow-x-auto rounded-lg border p-0.5 max-sm:ml-0 max-sm:w-full">
         {TABS.map((tab) => (
           <Link
             key={tab.key}
             to={`${base}${tab.path}`}
             className={cn(
-              "rounded-md px-2.5 py-1 text-xs",
+              "shrink-0 rounded-md px-2.5 py-1 text-xs",
               tab.key === active
                 ? "bg-accent font-medium"
                 : "text-muted-foreground hover:text-foreground"

--- a/web/viewer/app/lib/types.ts
+++ b/web/viewer/app/lib/types.ts
@@ -492,4 +492,9 @@ export interface DispatchEvent {
 export interface MemoryInfo {
   name: string;
   mtime: number;
+  id: string | null;
+  summary: string | null;
+  type: string;
+  created: string | null;
+  slug: string;
 }

--- a/web/viewer/app/routes/memories.tsx
+++ b/web/viewer/app/routes/memories.tsx
@@ -1,8 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useParams } from "react-router";
 
 import { IdentityTabs } from "~/components/identity-tabs";
+import { Badge } from "~/components/ui/badge";
 import {
   Empty,
   EmptyDescription,
@@ -10,7 +12,15 @@ import {
   EmptyTitle,
 } from "~/components/ui/empty";
 import { LoadingDots } from "~/components/ui/loading-dots";
+import { Input } from "~/components/ui/input";
 import { Markdown } from "~/components/ui/markdown";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
 import {
   fetchIdentityStatus,
   fetchMemories,
@@ -19,6 +29,28 @@ import {
 } from "~/lib/api";
 import { cn } from "~/lib/utils";
 
+const ALL_TYPES = "__all__";
+
+function readableSlug(slug: string) {
+  const readable = slug.replace(/[-_]+/g, " ").trim();
+  return readable
+    ? readable.charAt(0).toLocaleUpperCase() + readable.slice(1)
+    : "Untitled memory";
+}
+
+function memoryDate(created: string | null, mtime: number) {
+  if (created) return created.slice(0, 16).replace("T", " ");
+  return new Date(mtime * 1000).toLocaleDateString();
+}
+
+function memoryBody(content: string) {
+  const lines = content.split(/\r?\n/);
+  if (lines[0]?.trim() !== "---") return content;
+  const closing = lines.slice(1).findIndex((line) => line.trim() === "---");
+  if (closing < 0) return content;
+  return lines.slice(closing + 2).join("\n").replace(/^\s+/, "");
+}
+
 export function meta() {
   return [{ title: "Headlong · memories" }];
 }
@@ -26,6 +58,8 @@ export function meta() {
 export default function MemoriesPage() {
   const { identityId = "" } = useParams();
   const [selected, setSelected] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState(ALL_TYPES);
 
   const { data: status } = useQuery({
     queryKey: ["status", identityId],
@@ -40,7 +74,30 @@ export default function MemoriesPage() {
     refetchInterval: pollWhileLive(live),
   });
 
-  const active = selected ?? memories?.[0]?.name ?? null;
+  const types = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const memory of memories ?? []) {
+      counts.set(memory.type, (counts.get(memory.type) ?? 0) + 1);
+    }
+    return [...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [memories]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLocaleLowerCase();
+    return (memories ?? []).filter((memory) => {
+      if (typeFilter !== ALL_TYPES && memory.type !== typeFilter) return false;
+      if (!needle) return true;
+      return [memory.summary, memory.slug, memory.type, memory.name]
+        .filter(Boolean)
+        .some((value) => value?.toLocaleLowerCase().includes(needle));
+    });
+  }, [memories, query, typeFilter]);
+
+  const active =
+    (selected && filtered.some((memory) => memory.name === selected) && selected) ||
+    filtered[0]?.name ||
+    null;
+  const activeInfo = memories?.find((item) => item.name === active);
 
   const { data: memory } = useQuery({
     queryKey: ["memory", identityId, active],
@@ -69,28 +126,108 @@ export default function MemoriesPage() {
           </EmptyHeader>
         </Empty>
       ) : (
-        <div className="flex gap-4">
-          <aside className="w-72 shrink-0">
-            <div className="max-h-[75vh] overflow-y-auto rounded-lg border">
-              {memories.map((mem) => (
-                <button
-                  key={mem.name}
-                  type="button"
-                  onClick={() => setSelected(mem.name)}
-                  className={cn(
-                    "block w-full truncate border-b px-3 py-2 text-left font-mono text-[11px] last:border-b-0 hover:bg-accent",
-                    mem.name === active && "bg-accent font-medium"
-                  )}
-                  title={mem.name}
-                >
-                  {mem.name.replace(/\.md$/, "")}
-                </button>
-              ))}
+        <div className="flex flex-col gap-4 lg:flex-row">
+          <aside className="min-w-0 shrink-0 lg:w-80">
+            <div className="mb-2 flex gap-2">
+              <div className="relative min-w-0 flex-1">
+                <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search memories"
+                  aria-label="Search memories"
+                  className="pl-8"
+                />
+              </div>
+              <Select value={typeFilter} onValueChange={setTypeFilter}>
+                <SelectTrigger size="sm" className="max-w-36">
+                  <SelectValue placeholder="All types" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL_TYPES}>
+                    All types ({memories.length})
+                  </SelectItem>
+                  {types.map(([type, count]) => (
+                    <SelectItem key={type} value={type}>
+                      {type} ({count})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="mb-1 text-xs text-muted-foreground">
+              {filtered.length === memories.length
+                ? `${memories.length} memories`
+                : `${filtered.length} of ${memories.length} memories`}
+            </div>
+            <div className="max-h-[42vh] overflow-y-auto rounded-lg border lg:max-h-[calc(100vh-13rem)]">
+              {filtered.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No memories match these filters.
+                </div>
+              ) : (
+                filtered.map((mem) => (
+                  <button
+                    key={mem.name}
+                    type="button"
+                    onClick={() => setSelected(mem.name)}
+                    className={cn(
+                      "block w-full border-b px-3 py-2.5 text-left last:border-b-0 hover:bg-accent",
+                      mem.name === active && "bg-accent"
+                    )}
+                    title={mem.name}
+                  >
+                    <span className="mb-1 flex items-center gap-2">
+                      <Badge
+                        variant="outline"
+                        className="max-w-28 truncate text-[10px]"
+                      >
+                        {mem.type}
+                      </Badge>
+                      <span className="ml-auto shrink-0 text-[10px] tabular-nums text-muted-foreground">
+                        {memoryDate(mem.created, mem.mtime)}
+                      </span>
+                    </span>
+                    <span className="line-clamp-2 block text-sm font-medium leading-snug">
+                      {mem.summary || readableSlug(mem.slug)}
+                    </span>
+                    {mem.summary && (
+                      <span className="mt-1 block truncate font-mono text-[10px] text-muted-foreground">
+                        {readableSlug(mem.slug)}
+                      </span>
+                    )}
+                  </button>
+                ))
+              )}
             </div>
           </aside>
-          <div className="min-w-0 flex-1 rounded-lg border bg-card p-4">
-            {memory ? (
-              <Markdown className="max-w-none">{memory.content}</Markdown>
+          <div className="min-h-72 min-w-0 flex-1 rounded-lg border bg-card p-4 sm:p-6">
+            {!active ? (
+              <div className="flex min-h-60 items-center justify-center text-sm text-muted-foreground">
+                Choose a different filter to view a memory.
+              </div>
+            ) : memory ? (
+              <>
+                {activeInfo && (
+                  <div className="mb-5 border-b pb-4">
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
+                      <Badge variant="secondary">{activeInfo.type}</Badge>
+                      <span className="text-xs text-muted-foreground">
+                        {memoryDate(activeInfo.created, activeInfo.mtime)}
+                      </span>
+                      {activeInfo.id && (
+                        <span className="font-mono text-[10px] text-muted-foreground">
+                          {activeInfo.id}
+                        </span>
+                      )}
+                    </div>
+                    <h2 className="text-lg font-semibold leading-snug">
+                      {activeInfo.summary || readableSlug(activeInfo.slug)}
+                    </h2>
+                  </div>
+                )}
+                <Markdown className="max-w-none">{memoryBody(memory.content)}</Markdown>
+              </>
             ) : (
               <LoadingDots />
             )}


### PR DESCRIPTION
## Summary

- enrich the memories API with parsed metadata, stable date handling, and cached reads
- add memory search, type filters, readable cards, and a clearer reader view
- improve responsive behavior for the Memories page and identity tabs
- document the richer memory metadata response and add API coverage

## Verification

- `uv run pytest web/tests`: 126 passed, 2 skipped
- `npm run typecheck`
- `npm run build`
- visually checked desktop and mobile layouts against a read-only fixture