### PR TITLE
llm: add OpenCode providers (Go subscription + Zen)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LOC_LIMIT: 9900
+      LOC_LIMIT: 9950
     steps:
       - uses: actions/checkout@v5
       - name: Install cloc

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Headlong also gives an agent a few convenience tools, such as a way to
 distill and codify its experience (`mem`) and a way to save and reuse
 procedures for specialized tasks (`skills`). The core is the tools the
 running mind executes, the executables in `bin/` plus the thought
-processes in `thinkers/`, and it comes to 9.8K lines by cloc's count. A
+processes in `thinkers/`, and it comes to 9.9K lines by cloc's count. A
 harness this small can be read end to end, and it is easy to modify and
 experiment with.
 

--- a/bin/llm
+++ b/bin/llm
@@ -38,7 +38,7 @@ LLM_SYSTEM=""
 LLM_MAX_TOKENS=""
 LLM_MESSAGES=""
 LLM_STREAM=1
-LLM_PROVIDER=""
+LLM_PROVIDER="${LLM_PROVIDER:-}"
 LLM_THINKING=0
 LLM_THINKING_LEVEL=""
 LLM_EFFORT=""
@@ -146,7 +146,7 @@ Options:
   -t, --max-tokens N       Max output tokens. Default: model-specific cap
   -M, --messages JSON      Messages array JSON, e.g. [{"role":"user","content":"hi"}]
   --no-stream              Disable streaming (streaming is on by default)
-  --provider NAME          Provider: anthropic, openai, gemini, or openrouter
+  --provider NAME          Provider: anthropic, openai, gemini, openrouter, opencode, or opencode-go
   --thinking [LEVEL]       Enable thinking (Anthropic: adaptive; Gemini: minimal/low/medium/high)
   --effort LEVEL           Thinking effort/provider output effort
   --raw                    Print raw non-streaming API response JSON
@@ -158,6 +158,8 @@ Models:
   OpenAI:     gpt-5.5, gpt-5, gpt-4o, o1, o3, o4
   Gemini:     gemini-3.5-flash, gemini-2.0-flash, gemini-*
   OpenRouter: z-ai/glm-5.2, meta-llama/*, ... (any vendor/model name)
+  OpenCode:   opencode-go/* (Go subscription, OpenAI wire format)
+              opencode/*  (Zen pay-per-token, Anthropic wire format)
 
 Thinking & effort:
   These flags control how much reasoning the model does before answering.
@@ -192,6 +194,9 @@ Environment:
   OPENAI_API_KEY           Required for OpenAI models
   GEMINI_API_KEY           Required for Gemini models
   OPENROUTER_API_KEY       Required for OpenRouter models
+  OPENCODE_API_KEY         Required for OpenCode models — both plans use it;
+                           opencode-go/* bills the Go subscription, opencode/*
+                           bills Zen. Keys: `opencode auth login`
   LLM_API_URL              Override provider API URL
   LLM_RETRIES              Retries for transient API failures (default: 2;
                            0 disables). Never retries after partial output.
@@ -265,8 +270,13 @@ if [[ -z "$LLM_MODEL" ]]; then
         LLM_MODEL="gemini-3.5-flash"
     elif [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
         LLM_MODEL="anthropic/claude-sonnet-4.5"
+    elif [[ -n "${OPENCODE_API_KEY:-}" ]]; then
+        # OPENCODE_API_KEY covers both OpenCode plans and can't disambiguate
+        # them, so default to the flat-rate subscription; Zen models are one
+        # `-m opencode/<model>` away.
+        LLM_MODEL="opencode-go/deepseek-v4-flash"
     else
-        die "No model specified and no API key found. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, or OPENROUTER_API_KEY, or pass -m MODEL."
+        die "No model specified and no API key found. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY, or OPENCODE_API_KEY, or pass -m MODEL."
     fi
 fi
 
@@ -280,6 +290,13 @@ detect_provider() {
         claude-*)                        echo "anthropic" ;;
         gpt-*|o1*|o3*|o4*|chatgpt-*) echo "openai" ;;
         gemini-*)                        echo "gemini" ;;
+        # OpenCode: two plans behind one env var. Explicit prefixes win
+        # before vendor-looking names underneath (claude-*/gpt-*/glm-* would
+        # otherwise be detected as native providers and hit wrong endpoints).
+        #   opencode-go/<model> -> Go subscription (openai wire format)
+        #   opencode/<model>    -> Zen pay-per-token (anthropic wire format)
+        opencode-go/*)                   echo "opencode-go" ;;
+        opencode/*)                      echo "opencode" ;;
         # Vendor-prefixed names (z-ai/glm-5.2, meta-llama/..., etc.) are
         # OpenRouter's model-naming convention.
         */*)                             echo "openrouter" ;;
