### PR TITLE
bridges: the default identity is the `default` link, not `audel`

### DIFF
--- a/slack/README.md
+++ b/slack/README.md
@@ -26,11 +26,13 @@ format.
 ```bash
 export SLACK_BOT_TOKEN=xoxb-...     # see "Slack app lifecycle" below
 export SLACK_APP_TOKEN=xapp-...
-export HEADLONG_SLACK_IDENTITY=audel  # default (legacy SHELLM_SLACK_IDENTITY still honored)
+export HEADLONG_SLACK_IDENTITY=ada    # optional; defaults to the `default`
+                                      # identity link (legacy SHELLM_SLACK_IDENTITY
+                                      # still honored)
 tools/headlong-slack-bridge [ROOT]      # ROOT = serve root, default repo root
 ```
 
-The identity must exist (`identity new audel`) with a running dispatcher
+The identity must exist (`identity new <name>`) with a running dispatcher
 (`thinkers start monolith responder`), and headlong-web must be serving the same root
 (default `http://127.0.0.1:8080`, override with `HEADLONG_WEB_URL`; legacy `SHELLM_WEB_URL` still honored).
 

--- a/slack/src/headlong_slack/config.py
+++ b/slack/src/headlong_slack/config.py
@@ -30,11 +30,16 @@ class Config:
 
 
 def _default_identity(serve_root: Path) -> str:
-    """The identity the `default` symlink points at, as `persona` resolves it."""
+    """The identity the `default` symlink points at, as `persona` resolves it.
+
+    The immediate link target, not the end of the chain: an identity dir may
+    itself be a symlink elsewhere, and its name here is the one `identity
+    default` recorded.
+    """
     for base in (".identities", "identities"):
         link = serve_root / base / "default"
         if link.is_symlink():
