### PR TITLE
Docker broker: contain compose host paths by resolution, and check the fields it never read

### DIFF
--- a/tests/test_broker_compose_containment.sh
+++ b/tests/test_broker_compose_containment.sh
@@ -2,15 +2,25 @@
 # tests/test_broker_compose_containment.sh — the broker's compose validator
 # must contain host paths at a directory boundary, not a string prefix.
 #
-# compose_validate_model is the ONLY gate on the bind sources, build contexts
-# and absolute Dockerfiles in a compose model the sandbox hands the broker;
-# handle_compose runs the real `docker compose` as soon as it returns 0. A
-# textual prefix test is not containment: it lets /host/work-secret through
-# while the workdir is /host/work, and `docker compose config` hands the
-# validator paths it has NOT normalised (an absolute source keeps its `..`,
+# compose_validate_model is the ONLY gate on the host paths in a compose model
+# the sandbox hands the broker; handle_compose runs the real `docker compose`
+# as soon as it returns 0. Two things are under test here.
+#
+# Containment: a textual prefix test is not it. It lets /host/work-secret
+# through while the workdir is /host/work, and `docker compose config` hands
+# the validator paths it has NOT normalised (an absolute source keeps its `..`,
 # verified against compose 2.40.3) and never resolves symlinks. So the check
 # resolves each path and gates it with path_under(), and the cases below are
-# the three ways out: the sibling prefix, the `..` climb, and the symlink.
+# the four ways out: the sibling prefix, the `..` climb, the symlink, and the
+# DANGLING symlink that `test -e` calls missing.
+#
+# Coverage: bind sources are a fraction of the surface. A build context, an
+# absolute Dockerfile, an additional context, an ssh key, a local build cache,
+# a develop.watch path, a volume driver_opts.device, a secret or config file,
+# an env_file and a label_file each name a host path, and none of them passes
+# through .services[].volumes. The last two survive only the uninterpolated
+# render, and the default render is what reads them, so they are checked first
+# and the case below proves the default render never runs when one is outside.
 #
 # The real function is exercised against a stubbed `docker compose ... config`
 # so the resolved model is the input under test. The accept cases and the
@@ -37,20 +47,47 @@ export SHELLM_BROKER_WORKDIR="$WORK/work"
 mkdir -p "$SHELLM_BROKER_WORKDIR/sub" "$WORK/work-secret"
 ln -s "$WORK/work-secret" "$SHELLM_BROKER_WORKDIR/escape"   # symlink out, from inside
 ln -s "$SHELLM_BROKER_WORKDIR" "$WORK/alias"                # another spelling of the workdir
+ln -s "$WORK/never-created" "$SHELLM_BROKER_WORKDIR/dangle"  # points out, target absent
 
 # Source the broker for its functions: drop the trailing `main "$@"`, which
 # would otherwise print usage and exit.
 sed '$ d' "$REPO/tools/shellm-docker-broker" > "$WORK/broker.lib"
 
 # `docker compose ... config --format json` returns whatever the case wrote.
+# The validator renders the model TWICE and the two renders do not carry the
+# same fields: only the uninterpolated one still names env_file and label_file,
+# and the default one is the one that reads those files. So the stub answers
+# them separately, from $CFG_RAW and $CFG, and records which ran. A stub that
+# served one fixture to both would pass every env_file case with the second
+# render deleted, and could not show that the check happens before the read.
 mkdir -p "$WORK/bin"
 cat > "$WORK/bin/docker" <<'STUB'
 #!/usr/bin/env bash
-cat "$CFG"
+raw=""
+for arg in "$@"; do
+    [[ "$arg" == "--no-interpolate" ]] && raw=1
+done
+if [[ -n "$raw" ]]; then
+    printf 'raw\n' >> "$CALLS"
+    if [[ "${RAW_RC:-0}" != 0 ]]; then
+        printf '%s\n' "${RAW_ERR:-uninterpolated render failed}" >&2
+        exit "$RAW_RC"
+    fi
+    cat "$CFG_RAW"
+else
+    printf 'default\n' >> "$CALLS"
+    if [[ "${CFG_RC:-0}" != 0 ]]; then
+        printf '%s\n' "${CFG_ERR:-default render failed}" >&2
+        exit "$CFG_RC"
+    fi
+    cat "$CFG"
+fi
 STUB
 chmod +x "$WORK/bin/docker"
 export PATH="$WORK/bin:$PATH"
 export CFG="$WORK/cfg.json"
+export CFG_RAW="$WORK/cfg_raw.json"
+export CALLS="$WORK/calls"
 
 # shellcheck disable=SC1090  # generated copy of the broker under test
 source "$WORK/broker.lib"
@@ -61,12 +98,22 @@ set +e   # the broker sets -e; validation returning 65 is an expected outcome
 # A rejection has to be the containment verdict, not any nonzero exit: rc 65
 # with the "outside SHELLM_WORKDIR" message. Asserting only "nonzero" would let
 # a case pass because jq errored or the model failed to parse.
+#
+# The uninterpolated render defaults to an empty model, because the fields it
+# alone carries are absent from the default one. A case about those fields sets
+# RAW below and leaves them out of the default fixture, the way compose does.
+RAW='{}'
+LAST_OUT=""
 check() {
     local name="$1" want="$2" json="$3" request="${4:-}" out rc got
     [[ -n "$request" ]] || request='{}'
     printf '%s' "$json" > "$CFG"
+    printf '%s' "$RAW" > "$CFG_RAW"
+    RAW='{}'
+    : > "$CALLS"
     out=$(compose_validate_model "$request" "$SHELLM_BROKER_WORKDIR" up 2>&1)
     rc=$?
+    LAST_OUT="$out"
     [[ "$rc" -eq 0 ]] && got=accept || got=reject
     if [[ "$got" != "$want" ]]; then
         bad "$name" "expected $want, got $got${out:+ ($out)}"
@@ -117,10 +164,51 @@ check "additional build context outside is denied" reject \
   "$(printf '{"services":{"s":{"build":{"context":"%s","additional_contexts":{"extra":"/etc"}}}}}' "$SHELLM_BROKER_WORKDIR")"
 check "a non-path additional context is allowed" accept \
   "$(printf '{"services":{"s":{"build":{"context":"%s","additional_contexts":{"img":"docker-image://alpine"}}}}}' "$SHELLM_BROKER_WORKDIR")"
-check "env_file outside is denied"              reject \
-  '{"services":{"s":{"env_file":[{"path":"/etc/hostname","required":true}]}}}'
-check "env_file inside the workdir is allowed"  accept \
-  "$(printf '{"services":{"s":{"env_file":[{"path":"%s/app.env","required":true}]}}}' "$SHELLM_BROKER_WORKDIR")"
+# env_file and label_file exist only in the uninterpolated render, so these
+# cases put them there and leave the default fixture bare, the way compose
+# leaves it after it has read the files.
+RAW='{"services":{"s":{"env_file":[{"path":"/etc/hostname","required":true}]}}}'
+check "env_file outside is denied"              reject '{"services":{"s":{}}}'
+RAW="$(printf '{"services":{"s":{"env_file":[{"path":"%s/app.env","required":true}]}}}' "$SHELLM_BROKER_WORKDIR")"
+check "env_file inside the workdir is allowed"  accept '{"services":{"s":{}}}'
+RAW='{"services":{"s":{"label_file":["/etc/hostname"]}}}'
+check "label_file outside is denied"            reject '{"services":{"s":{}}}'
+RAW="$(printf '{"services":{"s":{"label_file":["%s/app.labels"]}}}' "$SHELLM_BROKER_WORKDIR")"
+check "label_file inside the workdir is allowed" accept '{"services":{"s":{}}}'
+
+# --- the surfaces that survive the default render ------------------------
+check "a relative additional context is denied" reject \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","additional_contexts":{"extra":"../work-secret"}}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "an oci-layout additional context is allowed" accept \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","additional_contexts":{"l":"oci-layout:///x"}}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "a local build cache source outside is denied" reject \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","cache_from":["type=local,src=/etc"]}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "a local build cache dest outside is denied" reject \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","cache_to":["type=local,dest=%s"]}}}}' "$SHELLM_BROKER_WORKDIR" "$WORK/work-secret")"
+check "a build cache inside the workdir is allowed" accept \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","cache_from":["type=local,src=%s/cache"]}}}}' "$SHELLM_BROKER_WORKDIR" "$SHELLM_BROKER_WORKDIR")"
+# Compose leaves a cache_to dest relative where it resolves every other path
+# field to absolute, so a dest inside the workdir is rejected for being
+# non-absolute. Fail-closed, but it is a false rejection, not a clean pass, and
+# it is pinned here so it is a known cost rather than a surprise.
+check "a relative cache dest is denied too"     reject \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","cache_to":["type=local,dest=./cacheout"]}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "a registry build cache is allowed"       accept \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","cache_from":["type=registry,ref=example.com/img:cache","alpine:latest"]}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "an ssh key outside is denied"            reject \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","ssh":["key=/root/.ssh/id_rsa"]}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "the default ssh agent is allowed"        accept \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","ssh":["default"]}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "a develop.watch path outside is denied"  reject \
+  "$(printf '{"services":{"s":{"develop":{"watch":[{"action":"sync","path":"%s","target":"/app"}]}}}}' "$WORK/work-secret")"
+check "a develop.watch path inside is allowed"  accept \
+  "$(printf '{"services":{"s":{"develop":{"watch":[{"action":"sync","path":"%s/src","target":"/app"}]}}}}' "$SHELLM_BROKER_WORKDIR")"
+
+# A dangling symlink is not a path compose may create: the daemon follows it to
+# a target outside the workdir. `test -e` is false for one, so it reads as a
+# missing component unless the walk stops at the link itself.
+check "a bind on a dangling symlink out is denied" reject "$(bind "$SHELLM_BROKER_WORKDIR/dangle")"
+check "a bind through a dangling symlink is denied" reject "$(bind "$SHELLM_BROKER_WORKDIR/dangle/sub")"
 
 # The workdir's own spelling can be a symlink too: macOS hands mktemp a path
 # under /var, which is a symlink to /private/var, and CI caught this when every
