### PR TITLE
web: bound the dispatch endpoint's read, not just its answer

### DIFF
--- a/web/src/headlong_web/logs.py
+++ b/web/src/headlong_web/logs.py
@@ -41,13 +41,46 @@ def tail_log(log_path: Path, tail_bytes: int) -> dict[str, Any]:
     }
 
 
+def _tail_lines(log_path: Path, max_lines: int, chunk_bytes: int = 1 << 16) -> list[str]:
+    """The newest max_lines non-blank lines, read backward from the end.
+
+    dispatcher.log is never rotated and the endpoint above this is polled every
+    couple of seconds, so the whole-file read this replaces cost 31s and ~1GB of
+    allocation on a 190MB log to return the same 2000 events. tail_log solves
+    the same problem for raw log tails; this one counts lines rather than bytes,
+    because the caller's cap is in events.
+    """
+    with log_path.open("rb") as fh:
+        fh.seek(0, 2)
+        pos = fh.tell()
+        data = b""
+        while pos > 0:
+            step = min(chunk_bytes, pos)
+            pos -= step
+            fh.seek(pos)
+            data = fh.read(step) + data
+            # Only whole lines count, so ignore anything before the first
+            # newline while more of the file remains.
+            complete = data.split(b"\n", 1)[-1] if pos > 0 else data
+            if sum(1 for line in complete.splitlines() if line.strip()) >= max_lines:
+                break
+    text = data.decode("utf-8", errors="replace")
+    lines = text.splitlines()
+    if pos > 0 and lines:
+        lines = lines[1:]  # drop the (likely partial) first line
+    return [line for line in lines if line.strip()][-max_lines:]
+
+
 def parse_dispatch_log(identity_dir: Path, max_events: int = 2000) -> list[dict[str, Any]]:
-    """Parse dispatcher.log into structured events (newest last)."""
+    """Parse dispatcher.log into structured events (newest last).
+
+    Only the tail is read: max_events bounds the work, not just the answer.
+    """
     log_path = identity_dir / "run" / "logs" / "dispatcher.log"
     if not log_path.is_file():
         return []
     events: list[dict[str, Any]] = []
-    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+    for line in _tail_lines(log_path, max_events):
         stripped = line.strip()
         if not stripped:
             continue

