### PR TITLE
responder: answer "already handled?" from the trajectory tail

### DIFF
--- a/tests/test_responder_idempotency.sh
+++ b/tests/test_responder_idempotency.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# tests/test_responder_idempotency.sh — the responder's "already handled?"
+# check, and the window it reads to answer it.
+#
+# Every inbound message runs this check before a reply is composed, so it sits
+# on the latency path. It used to scan the whole root trajectory: measured at
+# 0.98s over 40MB and 7.4s over 308MB, against ~0.08s for the tail, and
+# design/monolith_run_health.md records real trajectories in that range.
+#
+# Reading a window is only sound because every record the check looks for (a
+# stamped reply, a decision observation, a live claim, a later message to the
+# same person) can only be appended AFTER the trigger step. So a window holding
+# the trigger holds everything relevant to it; a window that does NOT is the
+# case that must fall back to the full scan, or a redelivered old message gets
+# answered twice.
+#
+# The six verdict cases are pinned first because they are the behaviour the
+# bounded read must not change.
+
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PATH="$REPO/bin:$PATH"
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+command -v jq >/dev/null 2>&1 || { echo "FAIL jq not found — the check needs it, so this proves nothing"; exit 1; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+ME=ada
+THEM=nick
+TRIGGER=trig-1
+FRESH=$(date -u +%Y-%m-%dT%H:%M:%S)
+STALE=2000-01-01T00:00:00
+
+# step <type> <json-fields...> — one trajectory line
+step() { printf '%s\n' "$1"; }
+
+# build <file> <filler-lines> <extra-json-lines...> — a trajectory whose
+# trigger sits after <filler-lines> junk steps.
+build() {
+    local f="$1" filler="$2"; shift 2
+    : > "$f"
+    local i
+    for ((i=0; i<filler; i++)); do
+        printf '{"step_id":"pad-%d","type":"shellm-run","from":"%s","content":"pad"}\n' "$i" "$ME" >> "$f"
+    done
+    printf '{"step_id":"%s","type":"message","from":"%s","to":"%s","content":"hello"}\n' "$TRIGGER" "$THEM" "$ME" >> "$f"
+    local line
+    for line in "$@"; do printf '%s\n' "$line" >> "$f"; done
+}
+
+# verdict <trajectory-file> [tail-lines] — run the check, echo its answer
+verdict() {
+    local f="$1" tail_lines="${2:-5000}" d
+    d="$WORK/run"; rm -rf "$d"; mkdir -p "$d/trajs/aaaaaaaa-t"
+    cp "$f" "$d/trajs/aaaaaaaa-t/trajectory.jsonl"
+    (
+        export TRAJ_DIR="$d/trajs" ROOT_TRAJ_ID=aaaaaaaa TRAJ_ID=aaaaaaaa
+        export IDENTITY_NAME="$ME" SHELLM_RAW_TAIL_LINES="$tail_lines"
+        export RESPONDER_TRAJ_FILE="$d/trajs/aaaaaaaa-t/trajectory.jsonl"
+        # shellcheck disable=SC1090  # the library under test
+        source "$REPO/thinkers/_lib/common.sh"
+        _responder_already_handled "$TRIGGER" "$THEM" "$(date -u -d '180 seconds ago' +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -v-180S +%Y-%m-%dT%H:%M:%S)"
+    )
+}
+
+check() {
+    local name="$1" want="$2" got="$3"
+    if [[ "$want" == handled && -n "$got" ]] || [[ "$want" == unhandled && -z "$got" ]]; then
+        ok "$name"
+    else
+        bad "$name" "wanted $want, got '${got:-<empty>}'"
+    fi
+}
+
+# --- the six verdicts, which the bounded read must preserve ---------------
+build "$WORK/a.jsonl" 3 "{\"step_id\":\"r1\",\"type\":\"message\",\"from\":\"$ME\",\"to\":\"$THEM\",\"reply_to\":\"$TRIGGER\",\"content\":\"hi\"}"
+check "a stamped reply counts as handled"        handled   "$(verdict "$WORK/a.jsonl")"
+
+build "$WORK/b.jsonl" 3 "{\"step_id\":\"o1\",\"type\":\"observation\",\"trigger_step\":\"$TRIGGER\",\"decision\":\"no-reply\"}"
+check "a no-reply decision sticks"               handled   "$(verdict "$WORK/b.jsonl")"
+
+build "$WORK/c.jsonl" 3 "{\"step_id\":\"c1\",\"type\":\"reply_claim\",\"trigger_step\":\"$TRIGGER\",\"ts\":\"$FRESH\"}"
+check "a fresh claim counts as handled"          handled   "$(verdict "$WORK/c.jsonl")"
+
+build "$WORK/d.jsonl" 3 "{\"step_id\":\"c2\",\"type\":\"reply_claim\",\"trigger_step\":\"$TRIGGER\",\"ts\":\"$STALE\"}"
+check "a stale claim does NOT count"             unhandled "$(verdict "$WORK/d.jsonl")"
+
+build "$WORK/e.jsonl" 3 "{\"step_id\":\"m1\",\"type\":\"message\",\"from\":\"$ME\",\"to\":\"$THEM\",\"content\":\"unstamped answer\"}"
+check "an unstamped later message counts"        handled   "$(verdict "$WORK/e.jsonl")"
+
+build "$WORK/f.jsonl" 3
+check "nothing about the trigger is unhandled"   unhandled "$(verdict "$WORK/f.jsonl")"
+
+# A message from us to them BEFORE the trigger must not count: that is the
+# clause the trigger's position in the log decides.
+: > "$WORK/g.jsonl"
+printf '{"step_id":"old","type":"message","from":"%s","to":"%s","content":"earlier"}\n' "$ME" "$THEM" >> "$WORK/g.jsonl"
+printf '{"step_id":"%s","type":"message","from":"%s","to":"%s","content":"hello"}\n' "$TRIGGER" "$THEM" "$ME" >> "$WORK/g.jsonl"
+check "an earlier message does not count"        unhandled "$(verdict "$WORK/g.jsonl")"
+
+# --- the window, and the case that must escape it ------------------------
+# A `traj` shim records every subcommand, so "did this read the whole file?"
+# is answered by what was invoked rather than by timing.
+mkdir -p "$WORK/shim"
+cat > "$WORK/shim/traj" <<SHIM
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >> "$WORK/traj-calls"
+case "\$1" in
+    path) printf '%s\n' "\$RESPONDER_TRAJ_FILE" ;;
+    cat)  cat -- "\$RESPONDER_TRAJ_FILE" ;;
+esac
+SHIM
+chmod +x "$WORK/shim/traj"
+
+# Trigger inside the window: the answer must come from the tail, with no full
+# scan at all.
+build "$WORK/h.jsonl" 20 "{\"step_id\":\"r1\",\"type\":\"message\",\"from\":\"$ME\",\"to\":\"$THEM\",\"reply_to\":\"$TRIGGER\",\"content\":\"hi\"}"
+: > "$WORK/traj-calls"
+got=$(PATH="$WORK/shim:$PATH" verdict "$WORK/h.jsonl" 50)
+check "handled is still found inside the window" handled "$got"
+if grep -qx cat "$WORK/traj-calls"; then
+    bad "no full scan when the trigger is in the window" "traj cat was called"
+else
+    ok "no full scan when the trigger is in the window"
+fi
+
+# Trigger older than the window: the tail cannot see it, so the check must fall
+# back to the full scan rather than reporting an unanswered message.
+build "$WORK/i.jsonl" 200 "{\"step_id\":\"r1\",\"type\":\"message\",\"from\":\"$ME\",\"to\":\"$THEM\",\"reply_to\":\"$TRIGGER\",\"content\":\"hi\"}"
+# push the trigger and its reply far above the window
+for i in $(seq 1 100); do
+    printf '{"step_id":"after-%d","type":"thought","from":"%s","content":"pad"}\n' "$i" "$ME" >> "$WORK/i.jsonl"
+done
+: > "$WORK/traj-calls"
+got=$(PATH="$WORK/shim:$PATH" verdict "$WORK/i.jsonl" 50)
+check "an old handled trigger is still found"    handled "$got"
+if grep -qx cat "$WORK/traj-calls"; then
+    ok "the full scan runs when the trigger is out of the window"
+else
+    bad "the full scan runs when the trigger is out of the window" "traj cat was never called"
+fi
+
+echo
+echo "$pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -156,6 +156,70 @@ _root_traj_raw_tail() {
     fi
 }
 
