### PR TITLE
explore: the report prompt no longer travels through argv

### DIFF
--- a/tests/test_explore_report_argv.sh
+++ b/tests/test_explore_report_argv.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# tests/test_explore_report_argv.sh — the report prompt stays off argv.
+#
+# Usage: tests/test_explore_report_argv.sh
+#
+# `shellm-explore --report` builds a prompt out of every run's context in the
+# tree. Nothing that can hold it may travel through argv: Linux caps a single
+# argument at 128 KiB and macOS caps total argv at 1 MiB, so a tree with a
+# large recorded command used to die with "Argument list too long" (rc=126)
+# before the model was ever called.
+#
+# The fixture is one run whose `command` holds a 200 KiB inline prompt — the
+# same shape that put --prompt-file into bin/shellm. `llm` is stubbed and
+# reports what it was handed, so the check is platform-independent: the
+# prompt arrives on stdin and argv stays small.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+mkdir -p "$WORK/bin" "$WORK/traj/abc12345-run"
+
+big=$(head -c 204800 /dev/zero | tr '\0' 'x')
+{
+    printf '{"type":"shellm-run","step_id":"s1","command":"shellm %s"}\n' "$big"
+    printf '{"type":"run-summary","tldr":"a run with a large inline prompt"}\n'
+} > "$WORK/traj/abc12345-run/trajectory.jsonl"
+
+cat > "$WORK/bin/llm" <<'STUB'
+#!/usr/bin/env bash
+argv_bytes=0
+for a in "$@"; do argv_bytes=$((argv_bytes + ${#a})); done
+if [[ -t 0 ]]; then stdin_bytes=0; else s=$(cat); stdin_bytes=${#s}; fi
+printf 'argv=%d stdin=%d\n' "$argv_bytes" "$stdin_bytes" >&2
+printf 'a report\n'
+STUB
+chmod +x "$WORK/bin/llm"
+
+PATH="$WORK/bin:$PATH" TRAJ_DIR="$WORK/traj" \
+    bash "$REPO/tools/shellm-explore" abc12345 --report \
+    > "$WORK/out" 2> "$WORK/err"
+rc=$?
+
+[[ "$rc" -eq 0 ]] \
+    && ok "report survives a 200 KiB recorded command" \
+    || bad "report survives a 200 KiB recorded command" "rc=$rc: $(tail -1 "$WORK/err")"
+
+seen=$(grep -o 'argv=[0-9]* stdin=[0-9]*' "$WORK/err" | tail -1)
+argv_bytes=${seen#argv=}; argv_bytes=${argv_bytes%% *}
+stdin_bytes=${seen##*stdin=}
+
+[[ -n "$seen" && "$argv_bytes" -lt 4096 ]] \
+    && ok "llm argv stays small (${argv_bytes:-?} bytes)" \
+    || bad "llm argv stays small" "${seen:-llm was never reached}"
+
+[[ -n "$seen" && "$stdin_bytes" -gt 204800 ]] \
+    && ok "the prompt reaches llm on stdin (${stdin_bytes:-?} bytes)" \
+    || bad "the prompt reaches llm on stdin" "${seen:-llm was never reached}"
+
+grep -q 'a report' "$WORK/out" \
+    && ok "the report is printed" \
+    || bad "the report is printed" "$(tail -1 "$WORK/out")"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tools/shellm-explore
+++ b/tools/shellm-explore
@@ -570,11 +570,14 @@ Please provide a detailed report explaining:
 
     local system_prompt="You are an analyst examining shellm run trees. A shellm run tree represents a hierarchy of LLM-powered bash execution sessions, where parent runs spawn child sub-runs to break down tasks. Provide clear, insightful analysis."
 
-    local msg_json
-    msg_json=$(jq -n --arg p "$user_prompt" '[{"role":"user","content":$p}]')
-
+    # The prompt carries every run's context in the tree, so it cannot travel
+    # through argv: Linux caps one argument at 128 KiB and macOS caps total
+    # argv at 1 MiB, and `jq --arg p` / `llm -M` both died with "Argument list
+    # too long" on a deep tree. llm reads the prompt from stdin, which also
+    # makes the jq call that built the message array unnecessary.
     local text
-    text=$(llm -m "$REPORT_MODEL" -t 4096 -s "$system_prompt" -M "$msg_json") \
+    text=$(printf '%s' "$user_prompt" \
+        | llm -m "$REPORT_MODEL" -t 4096 -s "$system_prompt") \
         || die "API request failed"
 
     if [[ -z "$text" ]]; then


### PR DESCRIPTION
Fixes #60

## Description

`generate_report` in `tools/shellm-explore` builds one prompt from every run's context in the tree, then sent the whole thing through argv twice: `jq -n --arg p "$user_prompt"` to build the message array, and `llm -M "$msg_json"` to send it.

`bin/llm:344` already states the rule that breaks — "Nothing that can hold the whole prompt may travel through argv" — and `bin/shellm` grew `--prompt-file` for the same reason. Per-run summaries here are bounded by `-w` (default 85), but the `command` each run records is appended untruncated at `tools/shellm-explore:507-508`, once per run in the tree. A run started with a large inline prompt puts one over the cap on its own, and the report then dies before the model is called:

```
/usr/bin/jq: Argument list too long   (rc=126)
```

`llm` reads the prompt from stdin, and builds the same single-user message array itself with `jq -Rs` (`bin/llm:348`). Piping it removes both argv hops and makes the local `jq` call redundant rather than moving it, so the fix is a net deletion. `-s "$system_prompt"` is applied to `LLM_MESSAGES` whichever way they were built, so the request is unchanged.

I only touched this call site. The same `--arg`-with-unbounded-content shape appears elsewhere in the tree, but this is the one I could demonstrate failing, and widening the diff past that seemed like the wrong trade for a fix PR.

## Tests

`tests/test_explore_report_argv.sh` is new — `shellm-explore` had no test coverage. It drives `--report` over a trajectory whose recorded command is 200 KiB, with `llm` stubbed to report what it was handed.

The assertions are platform-independent on purpose: the prompt arrives on stdin and argv stays under 4 KiB. That catches the bug on both runners, since the two caps differ — Linux caps one argument at 128 KiB, macOS caps total argv at 1 MiB.

Without the change:

- Ubuntu 24.04 container: 0 passed, 4 failed — `rc=126`, `jq: Argument list too long`
- macOS: 2 passed, 2 failed — `argv=205698 stdin=0`

With it, 4 passed on both, including under macOS's stock `/bin/bash` 3.2.

CI is showing `action_required` here, so this is what I could run locally: `tests/run-all.sh` 22 passed / 0 failed (same under bash 3.2), which matches `main` at `d8f8304` plus this PR's own test; pytest 20 / 35 / 150+2 for slack, telegram and web; `shellcheck -S warning` clean over CI's file set.

## Checklist

- [x] Tested
- [x] Linting passes — `shellcheck -S warning` clean on `tools/shellm-explore` and the new test
- [x] Type checks pass — no Python changed
- [x] No sensitive information committed

Found running Headlong outside systemd; the trajectory that surfaced it carried a wakeup prompt of the size that motivated `--prompt-file`.