### PR TITLE
install: keep API keys off the docker command line

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,33 @@ _docker_daemon_ok() {
     command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
 }
 
+# The `docker run` arguments that carry the operator's environment into the
+# container, one per line for the caller to read into an array.
+#
+# Keys go by NAME. `-e VAR=value` puts the value in the docker client's argv,
+# where `ps` shows it to every other user on the machine for as long as the
+# client runs; bin/thinkers forwards keys the same way for the same reason, and
+# tests/test_var_secrets.sh pins the rule for shellm. Docker reads a name-only
+# `-e VAR` from its own environment, so the name must be exported, which is why
+# the answers below do NOT use it: install.sh assigns HEADLONG_REPO and
+# HEADLONG_BRANCH itself without exporting them, so a bare name would forward
+# nothing and the container would clone the default repo instead of the
+# operator's. They are not secrets, so inline is fine.
+_docker_forward_args() {
+    local var
+    for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
+               OPENCODE_API_KEY; do
+        if [[ -n "${!var:-}" ]]; then
+            export "${var?}"
+            printf '%s\n%s\n' "-e" "$var"
+        fi
+    done
+    for var in HEADLONG_IDENTITY_NAME HEADLONG_IDENTITY_VIBE HEADLONG_IDENTITY_FOCUS \
+               HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME HEADLONG_REPO HEADLONG_BRANCH; do
+        if [[ -n "${!var:-}" ]]; then printf '%s\n%s\n' "-e" "$var=${!var}"; fi
+    done
+}
+
 # _offer_docker_install — with a working Docker daemon and a human at a tty,
 # offer to keep the whole agent inside a Docker container (the flow that
 # docs/install.md calls the Docker one-liner) instead of installing on the
@@ -157,13 +184,10 @@ EOF
     # Forward a key and interview answers already in the environment, so the
     # in-container installer does not re-ask for what the operator has set.
     local -a fwd=()
-    local var
-    for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
-               OPENCODE_API_KEY \
-               HEADLONG_IDENTITY_NAME HEADLONG_IDENTITY_VIBE HEADLONG_IDENTITY_FOCUS \
-               HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME HEADLONG_REPO HEADLONG_BRANCH; do
-        if [[ -n "${!var:-}" ]]; then fwd+=(-e "$var=${!var}"); fi
-    done
+    local line
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && fwd+=("$line")
+    done < <(_docker_forward_args)
 
     echo
     echo "==> Starting your agent in a Docker container named 'headlong'"