-            return link.resolve().name
+            return link.readlink().name
     raise SystemExit(
         "headlong-slack-bridge: no identity given and no default set "
         f"under {serve_root} (looked for .identities/default and "

--- a/slack/src/headlong_slack/config.py
+++ b/slack/src/headlong_slack/config.py
@@ -29,6 +29,20 @@ class Config:
         return str(rel).replace("/", "~")
 
 
+def _default_identity(serve_root: Path) -> str:
+    """The identity the `default` symlink points at, as `persona` resolves it."""
+    for base in (".identities", "identities"):
+        link = serve_root / base / "default"
+        if link.is_symlink():
+            return link.resolve().name
+    raise SystemExit(
+        "headlong-slack-bridge: no identity given and no default set "
+        f"under {serve_root} (looked for .identities/default and "
+        "identities/default). Set HEADLONG_SLACK_IDENTITY, or point the "
+        "default at one with: identity default <name>"
+    )
+
+
 def _find_identity_dir(serve_root: Path, name: str) -> Path:
     for base in (".identities", "identities"):
         candidate = serve_root / base / name
@@ -55,7 +69,7 @@ def load(serve_root: Path) -> Config:
     identity = (
         os.environ.get("HEADLONG_SLACK_IDENTITY")
         or os.environ.get("SHELLM_SLACK_IDENTITY")
-        or "audel"
+        or _default_identity(serve_root)
     )
     identity_dir = _find_identity_dir(serve_root, identity)
     state_dir = Path(

--- a/slack/tests/test_config.py
+++ b/slack/tests/test_config.py
@@ -28,8 +28,14 @@ def test_falls_back_to_the_default_symlink(tmp_path):
 
 
 def test_follows_only_the_immediate_link(tmp_path):
-    """An identity dir may itself be a symlink; the default's own target is
-    the name `identity default` recorded, and the one persona reports."""
+    """The default's own target is the name `identity default` recorded, and
+    the one persona reports — `resolve()` would walk past it to the end of the
+    chain and return a name no one configured.
+
+    The chained identity here is the fixture that tells the two apart, not an
+    endorsement: a symlinked identity dir is invisible to the web scan, so its
+    messages 404 however the name was chosen (#66).
+    """
     elsewhere = tmp_path / "elsewhere" / "current"
     elsewhere.mkdir(parents=True)
     (elsewhere / "info.txt").write_text("an identity\n")

--- a/slack/tests/test_config.py
+++ b/slack/tests/test_config.py
@@ -27,6 +27,19 @@ def test_falls_back_to_the_default_symlink(tmp_path):
     assert config.load(tmp_path).identity == "ada"
 
 
+def test_follows_only_the_immediate_link(tmp_path):
+    """An identity dir may itself be a symlink; the default's own target is
+    the name `identity default` recorded, and the one persona reports."""
+    elsewhere = tmp_path / "elsewhere" / "current"
+    elsewhere.mkdir(parents=True)
+    (elsewhere / "info.txt").write_text("an identity\n")
+    identities = tmp_path / ".identities"
+    identities.mkdir()
+    (identities / "ada").symlink_to(elsewhere)
+    (identities / "default").symlink_to("ada")
+
+    assert config.load(tmp_path).identity == "ada"
+
 def test_env_var_wins_over_the_default_symlink(tmp_path, monkeypatch):
     _identity(tmp_path, "ada")
     _identity(tmp_path, "bo")

--- a/slack/tests/test_config.py
+++ b/slack/tests/test_config.py
@@ -1,0 +1,44 @@
+"""Identity selection: the env var, then the `default` symlink, then an error."""
+
+import pytest
+
+from headlong_slack import config
+
+
+def _identity(root, name):
+    d = root / ".identities" / name
+    d.mkdir(parents=True)
+    (d / "info.txt").write_text("an identity\n")
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _tokens(monkeypatch):
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-test")
+    monkeypatch.delenv("HEADLONG_SLACK_IDENTITY", raising=False)
+    monkeypatch.delenv("SHELLM_SLACK_IDENTITY", raising=False)
+
+
+def test_falls_back_to_the_default_symlink(tmp_path):
+    _identity(tmp_path, "ada")
+    (tmp_path / ".identities" / "default").symlink_to("ada")
+
+    assert config.load(tmp_path).identity == "ada"
+
+
+def test_env_var_wins_over_the_default_symlink(tmp_path, monkeypatch):
+    _identity(tmp_path, "ada")
+    _identity(tmp_path, "bo")
+    (tmp_path / ".identities" / "default").symlink_to("ada")
+    monkeypatch.setenv("HEADLONG_SLACK_IDENTITY", "bo")
+
+    assert config.load(tmp_path).identity == "bo"
+
+
+def test_no_var_and_no_default_names_the_variable(tmp_path):
+    _identity(tmp_path, "ada")
+
+    with pytest.raises(SystemExit) as exc:
+        config.load(tmp_path)
+    assert "HEADLONG_SLACK_IDENTITY" in str(exc.value)

--- a/telegram/README.md
+++ b/telegram/README.md
@@ -48,11 +48,13 @@ The admin (you) is approved automatically on first start.
 export TELEGRAM_BOT_TOKEN=...       # from @BotFather
 export TELEGRAM_ADMIN_ID=...        # your numeric user id; message the bot
                                     # once and read it from the bridge log
-export HEADLONG_TELEGRAM_IDENTITY=audel  # default (legacy SHELLM_TELEGRAM_IDENTITY still honored)
+export HEADLONG_TELEGRAM_IDENTITY=ada  # optional; defaults to the `default`
+                                       # identity link (legacy
+                                       # SHELLM_TELEGRAM_IDENTITY still honored)
 tools/headlong-telegram-bridge [ROOT]   # ROOT = serve root, default repo root
 ```
 
-The identity must exist (`identity new audel`) with a running dispatcher
+The identity must exist (`identity new <name>`) with a running dispatcher
 (`thinkers start monolith responder`), and headlong-web must be serving the same root
 (default `http://127.0.0.1:8080`, override with `HEADLONG_WEB_URL`; legacy `SHELLM_WEB_URL` still honored).
 

--- a/telegram/src/headlong_telegram/config.py
+++ b/telegram/src/headlong_telegram/config.py
@@ -31,11 +31,16 @@ class Config:
 
 
 def _default_identity(serve_root: Path) -> str:
-    """The identity the `default` symlink points at, as `persona` resolves it."""
+    """The identity the `default` symlink points at, as `persona` resolves it.
+
+    The immediate link target, not the end of the chain: an identity dir may
+    itself be a symlink elsewhere, and its name here is the one `identity
+    default` recorded.
+    """
     for base in (".identities", "identities"):
         link = serve_root / base / "default"
         if link.is_symlink():
-            return link.resolve().name
+            return link.readlink().name
     raise SystemExit(
         "headlong-telegram-bridge: no identity given and no default set "
         f"under {serve_root} (looked for .identities/default and "

--- a/telegram/src/headlong_telegram/config.py
+++ b/telegram/src/headlong_telegram/config.py
@@ -30,6 +30,20 @@ class Config:
         return str(rel).replace("/", "~")
 
 
+def _default_identity(serve_root: Path) -> str:
+    """The identity the `default` symlink points at, as `persona` resolves it."""
+    for base in (".identities", "identities"):
+        link = serve_root / base / "default"
+        if link.is_symlink():
+            return link.resolve().name
+    raise SystemExit(
+        "headlong-telegram-bridge: no identity given and no default set "
+        f"under {serve_root} (looked for .identities/default and "
+        "identities/default). Set HEADLONG_TELEGRAM_IDENTITY, or point the "
+        "default at one with: identity default <name>"
+    )
+
+
 def _find_identity_dir(serve_root: Path, name: str) -> Path:
     for base in (".identities", "identities"):
         candidate = serve_root / base / name
@@ -57,7 +71,7 @@ def load(serve_root: Path) -> Config:
     identity = (
         os.environ.get("HEADLONG_TELEGRAM_IDENTITY")
         or os.environ.get("SHELLM_TELEGRAM_IDENTITY")
-        or "audel"
+        or _default_identity(serve_root)
     )
     identity_dir = _find_identity_dir(serve_root, identity)
     state_dir = Path(

--- a/telegram/tests/test_config.py
+++ b/telegram/tests/test_config.py
@@ -28,8 +28,14 @@ def test_falls_back_to_the_default_symlink(tmp_path):
 
 
 def test_follows_only_the_immediate_link(tmp_path):
-    """An identity dir may itself be a symlink; the default's own target is
-    the name `identity default` recorded, and the one persona reports."""
+    """The default's own target is the name `identity default` recorded, and
+    the one persona reports — `resolve()` would walk past it to the end of the
+    chain and return a name no one configured.
+
+    The chained identity here is the fixture that tells the two apart, not an
+    endorsement: a symlinked identity dir is invisible to the web scan, so its
+    messages 404 however the name was chosen (#66).
+    """
     elsewhere = tmp_path / "elsewhere" / "current"
     elsewhere.mkdir(parents=True)
     (elsewhere / "info.txt").write_text("an identity\n")

--- a/telegram/tests/test_config.py
+++ b/telegram/tests/test_config.py
@@ -1,0 +1,44 @@
+"""Identity selection: the env var, then the `default` symlink, then an error."""
+
+import pytest
+
+from headlong_telegram import config
+
+
+def _identity(root, name):
+    d = root / ".identities" / name
+    d.mkdir(parents=True)
+    (d / "info.txt").write_text("an identity\n")
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _tokens(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:test")
+    monkeypatch.setenv("TELEGRAM_ADMIN_ID", "1")
+    monkeypatch.delenv("HEADLONG_TELEGRAM_IDENTITY", raising=False)
+    monkeypatch.delenv("SHELLM_TELEGRAM_IDENTITY", raising=False)
+
+
+def test_falls_back_to_the_default_symlink(tmp_path):
+    _identity(tmp_path, "ada")
+    (tmp_path / ".identities" / "default").symlink_to("ada")
+
+    assert config.load(tmp_path).identity == "ada"
+
+
+def test_env_var_wins_over_the_default_symlink(tmp_path, monkeypatch):
+    _identity(tmp_path, "ada")
+    _identity(tmp_path, "bo")
+    (tmp_path / ".identities" / "default").symlink_to("ada")
+    monkeypatch.setenv("HEADLONG_TELEGRAM_IDENTITY", "bo")
+
+    assert config.load(tmp_path).identity == "bo"
+
+
+def test_no_var_and_no_default_names_the_variable(tmp_path):
+    _identity(tmp_path, "ada")
+
+    with pytest.raises(SystemExit) as exc:
+        config.load(tmp_path)
+    assert "HEADLONG_TELEGRAM_IDENTITY" in str(exc.value)

--- a/telegram/tests/test_config.py
+++ b/telegram/tests/test_config.py
@@ -27,6 +27,19 @@ def test_falls_back_to_the_default_symlink(tmp_path):
     assert config.load(tmp_path).identity == "ada"
 
 
+def test_follows_only_the_immediate_link(tmp_path):
+    """An identity dir may itself be a symlink; the default's own target is
+    the name `identity default` recorded, and the one persona reports."""
+    elsewhere = tmp_path / "elsewhere" / "current"
+    elsewhere.mkdir(parents=True)
+    (elsewhere / "info.txt").write_text("an identity\n")
+    identities = tmp_path / ".identities"
+    identities.mkdir()
+    (identities / "ada").symlink_to(elsewhere)
+    (identities / "default").symlink_to("ada")
+
+    assert config.load(tmp_path).identity == "ada"
+
 def test_env_var_wins_over_the_default_symlink(tmp_path, monkeypatch):
     _identity(tmp_path, "ada")
     _identity(tmp_path, "bo")

--- a/tools/headlong-slack-bridge
+++ b/tools/headlong-slack-bridge
@@ -8,8 +8,9 @@ set -euo pipefail
 #
 # ROOT defaults to the headlong repo (parent of this script's directory).
 # Requires uv. Configuration via env: SLACK_BOT_TOKEN, SLACK_APP_TOKEN,
-# HEADLONG_SLACK_IDENTITY (default audel), HEADLONG_WEB_URL (SHELLM_* names
-# still honored as fallbacks).
+# HEADLONG_SLACK_IDENTITY (defaults to the identity the `default`
+# link points at), HEADLONG_WEB_URL (SHELLM_* names still honored as
+# fallbacks).
 
 # Resolve through symlinks (install.sh --symlinks puts this on PATH), then
 # fall back to the checkout recorded by install.sh / headlong-init.

--- a/tools/headlong-telegram-bridge
+++ b/tools/headlong-telegram-bridge
@@ -8,8 +8,9 @@ set -euo pipefail
 #
 # ROOT defaults to the headlong repo (parent of this script's directory).
 # Requires uv. Configuration via env: TELEGRAM_BOT_TOKEN, TELEGRAM_ADMIN_ID,
-# HEADLONG_TELEGRAM_IDENTITY (default audel), HEADLONG_WEB_URL (SHELLM_* names
-# still honored as fallbacks).
+# HEADLONG_TELEGRAM_IDENTITY (defaults to the identity the `default`
+# link points at), HEADLONG_WEB_URL (SHELLM_* names still honored as
+# fallbacks).
 #
 # Note: the production systemd unit does NOT use this script — it execs the
 # project venv directly so the bridge can run as its own user (uv would try


### PR DESCRIPTION
Fixes #58

## Description

Both bridges fell back to the identity name `audel` when `HEADLONG_SLACK_IDENTITY` / `HEADLONG_TELEGRAM_IDENTITY` was unset. Anywhere but the deployment that name belongs to, the bridge exits with `identity 'audel' not found ... Create it with: identity new audel` — telling the operator to create the maintainers' identity while their own sits behind `.identities/default`.

That symlink is already the answer to "which identity, if you didn't say": `tools/persona:92` and `tools/headlong-init:449` both resolve it when no name is given. The bridges were the only place it was skipped. `_default_identity` now resolves it the same way — the immediate link target, as `basename $(readlink ...)` gives and not `readlink -f`, so an identity dir that is itself a symlink still reports the name `identity default` recorded — checking `.identities/` then `identities/` to match the neighbouring `_find_identity_dir`.

With no link and no variable set, the error names the variable instead of an identity nobody has:

```
headlong-slack-bridge: no identity given and no default set under <root>
(looked for .identities/default and identities/default). Set
HEADLONG_SLACK_IDENTITY, or point the default at one with: identity default <name>
```

Applied symmetrically to slack and telegram, as in #42. Nothing changes for a deployment that sets the variable, and `deploy/` is untouched — the Slack instance there passes `SHELLM_SLACK_IDENTITY=audel` explicitly.

The two bridge READMEs advertised `audel` as the default and told the reader to run `identity new audel`; both now describe the fallback and use `<name>`.

## Tests

`slack/tests/test_config.py` and `telegram/tests/test_config.py` are new — neither `config` module had tests. Four cases each: the `default` link is followed, only its immediate target is read, an explicit variable beats the link, and the no-variable-no-link error names the variable.

Three of the four fail without the change. The chained-identity case is the fixture that tells `readlink()` and `resolve()` apart — not a supported configuration; the web scan skips symlinked identity dirs, which is a pre-existing gap filed as #66. Suites go 20 → 24 (slack) and 35 → 39 (telegram).

```
uv run --project slack pytest slack/tests -q       # 24 passed
uv run --project telegram pytest telegram/tests -q # 39 passed
uv run --project web pytest web/tests -q           # 150 passed, 2 skipped
tests/run-all.sh                                    # 21 passed, 0 failed
```

Also checked end to end against a scratch serve root holding one identity named `ada`: the bridge resolved `ada` where it previously exited on `audel`.

CI is showing `action_required` here, so the above is what I could run locally — the harness result matches `main` at `d8f8304` exactly.

## Checklist

- [x] Tested
- [x] Linting passes — `shellcheck -S warning` clean over CI's file set (83 files)
- [x] Type checks pass — annotations match the surrounding module; no type checker configured for these projects
- [x] No sensitive information committed

Found running the bridge outside systemd, where the default is reached instead of being overridden by the unit's environment.