### PR TITLE
shellm: bash-4 ${n^^} breaks every shellm run on macOS (bash 3.2)

### DIFF
--- a/bin/shellm
+++ b/bin/shellm
@@ -2639,11 +2639,16 @@ exit \$__shellm_rc
 # whose NAME looks like a credential are masked. (Passing secrets as a bare
 # `--var NAME` keeps them off the command line altogether.)
 _redacted_cmdline() {
-    local out="shellm" prev="" a n
+    local out="shellm" prev="" a n nu
     for a in "$@"; do
         if [[ "$prev" == "--var" && "$a" == *=* ]]; then
             n="${a%%=*}"
-            if [[ "${n^^}" =~ (KEY|TOKEN|SECRET|PASSW|CREDENTIAL) ]]; then
+            # Uppercase via tr, not ${n^^}: the latter is a bash-4 expansion
+            # and macOS's /bin/bash is 3.2, where it is a fatal "bad
+            # substitution" that kills the whole run (every shellm run exited
+            # rc=1 with no output on macOS).
+            nu=$(printf '%s' "$n" | tr '[:lower:]' '[:upper:]')
+            if [[ "$nu" =~ (KEY|TOKEN|SECRET|PASSW|CREDENTIAL) ]]; then
                 a="$n=<redacted>"
             fi
         fi


### PR DESCRIPTION
## Summary

Every `shellm` run on macOS exits `rc=1` with **no output**, because `_redacted_cmdline` (added in a378053 to mask secret `--var` values) uppercases the var name with `${n^^}`:

```sh
if [[ "${n^^}" =~ (KEY|TOKEN|SECRET|PASSW|CREDENTIAL) ]]; then
```

`${var^^}` is a **bash-4 parameter expansion**. macOS's `/bin/bash` is **3.2**, where it's a fatal `bad substitution` that aborts the whole script. Since `_redacted_cmdline` runs early (building the command line to log), the script dies before doing anything — so **every shellm-driven thinker produced no work and fell back to idle**. (Observed on the monolith: hours of nothing but `idle` steps, `run produced no work (rc=1)` in the logs.)

## Fix

Uppercase with `tr` instead — portable across bash 3.2 and 4+. The case-insensitive secret redaction is unchanged.

## Test plan

- [x] `bin/shellm` parses under `/bin/bash` (3.2).
- [x] A real shellm run goes from `rc=1` / no output → `rc=0` with output.
- [x] Redaction intact: `openrouter_api_key=…`, `authToken=…` → `<redacted>`; `FOO=bar` untouched (verified case-insensitively).
- [x] The monolith resumes producing real reasoning/work instead of bare idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)