@@ -291,10 +308,26 @@ if [[ -z "$LLM_PROVIDER" ]]; then
     LLM_PROVIDER=$(detect_provider "$LLM_MODEL")
 fi
 
+# OpenCode routing prefixes hide the real catalog id from the API side;
+# strip once, up front, so the payload builders AND get_model_max_tokens see
+# the actual model name and its caps.
+case "$LLM_PROVIDER" in opencode) LLM_MODEL="${LLM_MODEL#opencode/}" ;; opencode-go) LLM_MODEL="${LLM_MODEL#opencode-go/}" ;; esac
+
 # Per-model max output token caps (synchronous APIs, no beta headers).
 # Used as the default when -t/--max-tokens is not given.
 get_model_max_tokens() {
     local model="$1"
+    # OpenCode Go catalog — frontier-class models with large outputs; the
+    # generic tiers starve agentic shellm steps. Scoped to the provider so
+    # identically-named models reached through other providers (OpenRouter's
+    # qwen/*, grok/*, ...) keep their tiers.
+    if [[ "${LLM_PROVIDER:-}" == "opencode-go" ]]; then
+        case "$model" in
+            glm-*|kimi-*|qwen*|minimax-*|deepseek-*|grok-*|longcat-*|mimo-*|hy3*|muse-*|ox-alpha-*) echo 32768 ;;
+            *) echo 16384 ;;
+        esac
+        return
+    fi
     case "$model" in
         # Anthropic — Claude 4.x family (caps verified via API 400 probing)
         claude-opus-4-7*|claude-opus-4-6*|claude-opus-4-5*|claude-opus-4-1*|claude-opus-4-0*) echo 128000 ;;
@@ -496,6 +529,22 @@ build_payload_gemini() {
 # OpenRouter is OpenAI-compatible (chat/completions wire format)
 build_payload_openrouter() { build_payload_openai; }
 
+# OpenCode Go is OpenAI-compatible (@ai-sdk/openai-compatible upstream);
+# its opencode-go/ prefix was already stripped above.
+build_payload_opencode-go() { build_payload_openai; }
+
+# OpenCode Zen speaks the Anthropic wire protocol (/v1/messages with
+# x-api-key), so the anthropic payload applies unchanged. Two deltas:
+#   - The opencode/ routing prefix was already stripped from LLM_MODEL above.
+#   - Zen's gateway rejects the adaptive-thinking beta ("adaptive thinking is
+#     not supported on this model") for every model tried, and effort's
+#     output_config rides the same beta family — drop both rather than fail.
+#     shellm always passes --thinking, so dropping it here is what makes
+#     shellm usable on Zen at all; thinking happens invisibly server-side.
+build_payload_opencode() {
+    LLM_THINKING=0; LLM_EFFORT=""; build_payload_anthropic
+}
+
 # ---------------------------------------------------------------------------
 # URL and headers per provider
 # ---------------------------------------------------------------------------
@@ -520,6 +569,19 @@ get_url_headers() {
             url="${LLM_API_URL:-https://openrouter.ai/api/v1/chat/completions}"
             headers=(-H "Content-Type: application/json"
                      -H "Authorization: Bearer $OPENROUTER_API_KEY")
+            ;;
+        opencode)
+            [[ -z "${OPENCODE_API_KEY:-}" ]] && die "OPENCODE_API_KEY is not set"
+            url="${LLM_API_URL:-https://opencode.ai/zen/v1/messages}"
+            headers=(-H "content-type: application/json"
+                     -H "x-api-key: $OPENCODE_API_KEY"
+                     -H "anthropic-version: 2023-06-01")
+            ;;
+        opencode-go)
+            [[ -z "${OPENCODE_API_KEY:-}" ]] && die "OPENCODE_API_KEY is not set"
+            url="${LLM_API_URL:-https://opencode.ai/zen/go/v1/chat/completions}"
+            headers=(-H "Content-Type: application/json"
+                     -H "Authorization: Bearer $OPENCODE_API_KEY")
             ;;
         gemini)
             [[ -z "${GEMINI_API_KEY:-}" ]] && die "GEMINI_API_KEY is not set"