--- a/tests/test_install_secret_argv.sh
+++ b/tests/test_install_secret_argv.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# tests/test_install_secret_argv.sh — the container install keeps API keys off
+# the docker command line.
+#
+# install.sh forwards a key and the interview answers into the container it
+# starts. A value passed as `-e VAR=value` is an argument of the docker client,
+# so it is readable from `ps` by any other local user for as long as that
+# process lives; tests/test_var_secrets.sh already pins the same rule for the
+# shellm path, and bin/thinkers already forwards keys by bare name for the same
+# reason. Keys therefore go by NAME, which requires them to be exported, and
+# the non-secret answers stay inline because two of them (HEADLONG_REPO,
+# HEADLONG_BRANCH) are assigned by install.sh without export and a bare name
+# would silently forward nothing.
+
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Source install.sh for its functions: drop the trailing `main "$@"`, which
+# would otherwise run the installer.
+sed '$ d' "$REPO/install.sh" > "$WORK/install.lib"
+
+SECRET=sk-or-ARGVCANARY
+OPENCODE_SECRET=sk-OPENCODECANARY
+args=$(
+    export OPENROUTER_API_KEY="$SECRET"
+    export OPENCODE_API_KEY="$OPENCODE_SECRET"
+    export HEADLONG_IDENTITY_NAME=ada
+    # Set, deliberately NOT exported, which is how install.sh leaves them.
+    # shellcheck disable=SC2034  # read by _docker_forward_args through ${!var}
+    HEADLONG_REPO=https://example.invalid/fork.git
+    # shellcheck disable=SC2034  # read by _docker_forward_args through ${!var}
+    HEADLONG_BRANCH=experiment
+    # shellcheck disable=SC1090  # generated copy of the installer under test
+    source "$WORK/install.lib"
+    _docker_forward_args
+    printf '\n'
+)
+flat=" $(printf '%s' "$args" | tr '\n' ' ') "   # padded so a match at either end still has a boundary
+
+case "$flat" in
+    *"$SECRET"*) bad "no API key value on the docker command line" "found $SECRET in: $flat" ;;
+    *)           ok  "no API key value on the docker command line" ;;
+esac
+case "$flat" in
+    *"-e OPENROUTER_API_KEY "*) ok "the key is forwarded by name" ;;
+    *) bad "the key is forwarded by name" "got: $flat" ;;
+esac
+case "$flat" in
+    *"$OPENCODE_SECRET"*) bad "every provider key goes by name, not just the first" "found $OPENCODE_SECRET in: $flat" ;;
+    *"-e OPENCODE_API_KEY "*) ok "every provider key goes by name, not just the first" ;;
+    *) bad "every provider key goes by name, not just the first" "got: $flat" ;;
+esac
+case "$flat" in
+    *"-e HEADLONG_IDENTITY_NAME=ada "*) ok "interview answers are still forwarded inline" ;;
+    *) bad "interview answers are still forwarded inline" "got: $flat" ;;
+esac
+# The two the script assigns itself: a bare name would forward nothing, because
+# docker reads a name-only -e from its own environment.
+case "$flat" in
+    *"-e HEADLONG_REPO=https://example.invalid/fork.git "*) ok "an unexported repo override still reaches the container" ;;
+    *) bad "an unexported repo override still reaches the container" "got: $flat" ;;
+esac
+case "$flat" in
+    *"-e HEADLONG_BRANCH=experiment "*) ok "an unexported branch override still reaches the container" ;;
+    *) bad "an unexported branch override still reaches the container" "got: $flat" ;;
+esac
+
+# Forwarding by name only works if the variable is actually exported, so prove
+# the helper leaves it that way rather than trusting that the caller did.
+exported=$(
+    OPENROUTER_API_KEY="$SECRET"        # set, NOT exported
+    # shellcheck disable=SC1090  # generated copy of the installer under test
+    source "$WORK/install.lib"
+    _docker_forward_args >/dev/null
+    export -p | grep -c '^declare -x OPENROUTER_API_KEY=' || true
+)
+[[ "$exported" -ge 1 ]] && ok "the key is exported, so the bare name carries a value" \
+    || bad "the key is exported, so the bare name carries a value" "not exported after the call"
+
+# With no key and no answers set, only the repo/branch defaults install.sh
+# fills in are forwarded, and no key name appears at all.
+none=$(
+    unset OPENROUTER_API_KEY ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENCODE_API_KEY
+    unset HEADLONG_IDENTITY_NAME HEADLONG_IDENTITY_VIBE HEADLONG_IDENTITY_FOCUS
+    unset HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME
+    # shellcheck disable=SC1090  # generated copy of the installer under test
+    source "$WORK/install.lib"
+    _docker_forward_args | tr '\n' ' '
+)
+case "$none" in
+    *API_KEY*) bad "no key is forwarded when none is set" "got: $none" ;;
+    *)         ok  "no key is forwarded when none is set" ;;
+esac
+
+echo
+echo "$pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Fixes #52.

The container install forwarded everything it carries as `-e VAR=value`, so an API key spent the life of the docker client readable in `ps` by any other user on the machine. `bin/thinkers:267-272` already forwards keys to nested calls by bare name for exactly this reason, and `tests/test_var_secrets.sh` pins the rule for the shellm path; the installer was the one place doing it the other way.

Keys now go by name with an explicit export, and the interview answers keep their values inline. That split is not cosmetic: docker reads a name-only `-e VAR` from the client's own environment, so the name has to be exported, and `install.sh:30-31` assigns `HEADLONG_REPO` and `HEADLONG_BRANCH` without exporting them. Forwarding those by name would send nothing and the in-container installer would clone the default repo instead of the operator's fork. They are not secrets, so inline is the right place for them.

The arguments move into `_docker_forward_args` because `_offer_docker_install` reads from `/dev/tty` and cannot be driven from a test.

## Verification

End to end against a real daemon, with the arguments the helper produces:

```
after:  inside container: key=[sk-or-E2ECANARY] name=[ada] repo=[https://example.invalid/fork.git]
        ps exposure:      none
before: inside container: key=[sk-or-E2ECANARY]
        ps exposure:      YES -> docker run --rm -e OPENROUTER_API_KEY=sk-or-E2ECANARY ...
```

The unexported repo override in that first line is the case the simpler fix would have dropped.

`tests/test_install_secret_argv.sh` is new: no key value on the command line, the key forwarded by name, the key actually exported so the bare name carries, answers still inline, an unexported repo and branch override still reaching the container, and no key forwarded when none is set. Three of the seven fail against the old behaviour.

`tests/run-all.sh` is 22/22, `tests/smoke_install.sh` is 114/114, and `shellcheck -S warning` is clean. No bash 4 constructs.
