### PR TITLE
Thinkers: read the API key from the state home the installer writes to

### DIFF
--- a/tests/test_thinker_env_fallback.sh
+++ b/tests/test_thinker_env_fallback.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# tests/test_thinker_env_fallback.sh — a thinker finds the API key where the
+# installer actually wrote it.
+#
+# tools/headlong-init writes the provider key and SHELLM_MODEL to
+# $HEADLONG_HOME/.env and nowhere else. The thinker step scripts resolve those
+# BEFORE calling llm/shellm (which load .env too late to influence the -m
+# flag), so _require_env has to read that file. It cannot lean on llm to do it
+# instead: both launchers export SHELLM_HOME as <identity>/.shellm
+# (bin/thinkers, web control.py), and llm resolves the state home through
+# SHELLM_HOME, so under a thinker it reads the identity directory rather than
+# the framework state home.
+#
+# The legacy ~/.shellm case is here because a pre-rename install keeps its
+# state there, and the "already set wins" case because the dispatcher's own
+# environment (deploy/thinkers-service.sh, the web _ENV_WRAPPER) must always
+# beat a file.
+
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+# probe <name> <expected-key-value> [env-assignment ...] -- runs _require_env in
+# a fresh HOME laid out by the caller's setup function.
+probe() {
+    local name="$1" want="$2" setup="$3" ; shift 3
+    local out
+    out=$(
+        H=$(mktemp -d)
+        export HOME="$H"
+        mkdir -p "$H/id/memories" "$H/id/skills" "$H/id/kernel" "$H/id/trajectories" "$H/wd"
+        printf 'name=probe\n' > "$H/id/info.txt"
+        "$setup" "$H"
+        export IDENTITY_DIR="$H/id" TRAJ_DIR="$H/id/trajectories" TRAJ_ID=t1 MEM_DIR="$H/id/memories"
+        cd "$H/wd" || exit 1
+        # shellcheck disable=SC1090  # the library under test
+        source "$REPO/thinkers/_lib/common.sh"
+        _require_env >/dev/null 2>&1
+        printf '%s' "${OPENROUTER_API_KEY:-<unset>}"
+        rm -rf "$H"
+    )
+    if [[ "$out" == "$want" ]]; then
+        ok "$name"
+    else
+        bad "$name" "expected $want, got $out"
+    fi
+}
+
+# Each writes the key into one of the places the loader consults.
+setup_headlong() { mkdir -p "$1/.headlong"; printf 'OPENROUTER_API_KEY=from-headlong\n' > "$1/.headlong/.env"; }
+setup_legacy()   { mkdir -p "$1/.shellm";   printf 'OPENROUTER_API_KEY=from-legacy\n'   > "$1/.shellm/.env"; }
+setup_both()     { setup_headlong "$1"; setup_legacy "$1"; }
+setup_identity() { printf 'OPENROUTER_API_KEY=from-identity\n' > "$1/id/.env"; }
+setup_none()     { :; }
+
+probe "state home .env is read"                 from-headlong setup_headlong
+probe "legacy ~/.shellm/.env still read"        from-legacy   setup_legacy
+probe "state home wins over the legacy path"    from-headlong setup_both
+probe "identity .env still wins over both"      from-identity setup_identity
+probe "no env file leaves the key unset"        '<unset>'     setup_none
+
+# HEADLONG_HOME points the lookup somewhere else entirely.
+out=$(
+    H=$(mktemp -d); export HOME="$H"
+    mkdir -p "$H/id" "$H/elsewhere" "$H/.headlong" "$H/wd"
+    printf 'name=probe\n' > "$H/id/info.txt"
+    printf 'OPENROUTER_API_KEY=from-default\n' > "$H/.headlong/.env"
+    printf 'OPENROUTER_API_KEY=from-override\n' > "$H/elsewhere/.env"
+    export HEADLONG_HOME="$H/elsewhere"
+    export IDENTITY_DIR="$H/id" TRAJ_DIR="$H/id" TRAJ_ID=t1 MEM_DIR="$H/id"
+    cd "$H/wd" || exit 1
+    # shellcheck disable=SC1090  # the library under test
+    source "$REPO/thinkers/_lib/common.sh"
+    _require_env >/dev/null 2>&1
+    printf '%s' "${OPENROUTER_API_KEY:-<unset>}"
+    rm -rf "$H"
+)
+[[ "$out" == from-override ]] && ok "HEADLONG_HOME overrides the default state home" \
+    || bad "HEADLONG_HOME overrides the default state home" "got $out"
+
+# The dispatcher's own environment must always beat a file.
+out=$(
+    H=$(mktemp -d); export HOME="$H"
+    mkdir -p "$H/id" "$H/.headlong" "$H/wd"
+    printf 'name=probe\n' > "$H/id/info.txt"
+    printf 'OPENROUTER_API_KEY=from-file\n' > "$H/.headlong/.env"
+    export OPENROUTER_API_KEY=from-environment
+    export IDENTITY_DIR="$H/id" TRAJ_DIR="$H/id" TRAJ_ID=t1 MEM_DIR="$H/id"
+    cd "$H/wd" || exit 1
+    # shellcheck disable=SC1090  # the library under test
+    source "$REPO/thinkers/_lib/common.sh"
+    _require_env >/dev/null 2>&1
+    printf '%s' "$OPENROUTER_API_KEY"
+    rm -rf "$H"
+)
+[[ "$out" == from-environment ]] && ok "an already-set value wins over the file" \
+    || bad "an already-set value wins over the file" "got $out"
+
+# The key has to reach the nested shellm as a bare --var NAME, or the model
+# still runs without it inside Docker.
+out=$(
+    H=$(mktemp -d); export HOME="$H"
+    mkdir -p "$H/id/memories" "$H/id/skills" "$H/id/kernel" "$H/id/trajectories" "$H/.headlong" "$H/wd"
+    printf 'name=probe\n' > "$H/id/info.txt"
+    printf 'OPENROUTER_API_KEY=from-headlong\n' > "$H/.headlong/.env"
+    export IDENTITY_DIR="$H/id" TRAJ_DIR="$H/id/trajectories" TRAJ_ID=t1 MEM_DIR="$H/id/memories"
+    cd "$H/wd" || exit 1
+    # shellcheck disable=SC1090  # the library under test
+    source "$REPO/thinkers/_lib/common.sh"
+    _require_env >/dev/null 2>&1
+    _build_shellm_flags "$IDENTITY_DIR" 2>/dev/null | tr '\n' ' '
+    rm -rf "$H"
+)
+case "$out" in
+    *"--var OPENROUTER_API_KEY "*) ok "the key is forwarded to the nested shellm" ;;
+    *) bad "the key is forwarded to the nested shellm" "no bare --var for it" ;;
+esac
+
+echo
+echo "$pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -50,6 +50,13 @@ _require_env() {
     # late to influence the -m flag), so the keys must be filled in here.
     _load_env_defaults "$IDENTITY_DIR/.env" || true
     _load_env_defaults ".env" || true