@@ -554,6 +616,11 @@ extract_text_gemini() {
 # OpenRouter is OpenAI-compatible
 extract_text_openrouter() { extract_text_openai; }
 
+# OpenCode: Go is OpenAI-compatible, Zen speaks the Anthropic protocol;
+# same response shapes as their respective bases throughout.
+extract_text_opencode-go() { extract_text_openai; }
+extract_text_opencode() { extract_text_anthropic; }
+
 # ---------------------------------------------------------------------------
 # Response failure checks (non-streaming)
 # ---------------------------------------------------------------------------
@@ -583,6 +650,9 @@ check_response_gemini() {
 
 check_response_openrouter() { check_response_openai; }
 
+check_response_opencode-go() { check_response_openai; }
+check_response_opencode() { check_response_anthropic; }
+
 # Truncation is its own silent failure mode: a 200 whose finish reason says
 # the output hit max_tokens looks complete to a caller reading stdout, and on
 # reasoning models the budget includes the (invisible) thinking tokens, so the
@@ -603,6 +673,9 @@ check_truncated_gemini() {
 }
 
 check_truncated_openrouter() { check_truncated_openai; }
+
+check_truncated_opencode-go() { check_truncated_openai; }
+check_truncated_opencode() { check_truncated_anthropic; }
 
 # Shared by the non-streaming path and the streaming handlers (stderr passes
 # straight through the handler subshell, so this works from either).
@@ -820,6 +893,10 @@ stream_gemini() {
 
 # OpenRouter is OpenAI-compatible (SSE chat/completions chunks)
 stream_openrouter() { stream_openai; }
+
+# OpenCode: same SSE shapes as their wire-format bases.
+stream_opencode-go() { stream_openai; }
+stream_opencode() { stream_anthropic; }
 
 # ---------------------------------------------------------------------------
 # Main execution

--- a/bin/shellm
+++ b/bin/shellm
@@ -52,6 +52,10 @@ if [[ -z "${SHELLM_MODEL:-}" ]]; then
         SHELLM_MODEL="gemini-3.5-flash"
     elif [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
         SHELLM_MODEL="anthropic/claude-sonnet-4.5"
+    elif [[ -n "${OPENCODE_API_KEY:-}" ]]; then
+        # One env var covers both OpenCode plans; default to the Go
+        # subscription (flat-rate). Zen models: SHELLM_MODEL=opencode/<model>.
+        SHELLM_MODEL="opencode-go/deepseek-v4-flash"
     else
         SHELLM_MODEL="claude-opus-4-7"
     fi

--- a/install.sh
+++ b/install.sh
@@ -159,6 +159,7 @@ EOF
     local -a fwd=()
     local var
     for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
+               OPENCODE_API_KEY \
                HEADLONG_IDENTITY_NAME HEADLONG_IDENTITY_VIBE HEADLONG_IDENTITY_FOCUS \
                HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME HEADLONG_REPO HEADLONG_BRANCH; do
         if [[ -n "${!var:-}" ]]; then fwd+=(-e "$var=${!var}"); fi

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -290,7 +290,7 @@ EOF
 # ---------------------------------------------------------------------------
 
 _have_key() {
-    [[ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GEMINI_API_KEY:-}${OPENROUTER_API_KEY:-}" ]]
+    [[ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GEMINI_API_KEY:-}${OPENROUTER_API_KEY:-}${OPENCODE_API_KEY:-}" ]]
 }
 
 _key_var_for() {  # guess the provider env var from the key's prefix
@@ -309,12 +309,13 @@ _default_model_for() {
         OPENAI_API_KEY)     echo "gpt-5.5" ;;
         GEMINI_API_KEY)     echo "gemini-3.5-flash" ;;
         OPENROUTER_API_KEY) echo "anthropic/claude-sonnet-4.5" ;;
+        OPENCODE_API_KEY)   echo "opencode-go/deepseek-v4-flash" ;;
     esac
 }
 
 _first_key_var() {  # first provider var that is set (llm's priority order)
     local var
-    for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY; do
+    for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY OPENCODE_API_KEY; do
         [[ -n "${!var:-}" ]] && { echo "$var"; return 0; }
     done
     return 1
@@ -350,13 +351,25 @@ _prompt_key() {
         fi
     done
     var=$(_key_var_for "$key")
-    if [[ -z "$var" ]]; then
+    if [[ "$key" == sk-* && "$key" != sk-ant-* && "$key" != sk-or-* ]]; then
+        # OpenAI and OpenCode keys share the bare sk- prefix, and a wrong
+        # guess sends the handshake to api.openai.com where it fails
+        # confusingly. Ask rather than guess; OpenAI stays the default so
+        # the common case is just Enter.
         local which
-        which=$(ask "Which provider is that key for? (1) Anthropic (2) OpenAI (3) Gemini (4) OpenRouter" "1")
+        which=$(ask "Is that an OpenAI or an OpenCode key? (1) OpenAI (2) OpenCode" "1")
+        case "$which" in
+            2) var=OPENCODE_API_KEY ;;
+            *) var=OPENAI_API_KEY ;;
+        esac
+    elif [[ -z "$var" ]]; then
+        local which
+        which=$(ask "Which provider is that key for? (1) Anthropic (2) OpenAI (3) Gemini (4) OpenRouter (5) OpenCode" "1")
         case "$which" in
             2) var=OPENAI_API_KEY ;;
             3) var=GEMINI_API_KEY ;;
             4) var=OPENROUTER_API_KEY ;;
