### PR TITLE
init/llm: resolve the provider from the key, not the variable holding it

### DIFF
--- a/bin/llm
+++ b/bin/llm
@@ -35,7 +35,7 @@ _llm_load_env "$_llm_home/.env" || true
 
 LLM_MODEL="${LLM_MODEL:-}"
 LLM_SYSTEM=""
-LLM_MAX_TOKENS=""
+LLM_MAX_TOKENS="${LLM_MAX_TOKENS:-}"
 LLM_MESSAGES=""
 LLM_STREAM=1
 LLM_PROVIDER="${LLM_PROVIDER:-}"

--- a/tests/test_key_var_resolution.sh
+++ b/tests/test_key_var_resolution.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# tests/test_key_var_resolution.sh — provider selection when a key sits in the
+# wrong variable, and LLM_MAX_TOKENS coming from the environment.
+#
+# Usage: tests/test_key_var_resolution.sh
+#
+# Why: the provider is chosen from whichever *_API_KEY variable is set first,
+# and the model default follows from that. A key exported into the wrong
+# variable (an sk-or- OpenRouter key in OPENAI_API_KEY) therefore picked
+# gpt-5.5, which detect_provider routes to api.openai.com, and the run died
+# with a confusing "Incorrect API key provided". The prefix now wins, except
+# where it is genuinely ambiguous (a bare sk- key is OpenAI or OpenCode).
+# No network and no real daemon are touched; curl, docker and llm are stubs.
+# Key fixtures below carry only the prefix that matters and are deliberately
+# shaped so they cannot match a real provider pattern (GitHub push protection
+# rejects fixtures that look like the genuine article).
+
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+trap 'cd /; rm -rf "$WORK"' EXIT
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+check()     { local l="$1"; shift; if "$@" >/dev/null 2>&1; then ok "$l"; else bad "$l"; fi; }
+check_not() { local l="$1"; shift; if "$@" >/dev/null 2>&1; then bad "$l"; else ok "$l"; fi; }
+
+STUB="$WORK/stub"; mkdir -p "$STUB"
+# docker: daemon up, everything else succeeds so no image is pulled.
+printf '#!/usr/bin/env bash\ncase "${1:-}" in info) exit 0 ;; *) exit 0 ;; esac\n' > "$STUB/docker"
+# llm: always fails, so init stops right after writing SHELLM_MODEL. Without a
+# tty that is a single fast failure, which is all these assertions need.
+printf '#!/usr/bin/env bash\nexit 1\n' > "$STUB/llm"
+chmod +x "$STUB/docker" "$STUB/llm"
+
+APP="$WORK/app"; mkdir -p "$APP/bin" "$APP/tools"
+: > "$APP/bin/shellm"
+
+# run_init <home> [VAR=VAL ...] — headlong-init with no tty, no inherited keys.
+run_init() {
+    local home="$1"; shift
+    mkdir -p "$home"
+    env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY \
+        -u OPENCODE_API_KEY -u SHELLM_MODEL -u HEADLONG_UNSANDBOXED \
+        HOME="$home" HEADLONG_HOME="$home/.headlong" HEADLONG_APP_DIR="$APP" \
+        HEADLONG_NO_TTY=1 HEADLONG_UNSANDBOXED=1 PATH="$STUB:$PATH" "$@" \
+        bash "$REPO/tools/headlong-init" </dev/null > "$WORK/out" 2>&1
+}
+model_of() { grep '^SHELLM_MODEL=' "$1/.headlong/.env" | tail -1; }
+
+# --- the reported case: OpenRouter key exported as OPENAI_API_KEY ------------
+run_init "$WORK/h1" OPENAI_API_KEY=sk-or-v1-EXAMPLE-NOT-A-REAL-KEY
+check "misplaced sk-or- key: model follows the key, not the variable" \
+    grep -qx 'SHELLM_MODEL=anthropic/claude-sonnet-4.5' "$WORK/h1/.headlong/.env"
+check "misplaced sk-or- key: says which variable it should be in" \
+    grep -q 'OPENROUTER_API_KEY' "$WORK/out"
+check_not "misplaced sk-or- key: never defaults to an OpenAI model" \
+    grep -q 'SHELLM_MODEL=gpt-' "$WORK/h1/.headlong/.env"
+
+# --- a correctly placed OpenAI key is untouched ------------------------------
+run_init "$WORK/h2" OPENAI_API_KEY=sk-proj-EXAMPLE-NOT-A-REAL-KEY
+check "consistent OpenAI key: keeps the OpenAI default" \
+    grep -qx 'SHELLM_MODEL=gpt-5.5' "$WORK/h2/.headlong/.env"
+check_not "consistent OpenAI key: warns about nothing" \
+    grep -qi 'prefix belongs to' "$WORK/out"
+
+# --- a bare sk- key is OpenAI *or* OpenCode: ambiguous, so never moved -------
+run_init "$WORK/h3" OPENCODE_API_KEY=sk-EXAMPLE-NOT-A-REAL-KEY
+check "bare sk- in OPENCODE_API_KEY: left where it is" \
+    grep -qx 'SHELLM_MODEL=opencode-go/deepseek-v4-flash' "$WORK/h3/.headlong/.env"
+check_not "bare sk- in OPENCODE_API_KEY: not remapped to OpenAI" \
+    grep -qi 'prefix belongs to' "$WORK/out"
+
+# --- misplaced key alongside a correctly placed one: the right one wins ------
+run_init "$WORK/h4" \
+    OPENAI_API_KEY=sk-or-v1-EXAMPLE-MISPLACED-KEY \
+    OPENROUTER_API_KEY=sk-or-v1-EXAMPLE-CORRECT-KEY
+check "both set: picks the consistent variable" \
+    grep -qx 'SHELLM_MODEL=anthropic/claude-sonnet-4.5' "$WORK/h4/.headlong/.env"
+
+# --- an Anthropic key in the wrong slot is corrected too ---------------------
+run_init "$WORK/h5" OPENAI_API_KEY=sk-ant-api03-EXAMPLE-NOT-A-REAL-KEY
+check "misplaced sk-ant- key: model follows the key" \
+    grep -qx 'SHELLM_MODEL=claude-sonnet-4-5-20250929' "$WORK/h5/.headlong/.env"
+
+# --- bin/llm honors LLM_MAX_TOKENS from the environment ----------------------
+# curl stub records the request body; llm builds it with jq before sending.
+CURL_STUB="$WORK/curlstub"; mkdir -p "$CURL_STUB"
+cat > "$CURL_STUB/curl" <<'EOF'
+#!/usr/bin/env bash
+body=""
+prev=""
+for a in "$@"; do
+    case "$prev" in -d|--data|--data-binary|--data-raw) body="$a" ;; esac
+    prev="$a"
+done
+case "$body" in
+    "@-"|"") body="$(cat)" ;;
+    @*)      body="$(cat "${body#@}")" ;;
+esac
+printf '%s' "$body" > "$PAYLOAD_OUT"
+printf 'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}\n\n'
+printf 'data: {"type":"message_stop"}\n\n'
+EOF
+chmod +x "$CURL_STUB/curl"
+
+export PAYLOAD_OUT="$WORK/payload.json"
+env -u SHELLM_MODEL -u HEADLONG_HOME PATH="$CURL_STUB:$PATH" \
+    HOME="$WORK/h6" ANTHROPIC_API_KEY=sk-ant-test LLM_MAX_TOKENS=4242 \
+    bash "$REPO/bin/llm" -m claude-sonnet-4-5-20250929 hi >/dev/null 2>&1
+check "bin/llm: LLM_MAX_TOKENS from the environment reaches the request" \
+    grep -q '"max_tokens":[[:space:]]*4242' "$PAYLOAD_OUT"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -313,8 +313,59 @@ _default_model_for() {
     esac
 }
 
-_first_key_var() {  # first provider var that is set (llm's priority order)
-    local var
+_key_var_unambiguous() {  # the ONLY provider var a key's prefix can belong to
+    # Deliberately stricter than _key_var_for: a bare sk- key is OpenAI *or*
+    # OpenCode (see _prompt_key, which has to ask), so it is not evidence of
+    # anything and must never move a key. Only these three prefixes settle it.
+    case "$1" in
+        sk-ant-*) echo ANTHROPIC_API_KEY ;;
+        sk-or-*)  echo OPENROUTER_API_KEY ;;
+        AIza*)    echo GEMINI_API_KEY ;;
+        *)        echo "" ;;
+    esac
+}
+
+_reconcile_key_vars() {
+    # A key exported into the wrong provider variable -- an sk-or- OpenRouter
+    # key sitting in OPENAI_API_KEY, say -- otherwise picks that variable's
+    # default model (gpt-5.5), which detect_provider maps to openai, so the
+    # handshake goes to api.openai.com and comes back "Incorrect API key
+    # provided". The prefix is better evidence of the provider than whichever
+    # variable the key was exported to, so honor the prefix and say so.
+    #
+    # Must run in the parent shell: the export has to outlive the call, so
+    # never invoke this inside $(...).
+    local var want
+    for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY OPENCODE_API_KEY; do
+        [[ -n "${!var:-}" ]] || continue
+        want=$(_key_var_unambiguous "${!var}")
+        [[ -n "$want" && "$want" != "$var" ]] || continue
+        if [[ -n "${!want:-}" ]]; then
+            # The right variable is already set; leave both alone and let the
+            # priority order below pick the consistent one.
+            [[ "${!want}" != "${!var}" ]] && printf \
+                'headlong-init: warning: %s holds a %s key; %s is also set, using that one.\n' \
+                "$var" "$want" "$want" >&2
+            continue
+        fi
+        printf 'headlong-init: warning: %s holds a key whose prefix belongs to %s; using it as %s.\n' \
+            "$var" "$want" "$want" >&2
+        export "$want=${!var}"
+    done
+}
+
+_first_key_var() {  # the provider var to use (llm's priority order)
+    local var want
+    # Prefer a variable its own key's prefix does not contradict, so a
+    # misplaced key cannot shadow a correctly-placed one.
+    for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY OPENCODE_API_KEY; do
+        [[ -n "${!var:-}" ]] || continue
+        want=$(_key_var_unambiguous "${!var}")
+        [[ -z "$want" || "$want" == "$var" ]] && { echo "$var"; return 0; }
+    done
+    # Every key present contradicts its variable and _reconcile_key_vars could
+    # not place one (it never runs inside $(...)); fall back to the old
+    # first-set-wins so behavior is unchanged rather than absent.
     for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY OPENCODE_API_KEY; do
         [[ -n "${!var:-}" ]] && { echo "$var"; return 0; }
     done
@@ -380,6 +431,7 @@ _prompt_key() {
 }
 
 _ensure_api_key() {
+    _reconcile_key_vars
     if ! _have_key && [[ "$HAS_TTY" -eq 0 ]]; then
         die "no API key found. Set ANTHROPIC_API_KEY (or OPENAI/GEMINI/OPENROUTER/OPENCODE_API_KEY), or put it in $HEADLONG_HOME/.env"
     fi


### PR DESCRIPTION
Two small, independent bugs that both show up as a non-Anthropic provider failing with a message that points somewhere other than the actual cause. Found while installing with an OpenRouter key.

## 1. A key in the wrong variable silently picks the wrong provider

`_have_key()` returns true if *any* `*_API_KEY` is set, and `_first_key_var()` then takes the first one in a fixed order. Nothing checks that the key actually belongs to the variable holding it.

Repro:

```bash
export OPENAI_API_KEY=sk-or-v1-...   # an OpenRouter key
curl -fsSL https://headlong.ai/install.sh | bash
```

`_first_key_var` returns `OPENAI_API_KEY`, `_default_model_for` gives `gpt-5.5`, `detect_provider` maps `gpt-*` to `openai`, and the handshake goes to `api.openai.com`:

```
==> Checking the LLM connection (model: gpt-5.5)
    FAILED — OPENAI_API_KEY (sk-o...bd64) did not get a reply from gpt-5.5.
    The key may be mistyped, for another provider, or out of credit.
```

The key is fine. It is in the wrong variable, and nothing in the output says so — the masked hint even elides the `sk-or-` prefix that would give it away. `gpt-5.5` never appears in anything the user typed, which makes it hard to work back to what happened.

`_prompt_key` already derives the provider from the prefix via `_key_var_for`, and the comment above `_env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" ...` says the intent is that "a stale key for another provider in the env can't shadow the one we just validated". This extends the same reasoning to keys arriving from the environment rather than from a paste.

Behaviour now:

- `_first_key_var` prefers a variable its own key's prefix does not contradict, so a correctly placed key always beats a misplaced one.
- `_reconcile_key_vars` moves a misplaced key to where it belongs and says so on stderr.
- A key is only moved when its prefix is **unambiguous** — `sk-ant-`, `sk-or-`, `AIza`. A bare `sk-` key is OpenAI *or* OpenCode (`_prompt_key` has to ask), so it is treated as no evidence at all and never moved. That is what `_key_var_unambiguous` is for, and why it is deliberately stricter than `_key_var_for`.
- `_reconcile_key_vars` is called once from `_ensure_api_key` in the parent shell, never inside `$(...)`, since the `export` has to outlive the call.

If nothing is misplaced, nothing changes.

## 2. `LLM_MAX_TOKENS` was ignored

`bin/llm` had:

```bash
LLM_MODEL="${LLM_MODEL:-}"
LLM_SYSTEM=""
LLM_MAX_TOKENS=""          # <-- env and .env silently dropped
LLM_MESSAGES=""
LLM_STREAM=1
LLM_PROVIDER="${LLM_PROVIDER:-}"
```

so the variable was ignored from the environment *and* from the state `.env` that `_llm_load_env` sources, unlike its neighbours. Only `-t` worked.

This matters most where `get_model_max_tokens` falls through to the generic `*/*` cap of 16384. The comments on the `anthropic/*` and `x-ai/grok*` entries already explain why that starves a reasoning model — "reasoning tokens count against max_tokens, so 16384 starves any answer that needed heavy thinking first" — and any other vendor-prefixed reasoning model on OpenRouter hits exactly that, with no way to raise it short of editing `bin/llm`. One-line fix; I left the cap table alone.

## Testing

New `tests/test_key_var_resolution.sh`, in the style of `test_sandbox_gate.sh` — `curl`, `docker` and `llm` stubbed, no network.

- 10/10 pass with these changes.
- 6/10 fail without them. The 4 that pass either way are the guards against changing behaviour that already worked: a correctly placed OpenAI key keeps `gpt-5.5` and warns about nothing, and a bare `sk-` key in `OPENCODE_API_KEY` is left alone.
- `tests/run-all.sh`: 23 passed, 0 failed.
- `shellcheck -S warning` clean on all three files.

Key fixtures are shaped so they cannot match a real provider pattern — the first version of this branch was blocked by GitHub push protection for containing a convincing fake `sk-or-v1-`, which seemed worth avoiding in a repo where people will copy the test.

Happy to split this into two PRs, or drop either half, if you would rather take them separately.
