### PR TITLE
mindlog: mkdir cursor parent before write (fix FileNotFoundError crash)

### DIFF
--- a/slack/src/headlong_slack/mindlog.py
+++ b/slack/src/headlong_slack/mindlog.py
@@ -81,6 +81,7 @@ def follow(
         steps, new_offset = read_new(path, offset)
         if new_offset != offset:
             offset = new_offset
+            cursor_file.parent.mkdir(parents=True, exist_ok=True)
             cursor_file.write_text(str(offset))
         yield from steps
         time.sleep(poll_interval)

--- a/slack/tests/test_mindlog.py
+++ b/slack/tests/test_mindlog.py
@@ -1,6 +1,8 @@
 import json
+import threading
+import time
 
-from headlong_slack.mindlog import find_trajectory, read_new
+from headlong_slack.mindlog import find_trajectory, follow, read_new
 
 
 def _append(path, obj, newline=True):
@@ -55,3 +57,30 @@ def test_find_trajectory(tmp_path):
         "name=audel\nroot_trajectory=deadbeef-1234-5678-9abc-def012345678\n"
     )
     assert find_trajectory(identity) == traj_dir / "trajectory.jsonl"
+
+
+def test_follow_creates_missing_cursor_parent(tmp_path):
+    """Outbound used to FileNotFoundError if state_dir vanished mid-run.
+
+    follow() starts at EOF when the cursor file is missing, so the new
+    line has to arrive *after* the generator has taken its initial
+    offset. Append from a thread so next() can observe it.
+    """
+    traj = tmp_path / "trajectory.jsonl"
+    traj.write_text("")
+    cursor = tmp_path / "missing-state" / "cursor"
+    assert not cursor.parent.exists()
+
+    def _later():
+        time.sleep(0.05)
+        _append(traj, {"content": "hello"})
+
+    threading.Thread(target=_later, daemon=True).start()
+    gen = follow(traj, cursor, poll_interval=0.01)
+    try:
+        step = next(gen)
+        assert step["content"] == "hello"
+        assert cursor.is_file()
+        assert cursor.parent.is_dir()
+    finally:
+        gen.close()

--- a/telegram/src/headlong_telegram/mindlog.py
+++ b/telegram/src/headlong_telegram/mindlog.py
@@ -84,6 +84,7 @@ def follow(
         steps, new_offset = read_new(path, offset)
         if new_offset != offset:
             offset = new_offset
+            cursor_file.parent.mkdir(parents=True, exist_ok=True)
             cursor_file.write_text(str(offset))
         yield from steps
         time.sleep(poll_interval)


### PR DESCRIPTION
## Summary

`follow()` in the slack and telegram mindlog bridges writes its cursor file inside a state dir that can vanish mid-run; when it does, `cursor_file.write_text()` raises `FileNotFoundError` and kills the outbound message loop (observed live: an Aug 17 21:10 outbound death). This `mkdir(parents=True, exist_ok=True)`s the cursor's parent before writing — applied symmetrically to slack and telegram. The initial offset is only *read* (missing cursor → start at EOF, no error), so the in-loop write is the only failure path.

Adds a slack regression test that follows into a missing state dir and asserts both that the appended step is read and that the cursor + parent are created.

**Authored autonomously by the `cleo` Headlong agent**; reviewed and committed by Bobby. Verified: slack 5 passed, telegram 30 passed.

## Test plan

- [x] `slack`: `test_follow_creates_missing_cursor_parent` (new) + existing — 5 passed.
- [x] `telegram`: existing suite — 30 passed (fix is byte-identical to slack's).
- Note: the fix is in both slack and telegram; the regression test is in slack only (telegram has no mindlog test module). A mirror test could close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)