+            5) var=OPENCODE_API_KEY ;;
             *) var=ANTHROPIC_API_KEY ;;
         esac
     fi
@@ -368,12 +381,12 @@ _prompt_key() {
 
 _ensure_api_key() {
     if ! _have_key && [[ "$HAS_TTY" -eq 0 ]]; then
-        die "no API key found. Set ANTHROPIC_API_KEY (or OPENAI/GEMINI/OPENROUTER_API_KEY), or put it in $HEADLONG_HOME/.env"
+        die "no API key found. Set ANTHROPIC_API_KEY (or OPENAI/GEMINI/OPENROUTER/OPENCODE_API_KEY), or put it in $HEADLONG_HOME/.env"
     fi
     if ! _have_key; then
         cat >/dev/tty <<'EOF'
 
-Headlong needs an LLM API key (Anthropic, OpenAI, Gemini, or OpenRouter).
+Headlong needs an LLM API key (Anthropic, OpenAI, Gemini, OpenRouter, or OpenCode).
 Paste just the key itself; headlong-init figures out the provider from it.
 
   * Use a DEDICATED, SPEND-CAPPED key. The agent you're about to create


### PR DESCRIPTION
 ## What

   Adds OpenCode as an LLM provider (both Go & Zen) across the
   harness: `llm`, `shellm`'s default-model chain, and `headlong-init`'s api key initialization.

   Having OpenCode as a provider gives easy access to models like `deepseek-v4-flash` that seem well suited to running continuously, as they are fast and cheap (closes #43).

   | model prefix | plan | endpoint | wire format |
   |---|---|---|---|
   | `opencode-go/<model>` | Go flat-rate subscription | `https://opencode.ai/zen/go/v1` | OpenAI (`chat/completions`) |
   | `opencode/<model>` | Zen pay-per-token | `https://opencode.ai/zen/v1` | Anthropic (`/v1/messages`) |

   Both plans authenticate with the same `OPENCODE_API_KEY`.

   ## Details

   - **Zen doesn't accept --thinking on all models** ("adaptive thinking is not
     supported on this model", tested on `claude-haiku-4-5` and
     `claude-sonnet-4-5`). Since `shellm` always passes `--thinking`, every shellm
     run would fail on Zen, so the Zen payload builder drops both `--thinking` and
     `--effort` rather than fail. (Whether `--effort` alone survives on Zen is
     untested; `shellm` never sends it alone).
   - **OpenCode keys collide with OpenAI's**: both start with `sk-…`, so the
     init script now asks "OpenAI or OpenCode?" (default OpenAI, so the common case is still just
     Enter); unambiguous prefixes (`sk-ant-`, `sk-or-`, `AIza`) skip the question.
   - **Token caps are provider-scoped.** The Go catalog (glm, kimi, qwen,
     deepseek, grok, …) gets a 32K output tier guarded on
     `LLM_PROVIDER == opencode-go`, so identically-named models reached through
     OpenRouter keep their existing tiers.
   - With no `SHELLM_MODEL` set and only `OPENCODE_API_KEY` present, the default
     is `opencode-go/deepseek-v4-flash`.

   ## Testing

   - Harness still runs correctly: shellcheck clean; bash-3.2 syntax clean.
   - Live end-to-end on a fresh install: init → OpenCode key → mind running with
     `opencode-go/deepseek-v4-flash`; streaming, non-streaming, and multi-step
     shellm runs verified against both plan endpoints.
   - Wrong key: a dummy key against `opencode-go/*` reaches
     opencode's server and is rejected there.

   ## LOC gate

   `cloc bin/ thinkers/` grows 9883 → 9927. Per the gate's policy
   ("raise the limit here … rather than drift"), this raises `LOC_LIMIT`
   9900 → 9950 and updates the README's count to 9.9K. We are still below 10k lines.