### PR TITLE
telegram: a malformed API reply no longer ends the poll loop

### DIFF
--- a/telegram/src/headlong_telegram/api.py
+++ b/telegram/src/headlong_telegram/api.py
@@ -30,9 +30,24 @@ class Bot:
 
     def _call(self, method: str, **params: Any) -> Any:
         response = self._client.post(f"{self._base}/{method}", json=params)
-        payload = response.json()
+        # Anything that is not a well-formed Telegram envelope has to leave here
+        # as ApiError. The poll loop retries on (ApiError, httpx.HTTPError) and
+        # dies on everything else, so a 502 HTML page from an edge would
+        # otherwise raise JSONDecodeError straight through it. The response text
+        # is truncated and the URL left out because the URL carries the token.
+        try:
+            payload = response.json()
+        except ValueError:
+            raise ApiError(
+                f"{method}: non-JSON response (HTTP {response.status_code}): "
+                f"{response.text[:200]}"
+            ) from None
+        if not isinstance(payload, dict):
+            raise ApiError(f"{method}: unexpected response shape {type(payload).__name__}")
         if not payload.get("ok"):
             raise ApiError(f"{method}: {payload.get('description', response.text)}")
+        if "result" not in payload:
+            raise ApiError(f"{method}: ok response carried no result")
         return payload["result"]
 
     def get_me(self) -> dict[str, Any]:

--- a/telegram/tests/test_api.py
+++ b/telegram/tests/test_api.py
@@ -1,0 +1,47 @@
+"""Bot._call's error contract: every failure arrives as ApiError.
+
+The module docstring promises callers that a call either returns `result` or
+raises ApiError. The poll loop leans on that promise -- it retries on
+(ApiError, httpx.HTTPError) and dies on anything else -- so a failure shape
+that escapes those two takes the bridge down.
+"""
+
+import httpx
+import pytest
+
+from headlong_telegram.api import ApiError, Bot
+
+
+def bot_returning(response_factory):
+    bot = Bot("t")
+    bot._client = httpx.Client(
+        transport=httpx.MockTransport(lambda request: response_factory(request))
+    )
+    return bot
+
+
+def test_non_json_body_raises_api_error():
+    """A 502 HTML page from an edge/proxy, not a Telegram JSON error."""
+    bot = bot_returning(lambda r: httpx.Response(502, text="<html>502 Bad Gateway</html>"))
+    with pytest.raises(ApiError):
+        bot.get_updates(0)
+
+
+def test_json_error_status_raises_api_error():
+    """A 500 whose body is valid JSON but carries no ok/description."""
+    bot = bot_returning(lambda r: httpx.Response(500, json={"oops": True}))
+    with pytest.raises(ApiError):
+        bot.get_updates(0)
+
+
+def test_ok_false_still_raises_api_error_with_description():
+    bot = bot_returning(
+        lambda r: httpx.Response(200, json={"ok": False, "description": "Conflict"})
+    )
+    with pytest.raises(ApiError, match="Conflict"):
+        bot.get_updates(0)
+
+
+def test_ok_true_returns_result():
+    bot = bot_returning(lambda r: httpx.Response(200, json={"ok": True, "result": [1, 2]}))
+    assert bot.get_updates(0) == [1, 2]

--- a/telegram/tests/test_inbound.py
+++ b/telegram/tests/test_inbound.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from headlong_telegram import inbound as inbound_mod
+from headlong_telegram.api import Bot
 from headlong_telegram.allowlist import Allowlist
 from headlong_telegram.config import Config
 from headlong_telegram.inbound import Inbound
@@ -164,3 +165,44 @@ def test_same_text_new_msg_id_is_delivered(bridge):
     ib._handle(_dm_with_msg_id(7, "ok", msg_id=503))
     ib._handle(_dm_with_msg_id(7, "ok", msg_id=504))
     assert len(posts) == 2
+
+
+def test_poll_loop_survives_a_malformed_api_response(tmp_path, monkeypatch):
+    """A non-JSON reply must reach the loop's retry branch, not end the loop.
+
+    Driven through a real Bot rather than FakeBot: the failure lives in how
+    Bot._call surfaces the error, which a fake bot cannot reproduce.
+    """
+    identity_dir = tmp_path / ".identities" / "audel"
+    identity_dir.mkdir(parents=True)
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    cfg = Config(
+        serve_root=tmp_path,
+        identity="audel",
+        identity_dir=identity_dir,
+        bot_token="t",
+        admin_id=ADMIN,
+        web_url="http://web.test",
+        state_dir=state_dir,
+    )
+
+    bot = Bot("t")
+    bot._client = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(502, text="<html>502 Bad Gateway</html>")
+        )
+    )
+
+    slept = []
+    monkeypatch.setattr(inbound_mod.time, "sleep", lambda s: slept.append(s))
+
+    ib = Inbound(cfg, bot, Allowlist(state_dir / "allowlist.json"))
+    calls = {"n": 0}
+
+    def should_stop():
+        calls["n"] += 1
+        return calls["n"] > 1  # one failing poll, then stop
+
+    ib.run(should_stop)  # must return, not raise
+    assert slept == [5]


### PR DESCRIPTION
Fixes #44

`Bot._call` called `response.json()` unguarded, so a non-JSON body raised `json.JSONDecodeError`. That subclasses `ValueError`, which is neither `ApiError` nor `httpx.HTTPError`, and those are exactly the two the poll loop catches. The exception walked past the retry branch and ended `Inbound.run`. systemd restarts the bridge five seconds later, so what is actually lost is the in-memory `_seen_msg_ids` map, and at-least-once delivery can then double-post a redelivered update.

The module docstring already promised the behavior this restores: a call returns `result` or raises `ApiError`. So `_call` now converts three shapes into `ApiError`: a body that is not JSON, a payload that is not an object (a bare list would have raised `AttributeError`), and an `ok` response with no `result` (previously a `KeyError`). None of those three were caught anywhere, so this only widens what the existing `except ApiError` sites already handle, in `inbound.py` and `outbound.py` both.

The error message truncates the response body to 200 characters and leaves the URL out, since the base URL carries the bot token.

## Tests

`api.py` had no tests, so `telegram/tests/test_api.py` is new: the non-JSON body, a JSON error status, `ok: false` still carrying its description, and the ok path still returning `result`.

The regression test in `test_inbound.py` drives a real `Bot` over `httpx.MockTransport` rather than the fake bot the other tests use. That is the point of it: the failure lives in how `_call` surfaces a transport-shaped error, which a fake bot cannot produce, and it is why the existing suite did not catch this.

Both fail without the fix and pass with it. `uv run --project telegram pytest telegram/tests -q` goes from 30 to 35 passing.