--- a/web/tests/test_dispatch_log.py
+++ b/web/tests/test_dispatch_log.py
@@ -1,0 +1,127 @@
+"""parse_dispatch_log: the event cap has to bound the read, not just the answer.
+
+The endpoint behind this (GET /api/identities/{id}/dispatch) is polled every
+2 seconds while an identity is live, and dispatcher.log is never rotated: a
+real box has been recorded at 465M of them. Reading the whole file to return
+the last 2000 events measured 31s and 1GB of allocation on a 190MB log, so
+these tests pin both halves, the events returned AND the fact that the head of
+the file is never touched.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from headlong_web import logs
+
+
+def _write_log(identity: Path, lines: list[str]) -> Path:
+    log_path = identity / "run" / "logs" / "dispatcher.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("\n".join(lines) + "\n")
+    return log_path
+
+
+STEP = "2026-08-01T00:00:{:02d}Z [dispatcher] step: type=message source=chat"
+FIRE = "2026-08-01T00:00:{:02d}Z [dispatcher] dispatch -> responder (active=1)"
+OTHER = "2026-08-01T00:00:{:02d}Z [dispatcher] tick: nothing to do"
+
+
+def test_parses_each_kind(tmp_path: Path) -> None:
+    _write_log(tmp_path, [STEP.format(1), FIRE.format(2), OTHER.format(3)])
+    events = logs.parse_dispatch_log(tmp_path)
+    assert [e["kind"] for e in events] == ["step", "dispatch", "other"]
+    assert events[0]["type"] == "message"
+    assert events[0]["source"] == "chat"
+    assert events[1]["thinker"] == "responder"
+    assert events[1]["active"] == 1
+
+
+def test_newest_last_and_capped(tmp_path: Path) -> None:
+    _write_log(tmp_path, [OTHER.format(i % 60) for i in range(50)] + [STEP.format(59)])
+    events = logs.parse_dispatch_log(tmp_path, max_events=10)
+    assert len(events) == 10
+    assert events[-1]["kind"] == "step"
+
+
+def test_blank_lines_and_missing_trailing_newline(tmp_path: Path) -> None:
+    log_path = tmp_path / "run" / "logs" / "dispatcher.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(f"{OTHER.format(1)}\n\n   \n{STEP.format(2)}")
+    events = logs.parse_dispatch_log(tmp_path)
+    assert [e["kind"] for e in events] == ["other", "step"]
+
+
+def test_empty_and_missing(tmp_path: Path) -> None:
+    assert logs.parse_dispatch_log(tmp_path) == []
+    _write_log(tmp_path, [])
+    assert logs.parse_dispatch_log(tmp_path) == []
+
+
+def test_returns_the_newest_events_from_a_long_log(tmp_path: Path) -> None:
+    """The oldest lines must not appear in the answer."""
+    lines = ["OLDEST-CANARY [dispatcher] step: type=oldest source=head"]
+    lines += [OTHER.format(i % 60) for i in range(5000)]
+    lines += [STEP.format(59)]
+    _write_log(tmp_path, lines)
+    events = logs.parse_dispatch_log(tmp_path, max_events=100)
+    assert len(events) == 100
+    assert not any("OLDEST-CANARY" in e["raw"] for e in events)
+    assert events[-1]["type"] == "message"
+
+
+def test_does_not_read_the_whole_file(tmp_path: Path, monkeypatch) -> None:
+    """The cap has to bound the read. A whole-file read fails this outright."""
+    lines = ["OLDEST-CANARY [dispatcher] step: type=oldest source=head"]
+    lines += [OTHER.format(i % 60) for i in range(20000)]
+    lines += [STEP.format(59)]
+    _write_log(tmp_path, lines)
+
+    def _boom(*args, **kwargs):  # pragma: no cover - only runs on failure
+        raise AssertionError("parse_dispatch_log read the entire file")
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+    events = logs.parse_dispatch_log(tmp_path, max_events=50)
+    assert len(events) == 50
+    assert events[-1]["type"] == "message"
+
+
+def test_reads_a_bounded_amount(tmp_path: Path) -> None:
+    """Peak allocation tracks the cap, not the file."""
+    tracemalloc = pytest.importorskip("tracemalloc")
+    lines = [OTHER.format(i % 60) for i in range(200000)]
+    _write_log(tmp_path, lines)
+    file_bytes = (tmp_path / "run" / "logs" / "dispatcher.log").stat().st_size
+    tracemalloc.start()
+    logs.parse_dispatch_log(tmp_path, max_events=100)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    assert peak < file_bytes / 4, f"peak {peak} against a {file_bytes} byte log"
+
+
+def test_multibyte_across_a_chunk_boundary(tmp_path: Path) -> None:
+    """Chunks are read backward and joined, so a character split across a
+    boundary must not corrupt a line that is kept."""
+    wide = "\u4e2d\u6587\u30c6\u30b9\u30c8"  # multibyte, 3 bytes per char
+    lines = [f"2026-08-01T00:00:00Z [dispatcher] tick: {wide}{i}" for i in range(5000)]
+    lines.append(STEP.format(59))
+    _write_log(tmp_path, lines)
+    events = logs.parse_dispatch_log(tmp_path, max_events=200)
+    assert len(events) == 200
+    assert all("\ufffd" not in e["raw"] for e in events), "a kept line was corrupted"
+    assert all(wide in e["raw"] for e in events[:-1])
+    assert events[-1]["type"] == "message"
+
+
+def test_a_line_longer_than_the_chunk(tmp_path: Path) -> None:
+    """One pathological line must not lose the lines after it."""
+    _write_log(
+        tmp_path,
+        [
+            "2026-08-01T00:00:00Z [dispatcher] tick: " + "x" * (1 << 17),
+            STEP.format(1),
+            FIRE.format(2),
+        ],
+    )
+    events = logs.parse_dispatch_log(tmp_path, max_events=2)
+    assert [e["kind"] for e in events] == ["step", "dispatch"]


### PR DESCRIPTION
Fixes #56.

`parse_dispatch_log` advertised `max_events=2000` and returned `events[-2000:]`, but read the whole file and ran a regex pass over every line to get there. The cap governed the answer and nothing else. Measured with the real function: 2.0s and 68MB at 12.7MB, 8.2s and 271MB at 50MB, 31.3s and 1013MB at 190MB, each returning the same 2000 events. `deploy/MIGRATIONS.md` records 465M of dispatcher logs on a real box, and nothing rotates them.

That is not paid once per look. `thinkers.tsx` polls this endpoint on `refetchInterval` and `api.ts` sets it to 2000ms, so on a grown identity a viewer sitting on the tab starts a fresh multi-second, multi-hundred-MB request every two seconds and they overlap in the threadpool. `--read-only` does not take the endpoint away either, since it is a read.

`tail_log` twenty lines above already seeks to the end for raw log tails. This does the same, counting lines rather than bytes because the cap is in events: read backward in 64KB chunks until `max_events` non-blank lines are in hand, drop the partial first line, parse those. Same shape, same ordering, same cap. On the 190MB log: 26ms and 0.9MB, still 2000 events.

## Verification

`web/tests/test_dispatch_log.py` is new; `logs.py` had no tests at all, which is part of why a cap could read like a bound. Nine cases: each event kind parses, newest-last ordering and the cap, blank lines, a missing trailing newline, an empty file, a missing file, a multibyte character split across a chunk boundary, and a line longer than the chunk. Two of them are about the change itself, and both fail on the old code: `Path.read_text` is monkeypatched to raise so a whole-file read fails outright, and peak allocation has to stay under a quarter of the file size.

The seven behavioural cases were written against the old implementation and passed there, so they pin existing semantics rather than describing the new code. On top of that, a differential run against the original: 160 comparisons over random logs (0 to 20k lines, blank lines, missing trailing newlines, caps of 1/7/100/2000), zero mismatches.

`web/tests` is 159 passed / 2 skipped.