+    # The framework state home, where headlong-init writes the API key and
+    # SHELLM_MODEL. Resolved without SHELLM_HOME on purpose, unlike bin/llm and
+    # bin/shellm: both launchers export SHELLM_HOME as <identity>/.shellm
+    # (bin/thinkers, web control.py), so honouring it here would read the
+    # identity directory and never the file holding the key. ~/.shellm stays
+    # after it for a pre-rename install.
+    _load_env_defaults "${HEADLONG_HOME:-$HOME/.headlong}/.env" || true
     _load_env_defaults "$HOME/.shellm/.env" || true
 
     mkdir -p "$MEM_DIR" "$SKILLS_DIR" "$SKILLS_KERNEL_DIR" "$TRAJ_DIR"


### PR DESCRIPTION
Fixes #50.

`tools/headlong-init` writes the provider key and `SHELLM_MODEL` to `$HEADLONG_HOME/.env` and nowhere else. `_require_env` filled its defaults from the identity `.env`, `./.env` and `$HOME/.shellm/.env`, the state home from before the rename; 99cb54d moved `bin/llm` and `bin/shellm` onto `~/.headlong` and left this file behind.

The step scripts cannot lean on `llm` to load it instead, which is what turns this from cosmetic into a thinker that does not run. Both launchers export `SHELLM_HOME` as `<identity>/.shellm` (`bin/thinkers:156`, `control.py:69`), and `llm` and `shellm` resolve the state home through `SHELLM_HOME`, so inside a thinker they read the identity directory. Checked by running it: with the key only in `~/.headlong/.env`, a step resolved no key and no model and forwarded neither to the nested `shellm`, and `llm` under that same `SHELLM_HOME` died with `No model specified and no API key found`. Unset `SHELLM_HOME` and the same `llm` finds it, which is the control.

So the lookup here is resolved as `${HEADLONG_HOME:-$HOME/.headlong}/.env`, deliberately without `SHELLM_HOME` unlike the two tools, with `~/.shellm` kept after it for a pre-rename install. Values still fill in only what is unset, so the dispatcher's environment keeps winning. That is why a provisioned box never showed this: `deploy/thinkers-service.sh` sources `$APP_DIR/.env` before starting. A local install has nothing playing that role, so a dash started from a shell that never loaded `~/.headlong/.env` gives every thinker an empty key.

## Verification

`tests/test_thinker_env_fallback.sh` is new; nothing in `tests/` sourced `common.sh` before, which is why this survived the rename. Eight cases, four of which fail without the change:

- the state home `.env` is read, and beats the legacy path
- `HEADLONG_HOME` redirects the lookup
- the key reaches the nested `shellm` as a bare `--var NAME`

The other four pass before and after, and are there so the file cannot go green vacuously: the legacy `~/.shellm/.env` still works, the identity `.env` still wins over both, no env file leaves the key unset, and an already-set value still beats the file.

`tests/run-all.sh` is 22/22 and `shellcheck -S warning` is clean on both files. No bash 4 constructs, so the macOS job is covered.