@@ -138,10 +226,84 @@ symlink_root_case() {
 }
 symlink_root_case
 
+# --- what the two renders owe the caller ---------------------------------
+# Either render failing is a rejection, not a shrug: a model the validator
+# could not read is a model it cannot vouch for.
+export RAW_RC=1 RAW_ERR="uninterpolated render exploded"
+check "an uninterpolated render that fails is denied" reject '{"services":{"s":{}}}'
+unset RAW_RC RAW_ERR
+
+export CFG_RC=1 CFG_ERR="default render exploded"
+check "a default render that fails is denied"         reject '{"services":{"s":{}}}'
+
+# compose puts the contents of the file it choked on into that error text (an
+# unterminated quote in an env_file comes back as the value itself), and the
+# requester is not trusted with it.
+CANARY="hunter2-canary"
+export CFG_RC=1
+export CFG_ERR="failed to read /etc/shadow: line 2: unterminated quoted value \"$CANARY\""
+check "a render error is not relayed to the caller"   reject '{"services":{"s":{}}}'
+unset CFG_RC CFG_ERR
+case "$LAST_OUT" in
+    *"$CANARY"*) bad "a render error is not relayed to the caller" "leaked: $LAST_OUT" ;;
+    *)           ok  "compose's own words stay host-side" ;;
+esac
+
+# The order is the point, not just the check: the default render READS every
+# env_file, so an env_file outside the workdir has to lose before it runs.
+RAW='{"services":{"s":{"env_file":[{"path":"/etc/shadow","required":true}]}}}'
+check "an env file outside is denied"           reject '{"services":{"s":{}}}'
+if grep -q default "$CALLS"; then
+    bad "the file is never read: the default render is skipped" "calls: $(tr '\n' ' ' < "$CALLS")"
+else
+    ok "the file is never read: the default render is skipped"
+fi
+
 # --- the validator is live -----------------------------------------------
 check "bind on /etc is denied"                  reject "$(bind /etc)"
 check "the Docker socket is denied"             reject "$(bind /var/run/docker.sock)"
 check "privileged is denied"                    reject '{"services":{"s":{"privileged":true}}}'
+
+# --- the denial as the requester actually sees it ------------------------
+# Every case above reads compose_validate_model's own return. What the sandbox
+# receives is handle_compose's JSON response, and a gate that rejects correctly
+# while the response reads as empty or successful is still a hole, so drive the
+# whole request path once and assert on what comes back.
+export SHELLM_BROKER_LOG="$WORK/broker.log"
+compose_request="$(printf '{"op":"compose","args":["up"],"cwd":"%s"}' "$SHELLM_BROKER_WORKDIR")"
+
+printf '{"services":{"s":{}}}' > "$CFG"
+printf '{"services":{"s":{"env_file":[{"path":"/etc/shadow","required":true}]}}}' > "$CFG_RAW"
+: > "$CALLS"
+response=$(handle_compose "$compose_request")
+got_code=$(printf '%s' "$response" | jq -r '.exit_code')
+got_err=$(printf '%s' "$response" | jq -r '.stderr')
+got_out=$(printf '%s' "$response" | jq -r '.stdout')
+if [[ "$got_code" == 65 && "$got_out" == "" && "$got_err" == *"outside SHELLM_WORKDIR"* ]]; then
+    ok "the requester gets the rejection, not an empty success"
+else
+    bad "the requester gets the rejection, not an empty success" "response: $response"
+fi
+
+# The reason a render failure is safe to swallow is that it is kept host-side.
+# If the log does not get it, the information is not redacted, it is gone.
+: > "$SHELLM_BROKER_LOG"
+: > "$CALLS"
+printf '{}' > "$CFG_RAW"
+export CFG_RC=1
+export CFG_ERR="failed to read /etc/shadow: line 2: unterminated quoted value \"$CANARY\""
+response=$(handle_compose "$compose_request")
+unset CFG_RC CFG_ERR
+got_err=$(printf '%s' "$response" | jq -r '.stderr')
+case "$got_err" in
+    *"$CANARY"*) bad "compose's words do not reach the requester" "leaked: $got_err" ;;
+    *)           ok  "compose's words do not reach the requester" ;;
+esac
+if grep -q "$CANARY" "$SHELLM_BROKER_LOG"; then
+    ok "and the operator can still read them in the broker log"
+else
+    bad "and the operator can still read them in the broker log" "log: $(cat "$SHELLM_BROKER_LOG")"
+fi
 
 echo
 echo "$pass passed, $fail failed"

--- a/tests/test_broker_compose_containment.sh
+++ b/tests/test_broker_compose_containment.sh
@@ -122,6 +122,22 @@ check "env_file outside is denied"              reject \
 check "env_file inside the workdir is allowed"  accept \
   "$(printf '{"services":{"s":{"env_file":[{"path":"%s/app.env","required":true}]}}}' "$SHELLM_BROKER_WORKDIR")"
 
+# The workdir's own spelling can be a symlink too: macOS hands mktemp a path
+# under /var, which is a symlink to /private/var, and CI caught this when every
+# accept case turned into a rejection there. Same rule as the paths: resolve it.
+symlink_root_case() {
+    local out rc
+    printf '%s' "$(bind "$WORK/alias/sub")" > "$CFG"
+    out=$(SHELLM_BROKER_WORKDIR="$WORK/alias" compose_validate_model '{}' "$WORK/alias" up 2>&1)
+    rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        ok "workdir spelled through a symlink still accepts what is inside it"
+    else
+        bad "workdir spelled through a symlink still accepts what is inside it" "rc=$rc${out:+ ($out)}"
+    fi
+}
+symlink_root_case
+
 # --- the validator is live -----------------------------------------------
 check "bind on /etc is denied"                  reject "$(bind /etc)"
 check "the Docker socket is denied"             reject "$(bind /var/run/docker.sock)"

