### PR TITLE
sandbox: confine symlink mounts to the checkout and an opt-in allowlist

### DIFF
--- a/tests/test_sandbox_symlink_mounts.sh
+++ b/tests/test_sandbox_symlink_mounts.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# tests/test_sandbox_symlink_mounts.sh — which host paths the broker will mount
+# into the sandbox.
+#
+# Usage: tests/test_sandbox_symlink_mounts.sh
+#
+# Why: symlink_mounts() mounts the *parent directory* of every symlink target
+# it finds in the workdir, and the agent has write access to that workdir. So
+# `ln -s ~/.ssh/id_ed25519 x` used to be enough to get ~/.ssh mounted into the
+# next container, and `ln -s ~/.headlong/.env x` the state home holding the API
+# key — the sandbox handing over host files rather than being broken out of.
+# Targets are now confined to the app checkout plus whatever the operator opts
+# into via HEADLONG_SANDBOX_RO_DIRS.
+#
+# The functions are exercised directly; no docker daemon and no network.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+BROKER="$REPO/tools/shellm-docker-broker"
+
+WORK=$(mktemp -d)
+trap 'cd /; rm -rf "$WORK"' EXIT
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+# Pull just the functions under test out of the broker, which otherwise starts
+# serving when run.
+{ awk '/^path_under\(\)/,/^}/'         "$BROKER"
+  awk '/^sandbox_ro_dirs\(\)/,/^}/'    "$BROKER"
+  awk '/^symlink_allow_root\(\)/,/^}/' "$BROKER"
+  awk '/^symlink_mounts\(\)/,/^}/'     "$BROKER"
+} > "$WORK/funcs.sh"
+log_msg() { :; }
+# shellcheck disable=SC1090
+. "$WORK/funcs.sh"
+
+# A checkout shaped like the real one: the app dir is the one holding
+# .identities, and thinkers/skills are symlinked into the identity from it.
+APP="$WORK/app"
+WD="$APP/.identities/ada/workdir"
+mkdir -p "$APP/.identities/ada" "$APP/thinkers/monolith" "$WD"
+echo step > "$APP/thinkers/monolith/step"
+ln -sf "$APP/thinkers/monolith/step" "$WD/step"
+
+# Somewhere the operator never opted into, standing in for ~/.ssh.
+SECRETS="$WORK/secrets"; mkdir -p "$SECRETS"; echo key > "$SECRETS/id_ed25519"
+# Somewhere they did.
+PROJ="$WORK/project"; mkdir -p "$PROJ"; echo code > "$PROJ/main.c"
+
+export HEADLONG_HOME="$WORK/state-empty"
+unset HEADLONG_SANDBOX_RO_DIRS
+
+# --- no allowlist: the checkout is reachable, nothing else ------------------
+ln -sf "$SECRETS/id_ed25519" "$WD/stolen"
+out=$(symlink_mounts "$WD")
+case "$out" in *"$APP/thinkers/monolith"*) ok "app-checkout symlink still mounted" ;;
+                *) bad "app-checkout symlink still mounted" "$out" ;; esac
+case "$out" in *"$SECRETS"*) bad "symlink to an unlisted dir refused" "$out" ;;
+                *) ok "symlink to an unlisted dir refused" ;; esac
+
+# --- opting a directory in makes it reachable, and only it ------------------
+export HEADLONG_SANDBOX_RO_DIRS="$PROJ"
+ln -sf "$PROJ/main.c" "$WD/proj"
+out=$(symlink_mounts "$WD")
+case "$out" in *"$PROJ"*) ok "symlink into an allowlisted dir permitted" ;;
+                *) bad "symlink into an allowlisted dir permitted" "$out" ;; esac
+case "$out" in *"$SECRETS"*) bad "unlisted dir still refused with an allowlist set" "$out" ;;
+                *) ok "unlisted dir still refused with an allowlist set" ;; esac
+
+# --- sandbox_ro_dirs ---------------------------------------------------------
+[ "$(sandbox_ro_dirs | grep -c "$PROJ")" -eq 1 ] \
+    && ok "sandbox_ro_dirs reads the environment" || bad "sandbox_ro_dirs reads the environment"
+
+export HEADLONG_SANDBOX_RO_DIRS="$PROJ:$WORK/does-not-exist"
+[ -z "$(sandbox_ro_dirs | grep does-not-exist)" ] \
+    && ok "sandbox_ro_dirs drops missing dirs" || bad "sandbox_ro_dirs drops missing dirs"
+
+# A single entry has no trailing newline once split; the last one must survive.
+export HEADLONG_SANDBOX_RO_DIRS="$PROJ"
+[ "$(sandbox_ro_dirs | wc -l | tr -d ' ')" -eq 1 ] \
+    && ok "sandbox_ro_dirs yields a sole entry (no trailing newline)" \
+    || bad "sandbox_ro_dirs yields a sole entry (no trailing newline)"
+
+unset HEADLONG_SANDBOX_RO_DIRS
+mkdir -p "$WORK/state"; export HEADLONG_HOME="$WORK/state"
+printf 'HEADLONG_SANDBOX_RO_DIRS=%s\n' "$PROJ" > "$WORK/state/.env"
+[ "$(sandbox_ro_dirs | grep -c "$PROJ")" -eq 1 ] \
+    && ok "sandbox_ro_dirs falls back to the state .env" || bad "sandbox_ro_dirs falls back to the state .env"
+
+# --- a workdir with no checkout above it allows nothing outside itself -------
+unset HEADLONG_SANDBOX_RO_DIRS; export HEADLONG_HOME="$WORK/state-empty"
+LONE="$WORK/lone"; mkdir -p "$LONE"; ln -sf "$SECRETS/id_ed25519" "$LONE/x"
+out=$(symlink_mounts "$LONE")
+case "$out" in *"$SECRETS"*) bad "no-checkout workdir denies outside targets" "$out" ;;
+                *) ok "no-checkout workdir denies outside targets" ;; esac
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tools/shellm-docker-broker
+++ b/tools/shellm-docker-broker
@@ -76,8 +76,60 @@ path_under() {
     [[ "$path" == "$root" || "$path" == "$root"/* ]]
 }
 
+# sandbox_ro_dirs - directories the operator has chosen to expose to the
+# sandbox read-only, newline-separated. Configured as a colon-separated list
+# in HEADLONG_SANDBOX_RO_DIRS, either in the environment or in the state
+# .env. These are mounted :ro into every run AND accepted as symlink targets.
+# Everything else outside the app checkout stays refused, so the agent cannot
+# widen its own view by planting a symlink.
+sandbox_ro_dirs() {
+    local raw="${HEADLONG_SANDBOX_RO_DIRS:-}" home_env
+    if [[ -z "$raw" ]]; then
+        home_env="${HEADLONG_HOME:-$HOME/.headlong}/.env"
+        [[ -r "$home_env" ]] && raw=$(sed -n 's/^HEADLONG_SANDBOX_RO_DIRS=//p' "$home_env" | tail -1)
+    fi
+    raw="${raw%\"}"; raw="${raw#\"}"
+    [[ -z "$raw" ]] && return 0
+    local d
+    # `|| [[ -n "$d" ]]` so a list with no trailing newline still yields its
+    # last entry -- read returns non-zero at EOF even when it read a value.
+    while IFS= read -r d || [[ -n "$d" ]]; do
+        [[ -n "$d" && -d "$d" ]] || continue
+        readlink -f "$d" 2>/dev/null || printf '%s\n' "$d"
+    done < <(printf '%s' "$raw" | tr ':' '\n') | sort -u
+}
+
+# symlink_allow_root WORKDIR - the only tree whose symlink targets may be
+# mounted: the app checkout (the directory holding .identities), which is
+# where every symlink Headlong itself creates points - thinkers, skills and
+# kernel entries. Falls back to the workdir, i.e. allow nothing outside it,
+# when no checkout can be identified.
+symlink_allow_root() {
+    local p="$1"
+    while [[ "$p" != "/" && "$p" != "." && -n "$p" ]]; do
+        [[ -d "$p/.identities" ]] && { printf '%s\n' "$p"; return 0; }
+        p=$(dirname "$p")
+    done
+    printf '%s\n' "$1"
+}
+
 symlink_mounts() {
     local workdir="$1"
+    # The agent has write access to its own workdir, so every symlink in there
+    # is a path IT may have chosen - and this function mounts the target's
+    # *parent directory*. Following an arbitrary target therefore hands the
+    # sandbox whole host directories: `ln -s ~/.ssh/id_ed25519 x` would mount
+    # ~/.ssh, `ln -s ~/.headlong/.env x` the state home. Confine targets to the
+    # app checkout, which is where all of Headlong's own symlinks point.
+    local allow_root allowed ro_dir
+    allow_root=$(symlink_allow_root "$workdir")
+    # Targets arrive canonicalized (readlink -f), so the root must be too, or
+    # a symlink anywhere in the install path -- /var -> /private/var on macOS,
+    # say -- makes every legitimate target look like it is outside the tree.
+    allow_root=$(readlink -f "$allow_root" 2>/dev/null || printf '%s' "$allow_root")
+    # Same reasoning for the workdir: uncanonicalized, a symlinked install path
+    # makes targets already inside the workdir look external and re-mounts it.
+    workdir=$(readlink -f "$workdir" 2>/dev/null || printf '%s' "$workdir")
 
     # bash 3.2 lacks associative arrays, so dedupe via sort -u.
     local -a mount_dirs=()
@@ -90,6 +142,18 @@ symlink_mounts() {
             target=$(readlink -f "$link" 2>/dev/null) || continue
             path_under "$target" "$workdir" && continue
             [[ -e "$target" ]] || continue
+            allowed=0
+            path_under "$target" "$allow_root" && allowed=1
+            if [[ "$allowed" -eq 0 ]]; then
+                while IFS= read -r ro_dir; do
+                    [[ -n "$ro_dir" ]] || continue
+                    path_under "$target" "$ro_dir" && { allowed=1; break; }
+                done < <(sandbox_ro_dirs)
+            fi
+            if [[ "$allowed" -eq 0 ]]; then
+                log_msg "symlink refused (outside $allow_root and the read-only allowlist): $link -> $target"
+                continue
+            fi
             dirname "$target"
         done < <(find "$workdir" -type l -print0 2>/dev/null) \
         | sort -u
@@ -231,6 +295,14 @@ handle_run() {
         [[ -n "$line" ]] && symlink_vols+=("$line")
     done < <(symlink_mounts "$workdir")
 
+    local -a ro_vols=()
+    local ro_dir
+    while IFS= read -r ro_dir; do
+        [[ -n "$ro_dir" ]] || continue
+        path_under "$ro_dir" "$workdir" && continue
+        ro_vols+=(-v "$ro_dir:$ro_dir:ro")
+    done < <(sandbox_ro_dirs)
+
     local -a cmd=(
         docker run --rm
         --label "shellm.broker=1"
@@ -241,6 +313,7 @@ handle_run() {
         --pids-limit "$pids"
         -v "$workdir:$workdir"
         "${symlink_vols[@]}"
+        "${ro_vols[@]}"
         -w "$cwd"
         -e "SHELLM_WORKDIR=$workdir"
         "$image"


### PR DESCRIPTION
## What

`symlink_mounts()` walks the workdir for symlinks and mounts the **parent directory** of each target into the next container. The agent has write access to that workdir, so the set of host directories the sandbox can see is effectively chosen by the agent.

```bash
ln -s ~/.ssh/id_ed25519 x     # next run mounts ~/.ssh
ln -s ~/.headlong/.env  x     # next run mounts the state home, where
                              # headlong-init writes the API key
```

I confirmed the first one against a live install: a broker-launched container could list `~/.ssh` and read `id_ed25519`.

## What it is, and isn't

Nothing breaks out of the container. There's no kernel exploit, no privilege escalation, no docker socket. The broker runs on the host and constructs the `-v` flag itself from agent-controlled input — a confused deputy, not an escape. Impact is host file **reads** only: no writes, no host code execution.

That said, the installer's own framing is "the agent's shell commands still run sandboxed in Docker", and for confidentiality that doesn't hold — the whole of `$HOME` is one `ln -s` away. It's also cheap to trigger, and the reachability isn't really "would the agent choose to do this": these agents read untrusted text, so a string in a fetched page or a checked-out README is enough to aim it, and the result goes wherever the configured model goes.

## Approach

Dropping the feature isn't an option — every thinker, skill and kernel entry reaches the identity through a symlink into the app checkout, so a blanket deny breaks the agent. Targets are confined to:

- **the app checkout** (the directory holding `.identities`), where all of Headlong's own symlinks point; and
- **directories the operator opts into** via `HEADLONG_SANDBOX_RO_DIRS`, a colon-separated list read from the environment or the state `.env`.

Opted-in directories are additionally mounted `:ro` into every run, so an operator can hand the agent project trees to read without a symlink dance, and without that grant widening to anything else. Refusals are logged.

Default behaviour is unchanged for anyone not setting the variable, except that agent-planted symlinks out of the checkout stop being followed.

```bash
# in ~/.headlong/.env
HEADLONG_SANDBOX_RO_DIRS=/Users/me/git_repos:/Users/me/notes
```

## Two details worth a reviewer's eye

- `allow_root` and `workdir` are canonicalized before comparison. Targets arrive from `readlink -f`, so without this a symlink anywhere in the install path — `/var` → `/private/var` on macOS — makes every legitimate target look external and refuses all of them. I hit exactly this: my first version passed the security assertions and silently broke the agent.
- `sandbox_ro_dirs` uses `read -r d || [[ -n "$d" ]]`. The split list has no trailing newline, so a single-entry list is otherwise dropped in full.

## Testing

`tests/test_sandbox_symlink_mounts.sh` exercises the functions directly — no docker daemon, no network, so it runs anywhere the rest of the bash suite does.

- 9/9 with this change.
- 6 of the 9 fail without it, and the failure output shows the secrets directory being mounted as `:ro`.
- `shellcheck -S warning` clean.
- `tests/run-all.sh`: all green.

One note in case you see it locally: `test_llm_retry.sh` fails for me only when my real `~/.headlong/.env` is visible, because `bin/llm` sources the state `.env` and picks up my configured `SHELLM_MODEL`. With `HEADLONG_HOME` pointed at a scratch dir it's 70/70, on this branch and on pristine `main` alike, so it's unrelated to this change — but the bash suite isn't quite as hermetic as the CI comment suggests for anyone with a real install on the same machine.

## Disclosure

Happy to have raised this in public rather than privately — it's read-only, needs local agent action, and the fix is in the same message. If you'd rather handle this class of thing through a security advisory instead, say so and I'll use that route next time.
