### PR TITLE
llm: document and test env-set LLM_PROVIDER

### DIFF
--- a/bin/llm
+++ b/bin/llm
@@ -202,6 +202,10 @@ Environment:
                            opencode-go/* bills the Go subscription, opencode/*
                            bills Zen. Keys: `opencode auth login`
   LLM_API_URL              Override provider API URL
+  LLM_PROVIDER             Provider to use when the model name implies none
+                           (same names as --provider); --provider takes
+                           precedence, and a value that disagrees with the
+                           name warns on stderr
   LLM_RETRIES              Retries for transient API failures (default: 2;
                            0 disables). Never retries after partial output.
   LLM_RETRY_BACKOFF        Backoff base seconds between retries (default: 1)

--- a/design/model-resolution.md
+++ b/design/model-resolution.md
@@ -15,7 +15,10 @@ environment variables that feed that decision come from. Two layers:
 There is no hard provider dependency anywhere: `bin/llm` picks the
 provider from the model name (`claude-*` → Anthropic, `vendor/model` →
 OpenRouter, `gpt-*`/`o*` → OpenAI, `gemini-*` → Gemini) and each provider
-needs only its own `<PROVIDER>_API_KEY`. Hardcoded `claude-*` names below
+needs only its own `<PROVIDER>_API_KEY`. A model name that implies no
+provider — a local OpenAI-compatible alias, say — is reached by setting
+`LLM_PROVIDER` or passing `--provider`; an env value that contradicts a
+name the harness *can* classify is still honored, but says so on stderr. Hardcoded `claude-*` names below
 are last-resort defaults, reached only when nothing is configured.
 
 ## The knobs
@@ -27,6 +30,7 @@ are last-resort defaults, reached only when nothing is configured.
 | `THINK_MODEL` | Per-thinker override (also settable per identity via `info.txt think_model=`) |
 | `SHELLM_SUMMARY_MODEL` | Run-summary override; beats `SHELLM_FAST_MODEL` |
 | `LLM_MODEL` | `bin/llm`'s own knob; equivalent to `-m` |
+| `LLM_PROVIDER` | `bin/llm`'s provider override; equivalent to `--provider`. Needed when the model name implies no provider. A value that disagrees with what the name implies is honored, but warns on stderr |
 
 ## Resolution chains
 

--- a/tests/test_llm_provider_env.sh
+++ b/tests/test_llm_provider_env.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# test_llm_provider_env.sh — LLM_PROVIDER is honored from the environment
+#
+# Usage: tests/test_llm_provider_env.sh
+#
+# curl is stubbed (it records the URL it was called with and answers with a
+# minimal SSE stream), so this checks which provider branch bin/llm took
+# without touching the network. The cases that matter:
+#
+#   - a model name no pattern matches (a local OpenAI-compatible alias) is
+#     reachable by exporting LLM_PROVIDER, not only by passing --provider
+#   - without a provider such a name still fails loudly
+#   - --provider still beats the environment
+#   - name-based detection is unchanged when LLM_PROVIDER is unset
+#   - an env provider that disagrees with a classifiable name is honored and
+#     warns on stderr, while a name no pattern matches stays quiet
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+# --- curl stub ---------------------------------------------------------------
+# Records every argument in $CURL_ARGS (so the test can see which URL was
+# picked) and answers with one SSE chunk plus [DONE], enough for the
+# OpenAI-compatible extractors.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >> "$CURL_ARGS"
+out_file=""
+prev=""
+for a in "$@"; do
+    [[ "$prev" == "-o" ]] && out_file="$a"
+    prev="$a"
+done
+if [[ -n "$out_file" ]]; then
+    printf '{"choices":[{"message":{"content":"ok"}}]}' > "$out_file"
+    printf '200'
+else
+    printf 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+    printf 'data: [DONE]\n'
+fi
+EOF
+chmod +x "$WORK/bin/curl"
+export PATH="$WORK/bin:$PATH"
+
+export ANTHROPIC_API_KEY="test-key"
+export OPENAI_API_KEY="test-key"
+export GEMINI_API_KEY="test-key"
+export OPENROUTER_API_KEY="test-key"
+export HEADLONG_HOME="$WORK/home"   # bin/llm writes run/llm_health.json here
+mkdir -p "$HEADLONG_HOME"
+export CURL_ARGS="$WORK/curl_args"
+export LLM_RETRIES=0
+
+LLM="$REPO/bin/llm"
+
+reset() { : > "$CURL_ARGS"; }
+url_seen() { grep -c "$1" "$CURL_ARGS"; }
+
+# ---------------------------------------------------------------------------
+# A local alias no pattern matches is reachable via LLM_PROVIDER
+# ---------------------------------------------------------------------------
+
+reset
+out=$(LLM_PROVIDER=openai LLM_API_URL="http://127.0.0.1:9/v1/chat/completions" \
+      "$LLM" -m my-local-alias "say ok" 2>"$WORK/stderr")
+rc=$?
+if [[ "$rc" -eq 0 && "$out" == *ok* ]]; then
+    ok "LLM_PROVIDER=openai reaches an unrecognized model name"
+else
+    bad "LLM_PROVIDER=openai reaches an unrecognized model name" "$(head -1 "$WORK/stderr")"
+fi
+if [[ "$(url_seen '127.0.0.1:9')" -ge 1 ]]; then
+    ok "request went to the configured endpoint"
+else
+    bad "request went to the configured endpoint"
+fi
+# The mismatch warning must stay quiet here: detect_provider cannot classify
+# this name, so there is nothing for the environment to disagree with.
+if grep -q "overrides detected provider" "$WORK/stderr"; then
+    bad "an unclassifiable name warns nothing" "$(grep -m1 'overrides detected' "$WORK/stderr")"
+else
+    ok "an unclassifiable name warns nothing"
+fi
+
+# ---------------------------------------------------------------------------
+# Without a provider the same name still fails loudly (no silent default)
+# ---------------------------------------------------------------------------
+
+reset
+"$LLM" -m my-local-alias "say ok" >/dev/null 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q "Cannot detect provider" "$WORK/stderr"; then
+    ok "unset LLM_PROVIDER still dies on an unrecognized name"
+else
+    bad "unset LLM_PROVIDER still dies on an unrecognized name" "rc=$rc"
+fi
+
+# ---------------------------------------------------------------------------
+# --provider beats the environment
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=openai "$LLM" -m my-local-alias --provider anthropic "say ok" \
+    >/dev/null 2>"$WORK/stderr"
+if [[ "$(url_seen 'api.anthropic.com')" -ge 1 ]]; then
+    ok "--provider overrides LLM_PROVIDER"
+else
+    bad "--provider overrides LLM_PROVIDER" "$(head -1 "$WORK/stderr")"
+fi
+
+# ---------------------------------------------------------------------------
+# Name-based detection is unchanged when LLM_PROVIDER is unset
+# ---------------------------------------------------------------------------
+
+reset
+"$LLM" -m claude-sonnet-4-5 "say ok" >/dev/null 2>"$WORK/stderr"
+if [[ "$(url_seen 'api.anthropic.com')" -ge 1 ]]; then
+    ok "claude-* still detected as anthropic"
+else
+    bad "claude-* still detected as anthropic" "$(head -1 "$WORK/stderr")"
+fi
+
+reset
+"$LLM" -m vendor/some-model "say ok" >/dev/null 2>"$WORK/stderr"
+if [[ "$(url_seen 'openrouter.ai')" -ge 1 ]]; then
+    ok "vendor/model still detected as openrouter"
+else
+    bad "vendor/model still detected as openrouter" "$(head -1 "$WORK/stderr")"
+fi
+
+# ---------------------------------------------------------------------------
+# An env provider that contradicts a classifiable name is honored, but loudly
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=openai OPENAI_API_KEY=stub-key \
+    "$LLM" -m claude-sonnet-4-5 "say ok" >/dev/null 2>"$WORK/stderr"
+if [[ "$(url_seen 'api.openai.com')" -ge 1 ]]; then
+    ok "env LLM_PROVIDER wins over a name it contradicts"
+else
+    bad "env LLM_PROVIDER wins over a name it contradicts" "$(head -1 "$WORK/stderr")"
+fi
+if grep -q "LLM_PROVIDER=openai overrides detected provider 'anthropic'" "$WORK/stderr"; then
+    ok "the mismatch is reported on stderr"
+else
+    bad "the mismatch is reported on stderr" "$(head -1 "$WORK/stderr")"
+fi
+
+# A flag that overrides the environment is a deliberate choice, not a
+# mismatch: nothing to warn about.
+reset
+LLM_PROVIDER=openai "$LLM" -m claude-sonnet-4-5 --provider anthropic "say ok" \
+    >/dev/null 2>"$WORK/stderr"
+if grep -q "overrides detected provider" "$WORK/stderr"; then
+    bad "--provider silences the mismatch warning" "$(grep -m1 'overrides detected' "$WORK/stderr")"
+else
+    ok "--provider silences the mismatch warning"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
# llm: document and test env-set LLM_PROVIDER

Rebased on main. The one-line fix this PR opened with is already there via #67,
so what remains is the part that wasn't: documentation and regression tests.

## What's in it

- `bin/llm --help` lists `LLM_PROVIDER` under Environment. It points at
  `--provider` for the list of provider names rather than repeating it, so the
  two can't drift as providers are added — they already had, my original text
  predated OpenCode.
- `design/model-resolution.md` names `LLM_PROVIDER` in the knobs table and, in
  the "no hard provider dependency" paragraph, says how a model name that
  implies no provider is reached. The page previously described provider
  selection as name-only.
- `tests/test_llm_provider_env.sh` — new, in the style of `test_llm_retry.sh`
  (stubbed `curl` recording the URL it was called with, no network).

## The tests

Six behaviours, including the mismatch warning main just gained:

- an alias no pattern matches is reachable through `LLM_PROVIDER` and the
  request goes to the configured endpoint;
- that case warns nothing — `detect_provider` cannot classify the name, so
  there is nothing for the environment to contradict;
- `LLM_PROVIDER=openai` with `claude-sonnet-4-5` is honored *and* reports
  `overrides detected provider 'anthropic'` on stderr;
- `--provider` overriding the environment warns about nothing: the flag is a
  deliberate choice, not a mismatch;
- an unset provider on an unclassifiable name still dies with
  `Cannot detect provider`;
- `claude-*` and `vendor/model` detection unchanged.

`tests/test_llm_provider_env.sh`: 10 passed, 0 failed. `test_llm_retry.sh`
stays green.

LOC gate: +4 code lines in `bin/` (the `--help` entry), comfortably inside
`LOC_LIMIT: 10000`.

## Context

Found while running Headlong against a self-hosted Qwen behind an internal
gateway, where the model is served under the alias `qwen-auto`. Two other
things stood in the way there; happy to open them separately if useful:

- `get_model_max_tokens` falls back to 4096 for an unrecognized name, which
  truncates utility calls that ask for more (the persona writer's `llm -t 3000`
  came back empty, so `headlong-init` silently used the starter template).
- vLLM-style endpoints take `chat_template_kwargs.enable_thinking` rather than
  `reasoning.effort`; with reasoning left on, that same budget goes to reasoning
  tokens.