--- a/tests/test_broker_compose_containment.sh
+++ b/tests/test_broker_compose_containment.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# tests/test_broker_compose_containment.sh — the broker's compose validator
+# must contain host paths at a directory boundary, not a string prefix.
+#
+# compose_validate_model is the ONLY gate on the bind sources, build contexts
+# and absolute Dockerfiles in a compose model the sandbox hands the broker;
+# handle_compose runs the real `docker compose` as soon as it returns 0. A
+# textual prefix test is not containment: it lets /host/work-secret through
+# while the workdir is /host/work, and `docker compose config` hands the
+# validator paths it has NOT normalised (an absolute source keeps its `..`,
+# verified against compose 2.40.3) and never resolves symlinks. So the check
+# resolves each path and gates it with path_under(), and the cases below are
+# the three ways out: the sibling prefix, the `..` climb, and the symlink.
+#
+# The real function is exercised against a stubbed `docker compose ... config`
+# so the resolved model is the input under test. The accept cases and the
+# unrelated rejections (privileged, docker.sock) are here to prove the
+# validator is live: without them a validator that rejected everything, or one
+# that never ran, would pass just as well.
+
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+# Not a skip: the broker cannot run without jq, so a green result here without
+# it would report a gate as verified that was never executed.
+command -v jq >/dev/null 2>&1 || { echo "FAIL jq not found — the broker needs it, so this proves nothing"; exit 1; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+export SHELLM_BROKER_WORKDIR="$WORK/work"
+mkdir -p "$SHELLM_BROKER_WORKDIR/sub" "$WORK/work-secret"
+ln -s "$WORK/work-secret" "$SHELLM_BROKER_WORKDIR/escape"   # symlink out, from inside
+ln -s "$SHELLM_BROKER_WORKDIR" "$WORK/alias"                # another spelling of the workdir
+
+# Source the broker for its functions: drop the trailing `main "$@"`, which
+# would otherwise print usage and exit.
+sed '$ d' "$REPO/tools/shellm-docker-broker" > "$WORK/broker.lib"
+
+# `docker compose ... config --format json` returns whatever the case wrote.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+cat "$CFG"
+STUB
+chmod +x "$WORK/bin/docker"
+export PATH="$WORK/bin:$PATH"
+export CFG="$WORK/cfg.json"
+
+# shellcheck disable=SC1090  # generated copy of the broker under test
+source "$WORK/broker.lib"
+set +e   # the broker sets -e; validation returning 65 is an expected outcome
+
+# check <name> accept|reject <compose-config-json> [request-json]
+#
+# A rejection has to be the containment verdict, not any nonzero exit: rc 65
+# with the "outside SHELLM_WORKDIR" message. Asserting only "nonzero" would let
+# a case pass because jq errored or the model failed to parse.
+check() {
+    local name="$1" want="$2" json="$3" request="${4:-}" out rc got
+    [[ -n "$request" ]] || request='{}'
+    printf '%s' "$json" > "$CFG"
+    out=$(compose_validate_model "$request" "$SHELLM_BROKER_WORKDIR" up 2>&1)
+    rc=$?
+    [[ "$rc" -eq 0 ]] && got=accept || got=reject
+    if [[ "$got" != "$want" ]]; then
+        bad "$name" "expected $want, got $got${out:+ ($out)}"
+    elif [[ "$want" == reject && "$rc" -ne 65 ]]; then
+        bad "$name" "rejected with rc=$rc, expected 65"
+    else
+        ok "$name"
+    fi
+}
+
+bind()    { printf '{"services":{"s":{"volumes":[{"type":"bind","source":"%s","target":"/x"}]}}}' "$1"; }
+context() { printf '{"services":{"s":{"build":{"context":"%s"}}}}' "$1"; }
+
+# --- the boundary itself -------------------------------------------------
+check "bind inside the workdir is allowed"      accept "$(bind "$SHELLM_BROKER_WORKDIR/sub")"
+check "bind on the workdir itself is allowed"   accept "$(bind "$SHELLM_BROKER_WORKDIR")"
+check "bind on a sibling prefix path is denied" reject "$(bind "$WORK/work-secret")"
+check "build context on a sibling is denied"    reject "$(context "$WORK/work-secret")"
+
+check "bind climbing out with .. is denied"      reject "$(bind "$SHELLM_BROKER_WORKDIR/../work-secret")"
+check "bind through a symlink out is denied"    reject "$(bind "$SHELLM_BROKER_WORKDIR/escape")"
+check "absolute Dockerfile outside is denied"   reject "$(printf '{"services":{"s":{"build":{"context":"%s","dockerfile":"/etc/Dockerfile"}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "a bind with no source is denied"         reject '{"services":{"s":{"volumes":[{"type":"bind","target":"/x"}]}}}'
+check "a path compose would create is allowed"  accept "$(bind "$SHELLM_BROKER_WORKDIR/not-yet/deep")"
+
+# --- the same rules through the workdir_alias spelling -------------------
+# A request whose .workdir resolves to the broker workdir may spell paths that
+# way; every case above must hold through that spelling too.
+alias_req="$(printf '{"workdir":"%s"}' "$WORK/alias")"
+check "alias: bind inside is allowed"           accept "$(bind "$WORK/alias/sub")"            "$alias_req"
+check "alias: sibling prefix is denied"         reject "$(bind "$WORK/alias-secret")"         "$alias_req"
+check "alias: .. climb is denied"               reject "$(bind "$WORK/alias/../work-secret")" "$alias_req"
+
+# A model the path extraction cannot parse must not read as "no paths to
+# object to". Against the pre-fix broker this is accepted.
+check "an unparseable model is denied"          reject 'not json at all'
+
+# --- the validator is live -----------------------------------------------
+check "bind on /etc is denied"                  reject "$(bind /etc)"
+check "the Docker socket is denied"             reject "$(bind /var/run/docker.sock)"
+check "privileged is denied"                    reject '{"services":{"s":{"privileged":true}}}'
+
+echo
+echo "$pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/tests/test_broker_compose_containment.sh
+++ b/tests/test_broker_compose_containment.sh
@@ -104,6 +104,24 @@ check "alias: .. climb is denied"               reject "$(bind "$WORK/alias/../w
 # object to". Against the pre-fix broker this is accepted.
 check "an unparseable model is denied"          reject 'not json at all'
 
+# --- the host paths that never pass through services[].volumes -----------
+# Each of these named a file outside the workdir and mounted it into a
+# brokered container while the bind check above was already in force.
+check "volume driver_opts.device outside is denied" reject \
+  "$(printf '{"services":{"s":{"volumes":[{"type":"volume","source":"esc","target":"/x"}]}},"volumes":{"esc":{"driver":"local","driver_opts":{"type":"none","device":"%s","o":"bind"}}}}' "$WORK/work-secret")"
+check "volume device inside the workdir is allowed" accept \
+  "$(printf '{"volumes":{"ok":{"driver":"local","driver_opts":{"type":"none","device":"%s","o":"bind"}}}}' "$SHELLM_BROKER_WORKDIR/sub")"
+check "secret file outside is denied"           reject '{"secrets":{"sec":{"file":"/etc/hostname"}}}'
+check "config file outside is denied"           reject '{"configs":{"c":{"file":"/etc/hostname"}}}'
+check "additional build context outside is denied" reject \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","additional_contexts":{"extra":"/etc"}}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "a non-path additional context is allowed" accept \
+  "$(printf '{"services":{"s":{"build":{"context":"%s","additional_contexts":{"img":"docker-image://alpine"}}}}}' "$SHELLM_BROKER_WORKDIR")"
+check "env_file outside is denied"              reject \
+  '{"services":{"s":{"env_file":[{"path":"/etc/hostname","required":true}]}}}'
+check "env_file inside the workdir is allowed"  accept \
+  "$(printf '{"services":{"s":{"env_file":[{"path":"%s/app.env","required":true}]}}}' "$SHELLM_BROKER_WORKDIR")"
+
 # --- the validator is live -----------------------------------------------
 check "bind on /etc is denied"                  reject "$(bind /etc)"
 check "the Docker socket is denied"             reject "$(bind /var/run/docker.sock)"

--- a/tools/shellm-docker-broker
+++ b/tools/shellm-docker-broker
@@ -113,6 +113,42 @@ symlink_allow_root() {
     printf '%s\n' "$1"
 }
 
+# Resolve a host path for containment without requiring it to exist: compose
+# marks missing bind sources create_host_path, so demanding existence would
+# reject work the sandbox is allowed to do. `realpath -m` would do this in one
+# call but is GNU-only, and this broker runs on macOS too, so walk up to the
+# deepest existing ancestor, resolve THAT (which is what follows symlinks),
+# and re-attach the tail. Callers reject `..` before calling, so the tail
+# cannot climb back out.
+resolve_for_containment() {
+    local path="$1"
+    local tail="" base resolved
+    while [[ ! -e "$path" && "$path" == */?* ]]; do
+        base="${path##*/}"
+        [[ -n "$base" ]] && tail="$base${tail:+/$tail}"
+        path="${path%/*}"
+        [[ -n "$path" ]] || path=/
+    done
+    resolved=$(realpath "$path" 2>/dev/null) || return 1
+    [[ -n "$tail" ]] && resolved="${resolved%/}/$tail"
+    printf '%s\n' "$resolved"
+}
+
+# One host path from a compose model, checked the way every other path in this
+# file is checked. Lexical containment is not enough here: `docker compose
+# config` leaves `..` in an ABSOLUTE bind source unnormalized (verified against
+# compose 2.40.3), and it never resolves symlinks, so a purely textual prefix
+# test blesses a string the daemon then resolves somewhere else entirely.
+path_contained() {
+    local path="$1"
+    local root="$2"
+    [[ "$path" == /* ]] || return 1
+    case "/$path/" in */../*) return 1 ;; esac
+    local resolved
+    resolved=$(resolve_for_containment "$path") || return 1
+    path_under "$resolved" "$root"
+}
+
 symlink_mounts() {
     local workdir="$1"
     # The agent has write access to its own workdir, so every symlink in there
@@ -418,6 +454,31 @@ handle_version() {
     run_capture "${cmd[@]}"
 }
 
+# The host paths a compose model names, emitted as NUL-terminated
+# "service<TAB>kind<TAB>path" records for the bash containment check below. A
+# missing or non-string source becomes an empty path so it is rejected rather
+# than skipped: the old jq predicate only flagged strings, so a null passed.
+# `read -d ''` returns nonzero at EOF, which set -e would treat as fatal.
+read -r -d '' PATHS_PROGRAM <<'JQ' || true
+
+            def build_contexts($b):
+              if $b == null then []
+              elif ($b | type) == "string" then [$b]
+              elif ($b | type) == "object" then [$b.context // ""]
+              else [] end;
+            def build_dockerfiles($b):
+              if ($b | type) == "object" and (($b.dockerfile // "") | startswith("/")) then [$b.dockerfile]
+              else [] end;
+            def emit($svc; $kind; $p):
+              "\($svc)\t\($kind)\t\(if ($p | type) == "string" then $p else "" end)\u0000";
+
+            .services // {} | to_entries[] as $svc |
+            ($svc.value // {}) as $s |
+            (build_contexts($s.build // null)[] | emit($svc.key; "context"; .)),
+            (build_dockerfiles($s.build // null)[] | emit($svc.key; "dockerfile"; .)),
+            (($s.volumes // [])[] | select(.type == "bind") | emit($svc.key; "bind"; .source // ""))
+JQ
+
 compose_validate_model() {
     local request="$1"
     local cwd="$2"
@@ -437,30 +498,8 @@ compose_validate_model() {
         return "$rc"
     fi
 
-    local request_workdir workdir_alias message
-    request_workdir=$(printf '%s' "$request" | jq -r '.workdir // empty')
-    workdir_alias=""
-    if [[ -n "$request_workdir" ]] && [[ "$(realpath "$request_workdir" 2>/dev/null || true)" == "$SHELLM_BROKER_WORKDIR" ]]; then
-        workdir_alias="$request_workdir"
-    fi
-
-    message=$(jq -r --arg workdir "$SHELLM_BROKER_WORKDIR" --arg workdir_alias "$workdir_alias" '
-        def under_allowed_root($p):
-          ($p | startswith($workdir)) or
-          (($workdir_alias | length) > 0 and ($p | startswith($workdir_alias)));
-        def bad_path($p):
-          ($p | type == "string") and
-          ($p == "/var/run/docker.sock" or ($p | startswith("/var/run/docker.sock/")) or
-           (under_allowed_root($p) | not));
-        def build_contexts($b):
-          if $b == null then []
-          elif ($b | type) == "string" then [$b]
-          elif ($b | type) == "object" then [$b.context // empty]
-          else [] end;
-        def build_dockerfiles($b):
-          if ($b | type) == "object" and (($b.dockerfile // "") | startswith("/")) then [$b.dockerfile]
-          else [] end;
-
+    local message
+    message=$(jq -r '
         .services // {} | to_entries[] as $svc |
         ($svc.value // {}) as $s |
         if ($s.privileged == true) then
@@ -469,10 +508,6 @@ compose_validate_model() {
           "service \($svc.key) requests cap_add"
         elif (($s.devices // []) | length) > 0 then
           "service \($svc.key) requests devices"
-        elif (build_contexts($s.build // null) | map(select(bad_path(.))) | length) > 0 then
-          "service \($svc.key) builds from a context outside SHELLM_WORKDIR"
-        elif (build_dockerfiles($s.build // null) | map(select(bad_path(.))) | length) > 0 then
-          "service \($svc.key) uses a Dockerfile outside SHELLM_WORKDIR"
         elif (($s.security_opt // []) | map(tostring) | any(. == "seccomp=unconfined" or . == "apparmor=unconfined")) then
           "service \($svc.key) disables container security policy"
         elif (($s.network_mode // "") | tostring) == "host" then
@@ -483,14 +518,40 @@ compose_validate_model() {
           "service \($svc.key) requests host ipc namespace"
         elif (($s.cgroup // "") | tostring) == "host" then
           "service \($svc.key) requests host cgroup namespace"
-        elif (($s.volumes // []) | map(select(.type == "bind") | select(bad_path(.source))) | length) > 0 then
-          "service \($svc.key) bind-mounts a host path outside SHELLM_WORKDIR"
         elif (($s.volumes // []) | map(select((.source // "") == "/var/run/docker.sock" or (.target // "") == "/var/run/docker.sock")) | length) > 0 then
           "service \($svc.key) tries to mount the Docker socket"
         else
           empty
         end
     ' "$config" | head -1)
+
+    # Every host path the model names, one NUL-terminated "service<TAB>kind<TAB>path"
+    # record each, checked in bash against the resolved workdir. A missing or
+    # non-string source is emitted as an empty path so it is rejected rather than
+    # skipped: the old jq predicate only flagged strings, so a null source passed.
+    if [[ -z "$message" ]]; then
+        # Collect first and check jq's status: a failure here must not read as
+        # "no paths to object to". The loop below runs in this shell (process
+        # substitution, not a pipe) so the verdict survives it.
+        local paths svc kind candidate
+        paths=$(mktemp)
+        if ! jq -j "$PATHS_PROGRAM" "$config" > "$paths" 2>/dev/null; then
+            rm -f "$paths" "$config" "$err"
+            printf 'compose model could not be inspected for host paths\n' >&2
+            return 65
+        fi
+        while IFS=$'\t' read -r -d '' svc kind candidate; do
+            path_contained "$candidate" "$SHELLM_BROKER_WORKDIR" && continue
+            case "$kind" in
+                context) message="service $svc builds from a context outside SHELLM_WORKDIR" ;;
+                dockerfile) message="service $svc uses a Dockerfile outside SHELLM_WORKDIR" ;;
+                *) message="service $svc bind-mounts a host path outside SHELLM_WORKDIR" ;;
+            esac
+            break
+        done < "$paths"
+        rm -f "$paths"
+    fi
+
     rm -f "$config" "$err"
     [[ -z "$message" ]] || { printf '%s\n' "$message" >&2; return 65; }
     return 0

--- a/tools/shellm-docker-broker
+++ b/tools/shellm-docker-broker
@@ -585,6 +585,13 @@ compose_validate_model() {
     # non-string source is emitted as an empty path so it is rejected rather than
     # skipped: the old jq predicate only flagged strings, so a null source passed.
     if [[ -z "$message" ]]; then
+        # Resolve the root as well as the candidates. start_broker realpaths the
+        # workdir before exporting it, but a check whose whole job is to distrust
+        # a spelling must not depend on its caller having done that: where /tmp
+        # or /var is itself a symlink (macOS), an unresolved root makes every
+        # path inside the workdir compare as outside it.
+        local root
+        root=$(realpath "$SHELLM_BROKER_WORKDIR" 2>/dev/null) || root="$SHELLM_BROKER_WORKDIR"
         # Collect first and check jq's status: a failure here must not read as
         # "no paths to object to". The loop below runs in this shell (process
         # substitution, not a pipe) so the verdict survives it.
@@ -597,7 +604,7 @@ compose_validate_model() {
             return 65
         fi
         while IFS=$'\t' read -r -d '' svc kind candidate; do
-            path_contained "$candidate" "$SHELLM_BROKER_WORKDIR" && continue
+            path_contained "$candidate" "$root" && continue
             case "$kind" in
                 context) message="service $svc builds from a context outside SHELLM_WORKDIR" ;;
                 dockerfile) message="service $svc uses a Dockerfile outside SHELLM_WORKDIR" ;;

--- a/tools/shellm-docker-broker
+++ b/tools/shellm-docker-broker
@@ -120,10 +120,18 @@ symlink_allow_root() {
 # deepest existing ancestor, resolve THAT (which is what follows symlinks),
 # and re-attach the tail. Callers reject `..` before calling, so the tail
 # cannot climb back out.
+#
+# The walk stops at a symlink as well as at anything that exists, because `-e`
+# is false for a DANGLING one. Without the `-L` test a dangling link reads as a
+# missing component: the walk strips it, resolves the parent it sits in, and
+# re-attaches the name, so the link is judged at its own location while the
+# daemon would follow it to the target. Stopping here hands the link to
+# realpath, which fails on a dangling target, and a path that cannot be
+# resolved is rejected.
 resolve_for_containment() {
     local path="$1"
     local tail="" base resolved
-    while [[ ! -e "$path" && "$path" == */?* ]]; do
+    while [[ ! -e "$path" && ! -L "$path" && "$path" == */?* ]]; do
         base="${path##*/}"
         [[ -n "$base" ]] && tail="$base${tail:+/$tail}"
         path="${path%/*}"
@@ -460,17 +468,38 @@ handle_version() {
 # than skipped: the old jq predicate only flagged strings, so a null passed.
 #
 # The bind sources and build contexts are not the whole surface. A named volume
-# with driver_opts.device, a secret or config with `file:`, and an extra build
-# context all name a host path too, and none of them passes through
-# .services[].volumes. Verified by execution before this was written: a volume
-# device and a secret file each mounted a host file from outside SHELLM_WORKDIR
-# into a brokered container while the bind check was already in force.
+# with driver_opts.device, a secret or config with `file:`, an extra build
+# context, a build ssh key, a local build cache, and a develop.watch path all
+# name a host path too, and none of them passes through .services[].volumes.
+# Verified by execution before this was written: a volume device and a secret
+# file each mounted a host file from outside SHELLM_WORKDIR into a brokered
+# container while the bind check was already in force, and compose 2.40.3
+# renders a develop.watch path and a `type=local,src=` cache entry pointing
+# anywhere on the host.
 #
-# additional_contexts values are not all paths -- `docker-image://`, `service:`
-# and git URLs share that map -- so only absolute ones are host paths to check.
-# A driver_opts.device is always checked: a device that is not an absolute path
-# (an NFS "host:/export", say) is not something this broker should hand out
-# either, and path_contained rejects it.
+# What this program does NOT cover, and why:
+#   - env_file and label_file: the default render consumes both, so their paths
+#     survive only in the uninterpolated render. RAW_PATHS_PROGRAM below reads
+#     them from there, and compose_validate_model checks them before the render
+#     that would read the files.
+#   - extends.file and top-level include: compose merges them away, so no path
+#     reaches either render. What they pull in becomes ordinary services, whose
+#     paths this program then checks (an extends.file naming /etc as a bind
+#     source is rejected as a bind). The residual is that compose reads the
+#     named YAML while rendering, which is why a render failure no longer
+#     relays compose's stderr to the caller.
+#   - build.env_file: not in the 2.40.3 schema; compose rejects the model.
+#
+# A value is skipped only when it cannot be a host path. additional_contexts
+# shares its map with `docker-image://`, `service:`, `oci-layout://` and git or
+# http(s)/ssh URLs, and those are the only values passed over: everything else,
+# absolute or not, goes to path_contained to accept or reject. Compose 2.40.3
+# resolves a relative additional context against the project directory before
+# this sees it, but a filter that drops what it does not recognise is the wrong
+# default in a gate, so the recognising is done on the non-paths instead. Same
+# reason a driver_opts.device is always checked: a device that is not an
+# absolute path (an NFS "host:/export", say) is not something this broker
+# should hand out either, and path_contained rejects it.
 # `read -d ''` returns nonzero at EOF, which set -e would treat as fatal.
 read -r -d '' PATHS_PROGRAM <<'JQ' || true
 
@@ -482,10 +511,37 @@ read -r -d '' PATHS_PROGRAM <<'JQ' || true
             def build_dockerfiles($b):
               if ($b | type) == "object" and (($b.dockerfile // "") | startswith("/")) then [$b.dockerfile]
               else [] end;
+            def non_path($v):
+              ["docker-image://", "oci-layout://", "service:", "git://",
+               "http://", "https://", "ssh://"] | any(. as $p | $v | startswith($p));
             def extra_contexts($b):
               if ($b | type) == "object" and (($b.additional_contexts // null) | type) == "object"
-              then [$b.additional_contexts[] | select((type == "string") and startswith("/"))]
+              then [$b.additional_contexts[]
+                    | if type == "string" then . else "" end
+                    | select(non_path(.) | not)]
               else [] end;
+            def ssh_keys($b):
+              if ($b | type) != "object" then []
+              else [(($b.ssh // []) | if type == "object" then [.[]] else . end)[]
+                    | if type != "string" then ""
+                      elif index("=") then sub("^[^=]*="; "")
+                      else empty end
+                    | select(. != "")]
+              end;
+            def cache_paths($b; $field):
+              if ($b | type) != "object" then []
+              else [(($b[$field] // []) | if type == "array" then . else [.] end)[]
+                    | if type != "string" then ""
+                      else (split(",")[]
+                            | select(startswith("src=") or startswith("dest="))
+                            | sub("^[^=]*="; ""))
+                      end]
+              end;
+            def watch_paths($s):
+              [((($s.develop // {}) | if type == "object" then (.watch // []) else [] end)
+                | if type == "array" then . else [] end)[]
+               | if type == "object" then (.path // "") else "" end
+               | if type == "string" then . else "" end];
             def emit($name; $kind; $p):
               "\($name)\t\($kind)\t\(if ($p | type) == "string" then $p else "" end)\u0000";
 
@@ -494,6 +550,10 @@ read -r -d '' PATHS_PROGRAM <<'JQ' || true
              (build_contexts($s.build // null)[] | emit($svc.key; "context"; .)),
              (build_dockerfiles($s.build // null)[] | emit($svc.key; "dockerfile"; .)),
              (extra_contexts($s.build // null)[] | emit($svc.key; "extra-context"; .)),
+             (ssh_keys($s.build // null)[] | emit($svc.key; "ssh-key"; .)),
+             (cache_paths($s.build // null; "cache_from")[] | emit($svc.key; "cache"; .)),
+             (cache_paths($s.build // null; "cache_to")[] | emit($svc.key; "cache"; .)),
+             (watch_paths($s)[] | emit($svc.key; "watch"; .)),
              (($s.volumes // [])[] | select(.type == "bind") | emit($svc.key; "bind"; .source // ""))),
             (.volumes // {} | to_entries[]
              | select((.value.driver_opts // null) | type == "object")
@@ -503,32 +563,107 @@ read -r -d '' PATHS_PROGRAM <<'JQ' || true
             (.configs // {} | to_entries[] | select(.value | has("file")) | emit(.key; "config"; .value.file))
 JQ
 
-# env_file is the one host path `docker compose config` destroys before the
-# validator sees it: the default render reads each file and inlines the values
-# into `environment`, leaving env_file null, so the paths are simply not in the
-# model (checked against compose 2.40.3; --no-env-resolution does not preserve
-# them either). --no-interpolate does keep them, with relative paths already
-# resolved against the project directory, so they come from a second render of
-# the same model. The cost is that an env_file spelled with an unexpanded
-# ${VAR} stays literal there and is rejected as non-absolute, which is the safe
-# direction.
-read -r -d '' ENV_FILE_PROGRAM <<'JQ' || true
+# env_file and label_file are the host paths `docker compose config` destroys
+# before the validator sees them: the default render reads each file and inlines
+# what it finds (values into `environment`, labels into `labels`), leaving the
+# path fields null, so they are simply not in the model (checked against compose
+# 2.40.3; --no-env-resolution does not preserve them either). --no-interpolate
+# does keep them, with relative paths already resolved against the project
+# directory, so they come from a second render of the same model. The cost is
+# that a path spelled with an unexpanded ${VAR} stays literal there and is
+# rejected as non-absolute, which is the safe direction.
+read -r -d '' RAW_PATHS_PROGRAM <<'JQ' || true
 
             def emit($name; $kind; $p):
               "\($name)\t\($kind)\t\(if ($p | type) == "string" then $p else "" end)\u0000";
             .services // {} | to_entries[] as $svc |
-            (($svc.value.env_file // []) | if type == "array" then . else [.] end)[]
-            | emit($svc.key; "env-file"; (if type == "object" then (.path // "") else . end))
+            ((($svc.value.env_file // []) | if type == "array" then . else [.] end)[]
+             | emit($svc.key; "env-file"; (if type == "object" then (.path // "") else . end))),
+            ((($svc.value.label_file // []) | if type == "array" then . else [.] end)[]
+             | emit($svc.key; "label-file"; .))
 JQ
+
+# A compose render that fails says why in compose's own words, and those words
+# can carry the contents of a host file: point env_file at any file on the host
+# and an unterminated quote comes back as `unterminated quoted value "<the
+# value>"` (compose 2.40.3, verified). The requester is not trusted with that,
+# so the reason is logged host-side and the caller gets a fixed message.
+compose_render_failed() {
+    local err="$1" message="$2"
+    log_msg "compose render failed: $(tr '\n' ' ' < "$err" | cut -c1-500)"
+    printf '%s\n' "$message" >&2
+}
+
+# The first path in `paths` that is not inside `root`, as the message to reject
+# the request with. Prints nothing when every path is contained.
+compose_containment_message() {
+    local paths="$1" root="$2"
+    local svc kind candidate
+    while IFS=$'\t' read -r -d '' svc kind candidate; do
+        path_contained "$candidate" "$root" && continue
+        case "$kind" in
+            context) printf 'service %s builds from a context outside SHELLM_WORKDIR\n' "$svc" ;;
+            dockerfile) printf 'service %s uses a Dockerfile outside SHELLM_WORKDIR\n' "$svc" ;;
+            extra-context) printf 'service %s uses an additional build context outside SHELLM_WORKDIR\n' "$svc" ;;
+            ssh-key) printf 'service %s builds with an ssh key outside SHELLM_WORKDIR\n' "$svc" ;;
+            cache) printf 'service %s uses a build cache outside SHELLM_WORKDIR\n' "$svc" ;;
+            watch) printf 'service %s watches a path outside SHELLM_WORKDIR\n' "$svc" ;;
+            env-file) printf 'service %s reads an env file outside SHELLM_WORKDIR\n' "$svc" ;;
+            label-file) printf 'service %s reads a label file outside SHELLM_WORKDIR\n' "$svc" ;;
+            volume-device) printf 'volume %s mounts a host path outside SHELLM_WORKDIR\n' "$svc" ;;
+            secret) printf 'secret %s reads a file outside SHELLM_WORKDIR\n' "$svc" ;;
+            config) printf 'config %s reads a file outside SHELLM_WORKDIR\n' "$svc" ;;
+            *) printf 'service %s bind-mounts a host path outside SHELLM_WORKDIR\n' "$svc" ;;
+        esac
+        return 0
+    done < "$paths"
+}
 
 compose_validate_model() {
     local request="$1"
     local cwd="$2"
     shift 2
-    local config config_raw err rc
+    local config config_raw paths err rc message root
     config=$(mktemp)
     config_raw=$(mktemp)
+    paths=$(mktemp)
     err=$(mktemp)
+
+    # Resolve the root as well as the candidates. start_broker realpaths the
+    # workdir before exporting it, but a check whose whole job is to distrust a
+    # spelling must not depend on its caller having done that: where /tmp or
+    # /var is itself a symlink (macOS), an unresolved root makes every path
+    # inside the workdir compare as outside it.
+    root=$(realpath "$SHELLM_BROKER_WORKDIR" 2>/dev/null) || root="$SHELLM_BROKER_WORKDIR"
+
+    # The uninterpolated render runs FIRST because it is the only one that still
+    # names the env_file and label_file paths, and the render below READS those
+    # files. Checking them afterwards would be checking a file compose has
+    # already opened and quoted back in its errors. Its failure is a rejection
+    # rather than a shrug: without it that surface goes unchecked.
+    rc=0
+    (
+        cd "$cwd" || exit 1
+        apply_request_env "$request"
+        docker compose "$@" config --format json --no-interpolate
+    ) >"$config_raw" 2>"$err" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        compose_render_failed "$err" "compose model could not be inspected for the files it reads"
+        rm -f "$config" "$config_raw" "$paths" "$err"
+        return 65
+    fi
+    if ! jq -j "$RAW_PATHS_PROGRAM" "$config_raw" > "$paths" 2>/dev/null; then
+        rm -f "$config" "$config_raw" "$paths" "$err"
+        printf 'compose model could not be inspected for host paths\n' >&2
+        return 65
+    fi
+    message=$(compose_containment_message "$paths" "$root")
+    if [[ -n "$message" ]]; then
+        rm -f "$config" "$config_raw" "$paths" "$err"
+        printf '%s\n' "$message" >&2
+        return 65
+    fi
+
     rc=0
     (
         cd "$cwd" || exit 1
@@ -536,24 +671,11 @@ compose_validate_model() {
         docker compose "$@" config --format json
     ) >"$config" 2>"$err" || rc=$?
     if [[ "$rc" -ne 0 ]]; then
-        cat "$err" >&2
-        rm -f "$config" "$config_raw" "$err"
-        return "$rc"
-    fi
-    # Second render, uninterpolated, purely to recover the env_file paths the
-    # first one consumes. Its failure is a rejection rather than a shrug:
-    # without it the env_file surface goes unchecked.
-    (
-        cd "$cwd" || exit 1
-        apply_request_env "$request"
-        docker compose "$@" config --format json --no-interpolate
-    ) >"$config_raw" 2>/dev/null || {
-        rm -f "$config" "$config_raw" "$err"
-        printf 'compose model could not be inspected for env files\n' >&2
+        compose_render_failed "$err" "compose model could not be rendered"
+        rm -f "$config" "$config_raw" "$paths" "$err"
         return 65
-    }
+    fi
 
-    local message
     message=$(jq -r '
         .services // {} | to_entries[] as $svc |
         ($svc.value // {}) as $s |
@@ -580,47 +702,20 @@ compose_validate_model() {
         end
     ' "$config" | head -1)
 
-    # Every host path the model names, one NUL-terminated "service<TAB>kind<TAB>path"
-    # record each, checked in bash against the resolved workdir. A missing or
-    # non-string source is emitted as an empty path so it is rejected rather than
-    # skipped: the old jq predicate only flagged strings, so a null source passed.
+    # The host paths the rendered model names, one NUL-terminated
+    # "service<TAB>kind<TAB>path" record each, checked in bash against the
+    # resolved workdir. Collect first and check jq's status: a failure here must
+    # not read as "no paths to object to".
     if [[ -z "$message" ]]; then
-        # Resolve the root as well as the candidates. start_broker realpaths the
-        # workdir before exporting it, but a check whose whole job is to distrust
-        # a spelling must not depend on its caller having done that: where /tmp
-        # or /var is itself a symlink (macOS), an unresolved root makes every
-        # path inside the workdir compare as outside it.
-        local root
-        root=$(realpath "$SHELLM_BROKER_WORKDIR" 2>/dev/null) || root="$SHELLM_BROKER_WORKDIR"
-        # Collect first and check jq's status: a failure here must not read as
-        # "no paths to object to". The loop below runs in this shell (process
-        # substitution, not a pipe) so the verdict survives it.
-        local paths svc kind candidate
-        paths=$(mktemp)
-        if ! jq -j "$PATHS_PROGRAM" "$config" > "$paths" 2>/dev/null \
-           || ! jq -j "$ENV_FILE_PROGRAM" "$config_raw" >> "$paths" 2>/dev/null; then
-            rm -f "$paths" "$config" "$config_raw" "$err"
+        if ! jq -j "$PATHS_PROGRAM" "$config" > "$paths" 2>/dev/null; then
+            rm -f "$config" "$config_raw" "$paths" "$err"
             printf 'compose model could not be inspected for host paths\n' >&2
             return 65
         fi
-        while IFS=$'\t' read -r -d '' svc kind candidate; do
-            path_contained "$candidate" "$root" && continue
-            case "$kind" in
-                context) message="service $svc builds from a context outside SHELLM_WORKDIR" ;;
-                dockerfile) message="service $svc uses a Dockerfile outside SHELLM_WORKDIR" ;;
-                extra-context) message="service $svc uses an additional build context outside SHELLM_WORKDIR" ;;
-                env-file) message="service $svc reads an env file outside SHELLM_WORKDIR" ;;
-                volume-device) message="volume $svc mounts a host path outside SHELLM_WORKDIR" ;;
-                secret) message="secret $svc reads a file outside SHELLM_WORKDIR" ;;
-                config) message="config $svc reads a file outside SHELLM_WORKDIR" ;;
-                *) message="service $svc bind-mounts a host path outside SHELLM_WORKDIR" ;;
-            esac
-            break
-        done < "$paths"
-        rm -f "$paths"
+        message=$(compose_containment_message "$paths" "$root")
     fi
 
-    rm -f "$config" "$config_raw" "$err"
+    rm -f "$config" "$config_raw" "$paths" "$err"
     [[ -z "$message" ]] || { printf '%s\n' "$message" >&2; return 65; }
     return 0
 }

--- a/tools/shellm-docker-broker
+++ b/tools/shellm-docker-broker
@@ -455,9 +455,22 @@ handle_version() {
 }
 
 # The host paths a compose model names, emitted as NUL-terminated
-# "service<TAB>kind<TAB>path" records for the bash containment check below. A
-# missing or non-string source becomes an empty path so it is rejected rather
+# "name<TAB>kind<TAB>path" records for the bash containment check below. A
+# missing or non-string path becomes an empty string so it is rejected rather
 # than skipped: the old jq predicate only flagged strings, so a null passed.
+#
+# The bind sources and build contexts are not the whole surface. A named volume
+# with driver_opts.device, a secret or config with `file:`, and an extra build
+# context all name a host path too, and none of them passes through
+# .services[].volumes. Verified by execution before this was written: a volume
+# device and a secret file each mounted a host file from outside SHELLM_WORKDIR
+# into a brokered container while the bind check was already in force.
+#
+# additional_contexts values are not all paths -- `docker-image://`, `service:`
+# and git URLs share that map -- so only absolute ones are host paths to check.
+# A driver_opts.device is always checked: a device that is not an absolute path
+# (an NFS "host:/export", say) is not something this broker should hand out
+# either, and path_contained rejects it.
 # `read -d ''` returns nonzero at EOF, which set -e would treat as fatal.
 read -r -d '' PATHS_PROGRAM <<'JQ' || true
 
@@ -469,22 +482,52 @@ read -r -d '' PATHS_PROGRAM <<'JQ' || true
             def build_dockerfiles($b):
               if ($b | type) == "object" and (($b.dockerfile // "") | startswith("/")) then [$b.dockerfile]
               else [] end;
-            def emit($svc; $kind; $p):
-              "\($svc)\t\($kind)\t\(if ($p | type) == "string" then $p else "" end)\u0000";
+            def extra_contexts($b):
+              if ($b | type) == "object" and (($b.additional_contexts // null) | type) == "object"
+              then [$b.additional_contexts[] | select((type == "string") and startswith("/"))]
+              else [] end;
+            def emit($name; $kind; $p):
+              "\($name)\t\($kind)\t\(if ($p | type) == "string" then $p else "" end)\u0000";
 
+            (.services // {} | to_entries[] as $svc |
+             ($svc.value // {}) as $s |
+             (build_contexts($s.build // null)[] | emit($svc.key; "context"; .)),
+             (build_dockerfiles($s.build // null)[] | emit($svc.key; "dockerfile"; .)),
+             (extra_contexts($s.build // null)[] | emit($svc.key; "extra-context"; .)),
+             (($s.volumes // [])[] | select(.type == "bind") | emit($svc.key; "bind"; .source // ""))),
+            (.volumes // {} | to_entries[]
+             | select((.value.driver_opts // null) | type == "object")
+             | select(.value.driver_opts | has("device"))
+             | emit(.key; "volume-device"; .value.driver_opts.device)),
+            (.secrets // {} | to_entries[] | select(.value | has("file")) | emit(.key; "secret"; .value.file)),
+            (.configs // {} | to_entries[] | select(.value | has("file")) | emit(.key; "config"; .value.file))
+JQ
+
+# env_file is the one host path `docker compose config` destroys before the
+# validator sees it: the default render reads each file and inlines the values
+# into `environment`, leaving env_file null, so the paths are simply not in the
+# model (checked against compose 2.40.3; --no-env-resolution does not preserve
+# them either). --no-interpolate does keep them, with relative paths already
+# resolved against the project directory, so they come from a second render of
+# the same model. The cost is that an env_file spelled with an unexpanded
+# ${VAR} stays literal there and is rejected as non-absolute, which is the safe
+# direction.
+read -r -d '' ENV_FILE_PROGRAM <<'JQ' || true
+
+            def emit($name; $kind; $p):
+              "\($name)\t\($kind)\t\(if ($p | type) == "string" then $p else "" end)\u0000";
             .services // {} | to_entries[] as $svc |
-            ($svc.value // {}) as $s |
-            (build_contexts($s.build // null)[] | emit($svc.key; "context"; .)),
-            (build_dockerfiles($s.build // null)[] | emit($svc.key; "dockerfile"; .)),
-            (($s.volumes // [])[] | select(.type == "bind") | emit($svc.key; "bind"; .source // ""))
+            (($svc.value.env_file // []) | if type == "array" then . else [.] end)[]
+            | emit($svc.key; "env-file"; (if type == "object" then (.path // "") else . end))
 JQ
 
 compose_validate_model() {
     local request="$1"
     local cwd="$2"
     shift 2
-    local config err rc
+    local config config_raw err rc
     config=$(mktemp)
+    config_raw=$(mktemp)
     err=$(mktemp)
     rc=0
     (
@@ -494,9 +537,21 @@ compose_validate_model() {
     ) >"$config" 2>"$err" || rc=$?
     if [[ "$rc" -ne 0 ]]; then
         cat "$err" >&2
-        rm -f "$config" "$err"
+        rm -f "$config" "$config_raw" "$err"
         return "$rc"
     fi
+    # Second render, uninterpolated, purely to recover the env_file paths the
+    # first one consumes. Its failure is a rejection rather than a shrug:
+    # without it the env_file surface goes unchecked.
+    (
+        cd "$cwd" || exit 1
+        apply_request_env "$request"
+        docker compose "$@" config --format json --no-interpolate
+    ) >"$config_raw" 2>/dev/null || {
+        rm -f "$config" "$config_raw" "$err"
+        printf 'compose model could not be inspected for env files\n' >&2
+        return 65
+    }
 
     local message
     message=$(jq -r '
@@ -535,8 +590,9 @@ compose_validate_model() {
         # substitution, not a pipe) so the verdict survives it.
         local paths svc kind candidate
         paths=$(mktemp)
-        if ! jq -j "$PATHS_PROGRAM" "$config" > "$paths" 2>/dev/null; then
-            rm -f "$paths" "$config" "$err"
+        if ! jq -j "$PATHS_PROGRAM" "$config" > "$paths" 2>/dev/null \
+           || ! jq -j "$ENV_FILE_PROGRAM" "$config_raw" >> "$paths" 2>/dev/null; then
+            rm -f "$paths" "$config" "$config_raw" "$err"
             printf 'compose model could not be inspected for host paths\n' >&2
             return 65
         fi
@@ -545,6 +601,11 @@ compose_validate_model() {
             case "$kind" in
                 context) message="service $svc builds from a context outside SHELLM_WORKDIR" ;;
                 dockerfile) message="service $svc uses a Dockerfile outside SHELLM_WORKDIR" ;;
+                extra-context) message="service $svc uses an additional build context outside SHELLM_WORKDIR" ;;
+                env-file) message="service $svc reads an env file outside SHELLM_WORKDIR" ;;
+                volume-device) message="volume $svc mounts a host path outside SHELLM_WORKDIR" ;;
+                secret) message="secret $svc reads a file outside SHELLM_WORKDIR" ;;
+                config) message="config $svc reads a file outside SHELLM_WORKDIR" ;;
                 *) message="service $svc bind-mounts a host path outside SHELLM_WORKDIR" ;;
             esac
             break
@@ -552,7 +613,7 @@ compose_validate_model() {
         rm -f "$paths"
     fi
 
-    rm -f "$config" "$err"
+    rm -f "$config" "$config_raw" "$err"
     [[ -z "$message" ]] || { printf '%s\n' "$message" >&2; return 65; }
     return 0
 }
@@ -745,25 +806,26 @@ handle_compose() {
             ;;
     esac
 
-    if [[ "$subcommand" != "config" ]]; then
-        local validation_out validation_err validation_rc
-        validation_out=$(mktemp)
-        validation_err=$(mktemp)
-        set +e
-        if [[ "${#global_args[@]}" -gt 0 ]]; then
-            compose_validate_model "$request" "$cwd" "${global_args[@]}" >"$validation_out" 2>"$validation_err"
-        else
-            compose_validate_model "$request" "$cwd" >"$validation_out" 2>"$validation_err"
-        fi
-        validation_rc=$?
-        set -e
-        if [[ "$validation_rc" -ne 0 ]]; then
-            json_response "$validation_rc" "$validation_out" "$validation_err"
-            rm -f "$validation_out" "$validation_err"
-            return
-        fi
-        rm -f "$validation_out" "$validation_err"
+    # `config` is validated like every other subcommand. It renders the model
+    # back to the caller and compose inlines the contents of every env_file
+    # into that render, so exempting it hands out host files verbatim.
+    local validation_out validation_err validation_rc
+    validation_out=$(mktemp)
+    validation_err=$(mktemp)
+    set +e
+    if [[ "${#global_args[@]}" -gt 0 ]]; then
+        compose_validate_model "$request" "$cwd" "${global_args[@]}" >"$validation_out" 2>"$validation_err"
+    else
+        compose_validate_model "$request" "$cwd" >"$validation_out" 2>"$validation_err"
     fi
+    validation_rc=$?
+    set -e
+    if [[ "$validation_rc" -ne 0 ]]; then
+        json_response "$validation_rc" "$validation_out" "$validation_err"
+        rm -f "$validation_out" "$validation_err"
+        return
+    fi
+    rm -f "$validation_out" "$validation_err"
 
     log_msg "compose project_dir=$project_dir subcommand=$subcommand argc=${#args[@]}"
     local -a cmd=(docker compose)


### PR DESCRIPTION
`compose_validate_model` is the only gate between a compose model the sandbox authors and the host filesystem: `handle_compose` runs the real `docker compose` the moment it returns 0. It was not containing host paths. Both commits are about that, and both are reachable only with `SHELLM_DOCKER_ACCESS=broker`, which is opt-in.

**Containment by resolution, not by string prefix.** `under_allowed_root` was `startswith($workdir)`, and nothing resolved the path first, so three things got through: a sibling directory sharing the prefix (`/host/work` accepted a bind on `/host/work-secret`), an absolute source carrying `..` (compose normalizes a relative source but leaves an absolute one verbatim, checked on 2.40.3), and a symlink created inside the workdir pointing out. Every other containment site in the file already routes through `realpath` and `path_under()`; this one now does too. jq emits the candidate paths, bash rejects a relative path or any `..` component, resolves the rest, and gates with `path_under()`. Resolution is lenient about a missing tail because compose creates a missing bind source, and `realpath -m` is GNU-only while this also runs on macOS.

Two things fell out of that. The `workdir_alias` branch is gone, since an aliased spelling now resolves to the workdir like anything else. And a bind whose source is missing or not a string, or a model the extraction cannot parse, is rejected rather than skipped.

**Every host path the model names.** The check only ever read `services[].volumes[]` binds, build contexts and absolute Dockerfiles. A named volume with `driver_opts.device`, `secrets:`/`configs:` with `file:`, `build.additional_contexts` and `env_file` all name a host path and reach the daemon without passing any of them. `env_file` needs a second `--no-interpolate` render to see at all: the default render reads each file and inlines the values into `environment`, leaving `env_file` null, so the paths are gone before validation runs. `config` is no longer exempt from validation either, because the render it hands back carries those inlined values.

Two fail-closed edges worth flagging. `additional_contexts` values are checked only when absolute, since `docker-image://` and `service:` references share that map. A `driver_opts.device` is always checked, so a device that is not an absolute path (an NFS `host:/export`) is rejected rather than passed through.

## Verification

`tests/test_broker_compose_containment.sh` is new and drives the real function against a stubbed `docker compose config`. 24 cases; every reject asserts rc 65 rather than merely nonzero, and the accept cases and the unrelated rejections are there so a validator that denied everything, or never ran, could not pass. Each case is red against the code it fixes.

Separately, every escape was run end to end against a real daemon, with a brokered container reading a host file outside the workdir:

| | before | after |
|---|---|---|
| sibling prefix, `..`, symlink | host file read | rejected, rc 65 |
| volume `driver_opts.device` | host file read | rejected, rc 65 |
| `secrets:` / `configs:` `file:` | host file read | rejected, rc 65 |
| `env_file` into the container | host file read | rejected, rc 65 |
| `env_file` via `compose config` | rendered to the caller | rejected, rc 65 |

Positive controls in the same setup, all still working: a relative bind plus relative `env_file`, a build from a context inside the workdir, a named volume device inside it, a legitimate mount, and `config` on a clean model.

`tests/run-all.sh` is 22/22 and `shellcheck -S warning` is clean on both files. Not exercised: the facade and transport hop (the tests drive `handle_compose` directly), compose subcommands other than `up`, `config` and `build`, and the macOS bash 3.2 job, which CI covers.