+# Sentinel for "the trigger step was not in the stream", distinct from both a
+# verdict and an empty answer.
+_RESPONDER_TRIGGER_MISSING=$'\x01trigger-not-in-window'
+
+# Has this inbound message already been handled? Echoes the step id that says
+# so (or "handled"), empty when nothing has. Three layers keyed on the trigger
+# step, plus any later message from us to the same person; see the header in
+# thinkers/responder/step for why a STALE claim deliberately does not count.
+#
+# Lives here rather than in the step script so it can be tested: the step runs
+# top to bottom and cannot be sourced.
+# Reads the tail first (_root_traj_raw_tail), and only falls back to the full
+# `traj cat` when the trigger step is not in that window. Every record this
+# looks for can only be appended AFTER the trigger, so a window holding the
+# trigger holds the whole answer; a window that misses it could report an
+# already-answered message as unanswered and reply twice, which is the one case
+# worth paying the full scan for. Same argument fe2acd2 used moving the
+# monolith's work probe off traj cat, and the cost is the same: 7.4s over a
+# 308MB trajectory against 0.08s for the tail.
+_responder_already_handled() {
+    local trigger="$1" them="$2" cutoff="$3" out
+    out=$(_root_traj_raw_tail | _responder_scan "$trigger" "$them" "$cutoff" --require-trigger)
+    if [[ "$out" == "$_RESPONDER_TRIGGER_MISSING" ]]; then
+        traj cat "${ROOT_TRAJ_ID:-$TRAJ_ID}" --raw 2>/dev/null \
+            | _responder_scan "$trigger" "$them" "$cutoff"
+    else
+        printf '%s' "$out"
+    fi
+}
+
+
+# The scan itself, over whatever stream it is given. With --require-trigger it
+# emits the sentinel instead of a verdict when the trigger step is absent, so
+# the caller can tell "nothing has handled this" from "I could not see far
+# enough to know".
+_responder_scan() {
+    local require_trigger=0
+    [[ "${4:-}" == "--require-trigger" ]] && require_trigger=1
+    jq -Rrn --arg me "$IDENTITY_NAME" --arg them "$2" --arg t "$1" --arg cutoff "$3" \
+           --arg missing "$_RESPONDER_TRIGGER_MISSING" --argjson require "$require_trigger" '
+        [inputs | fromjson? // empty] as $steps
+        | ([$steps | to_entries[] | select(.value.step_id == $t)] | last) as $in
+        | if $require == 1 and $in == null then $missing else
+        [$steps[] | select(.type == "message" and .from == $me
+                             and (.reply_to // "") == $t)]
+          + [$steps[] | select(.type == "observation"
+                               and (.trigger_step // "") == $t
+                               and ((.decision // "") == "replied"
+                                    or (.decision // "") == "no-reply"))]
+          + [$steps[] | select(.type == "reply_claim"
+                               and (.trigger_step // "") == $t
+                               and $cutoff != ""
+                               and (.ts // "") > $cutoff)]
+          + (if $in == null then []
+             else [$steps[($in.key + 1):][]
+                   | select(.type == "message" and .from == $me and .to == $them
+                            and ((.reply_to // "") == "" or (.reply_to // "") == $t))]
+             end)
+        | if length == 0 then empty
+          else (.[0].step_id // "handled") end
+          end' 2>/dev/null \
+        | head -n 1
+}
+
 # Build a compact recent-stream context for thinker prompts: meaningful step
 # types only, long content truncated. Excluding bulky machinery steps (prompt,
 # shell-output, shellm-run, ...) keeps thinker prompts small AND prevents

--- a/thinkers/responder/step
+++ b/thinkers/responder/step
@@ -78,29 +78,7 @@ if [[ -n "$trigger_step_id" ]]; then
     # a retry is safer than a dropped message.
     claim_cutoff=$(date -u -v-"${CLAIM_TTL}"S +%Y-%m-%dT%H:%M:%S 2>/dev/null \
         || date -u -d "${CLAIM_TTL} seconds ago" +%Y-%m-%dT%H:%M:%S 2>/dev/null) || claim_cutoff=""
-    already=$(traj cat "${ROOT_TRAJ_ID:-$TRAJ_ID}" --raw 2>/dev/null \
-        | jq -Rrn --arg me "$IDENTITY_NAME" --arg them "$msg_from" --arg t "$trigger_step_id" \
-              --arg cutoff "$claim_cutoff" '
-            [inputs | fromjson? // empty] as $steps
-            | ([$steps | to_entries[] | select(.value.step_id == $t)] | last) as $in
-            | [$steps[] | select(.type == "message" and .from == $me
-                                 and (.reply_to // "") == $t)]
-              + [$steps[] | select(.type == "observation"
-                                   and (.trigger_step // "") == $t
-                                   and ((.decision // "") == "replied"
-                                        or (.decision // "") == "no-reply"))]
-              + [$steps[] | select(.type == "reply_claim"
-                                   and (.trigger_step // "") == $t
-                                   and $cutoff != ""
-                                   and (.ts // "") > $cutoff)]
-              + (if $in == null then []
-                 else [$steps[($in.key + 1):][]
-                       | select(.type == "message" and .from == $me and .to == $them
-                                and ((.reply_to // "") == "" or (.reply_to // "") == $t))]
-                 end)
-            | if length == 0 then empty
-              else (.[0].step_id // "handled") end' 2>/dev/null \
-        | head -n 1) || already=""
+    already=$(_responder_already_handled "$trigger_step_id" "$msg_from" "$claim_cutoff") || already=""
     if [[ -n "$already" ]]; then
         printf '  already handled step %s (reply/decision/live claim) — skipping\n' "$trigger_step_id" >&2
         exit 0


### PR DESCRIPTION
Fixes #54.

The idempotency check ran over the whole root trajectory before any reply was composed, so the cheapest thing the mind does cost O(total lifetime log size), on the path someone is waiting on. Measured with the step's own jq program over real `traj cat` output: 0.98s at 40MB, 3.9s at 161MB, 7.4s at 308MB, against ~0.08s for the tail. `design/monolith_run_health.md` records a live trajectory at 312MB.

`_root_traj_raw_tail` already existed for this, and `fe2acd2` moved the monolith's work probe onto it naming "two full 312MB scans per wake on cleo". The responder was the last `traj cat --raw` in `thinkers/`.

A window is sound here because every record the check looks for (a stamped reply, a decision observation, a live claim, a later message to the same person) can only be appended after the trigger step, so a window holding the trigger holds the whole answer. The case that is not sound is a window that misses the trigger, which is what a redelivered old message looks like: the check would report an answered message as unanswered and the identity would reply twice. So the scan reports "trigger not in this stream" separately from a verdict, and only that runs the full `traj cat`. At 308MB: 96ms when the trigger is in the window, 8.6s and correct when it is not.

The scan moves into `_responder_already_handled` beside `_root_traj_raw_tail`. That is what makes it testable at all: the step script runs top to bottom and cannot be sourced, which is why none of this had a test.

## Verification

`tests/test_responder_idempotency.sh` is new. Six cases pin the verdicts that must not move: a stamped reply, a decision observation and a fresh claim all count as handled; a stale claim deliberately does not (that is the crashed send, and treating it as handled is how messages used to drop); a later unstamped message to the same person counts; an earlier one does not. Two more cover the change: no `traj cat` at all when the trigger is in the window, and a full scan that still finds an old reply when it is not. A `traj` shim records the subcommands, so "did it read the whole file" is answered by what was invoked rather than by timing.

I extracted the helper with the original full-scan behaviour first and confirmed all six verdicts green against it, so the window change is a real red-then-green rather than a test written to fit the new code.

`tests/run-all.sh` is 22/22, `shellcheck -S warning` is clean, no bash 4 constructs.

Note this touches `thinkers/_lib/common.sh`, as does #51. Different parts of the file; I merged the two branches locally and they combine with no conflict, 23/23 with both new tests green.
