### PR TITLE
persona: resume starts the responder, not just the monolith

### DIFF
--- a/tests/test_thinker_set_coupling.sh
+++ b/tests/test_thinker_set_coupling.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# tests/test_thinker_set_coupling.sh — headlong-init and persona must start the
+# same thinkers.
+#
+# Usage: tests/test_thinker_set_coupling.sh
+#
+# Why: this is a coupling that fails SILENTLY. headlong-init brings a mind up
+# with `thinkers start monolith responder`; `<name> start` in tools/persona
+# brings it back after `<name> stop`. When the two lists drift, nothing errors
+# — the dispatcher starts, status.json says "ok", the dash says "ok", and the
+# agent visibly thinks. Only the dropped thinker's job stops happening. With
+# the responder missing, messages from the human are no longer answered by the
+# thinker built to answer them promptly; they wait on the monolith's reasoning
+# loop instead, turning a few seconds of latency into minutes, and the pause/
+# resume that caused it is long forgotten by then.
+#
+# Derived from the shipped scripts, so adding a thinker to one starter and not
+# the other fails here rather than in someone's session.
+
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+# The thinker names on a `thinkers start ...` line, sorted, one per line.
+# Comments are stripped first so prose mentioning the command cannot match.
+start_set() {
+    sed 's/#.*//' "$1" \
+        | grep -oE '\bthinkers start [a-z_ ]+' \
+        | sed 's/^thinkers start //' \
+        | tr ' ' '\n' | sed '/^$/d' | sort -u
+}
+
+init_set=$(start_set "$REPO/tools/headlong-init")
+persona_set=$(start_set "$REPO/tools/persona")
+
+if [[ -z "$init_set" ]]; then
+    bad "found a 'thinkers start' line in tools/headlong-init"
+elif [[ -z "$persona_set" ]]; then
+    bad "found a 'thinkers start' line in tools/persona"
+else
+    ok "both starters invoke 'thinkers start'"
+    if [[ "$init_set" == "$persona_set" ]]; then
+        ok "they start the same thinkers: $(echo "$init_set" | tr '\n' ' ')"
+    else
+        bad "they start the same thinkers" \
+            "headlong-init=[$(echo "$init_set" | tr '\n' ' ')] persona=[$(echo "$persona_set" | tr '\n' ' ')]"
+    fi
+    # The responder is the human-facing one; name it explicitly so that
+    # dropping it from BOTH starters still fails here.
+    if echo "$persona_set" | grep -qx responder; then
+        ok "persona starts the responder (the human-facing thinker)"
+    else
+        bad "persona starts the responder (the human-facing thinker)" \
+            "resume would leave messages waiting on the monolith"
+    fi
+fi
+
+# Every named thinker must actually ship, or the starter silently no-ops.
+while IFS= read -r t; do
+    [[ -n "$t" ]] || continue
+    if [[ -e "$REPO/thinkers/$t/step" ]]; then
+        ok "thinker '$t' ships a step script"
+    else
+        bad "thinker '$t' ships a step script" "thinkers/$t/step is missing"
+    fi
+done <<< "$init_set"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tools/persona
+++ b/tools/persona
@@ -203,7 +203,11 @@ cmd_start() {
     if _dispatcher_pid >/dev/null; then
         echo "$NAME's mind is already running."
     else
-        thinkers start monolith
+        # Keep this set in step with headlong-init: the responder is what
+        # answers the human. Starting only the monolith leaves every message
+        # waiting on its long reasoning loop, so a stop/start cycle silently
+        # destroys interactive latency until the next headlong-init.
+        thinkers start monolith responder
         echo "$NAME is thinking again."
     fi
     local url


### PR DESCRIPTION
## The bug

`headlong-init:663` starts a mind with:

```bash
thinkers start monolith responder
```

`cmd_start` in `tools/persona:206`, which is what `<name> start` runs after a `<name> stop`, started:

```bash
thinkers start monolith
```

So the first pause/resume in an identity's life drops the responder permanently. Nothing puts it back until the next `headlong-init`.

## Why it's worth a test rather than just a one-line fix

It fails silently, and expensively.

After the resume, the dispatcher starts, `status.json` reports mind `ok`, the dash reports `ok`, and the agent is visibly thinking — the monolith is running and its trajectory keeps advancing every few seconds. Everything you'd check looks healthy. `run/active_thinkers` contains just `monolith`, but you'd have to already suspect the problem to go and read it.

The only symptom is that messages from the human stop being handled by the thinker built to handle them promptly, and wait on the monolith's reasoning loop instead. On a reasoning model that's the difference between a few seconds and minutes. And because the `<name> stop` that caused it may have been hours earlier, the effect is completely detached from the cause — it reads as "the agent is stuck", or as an argument that you need to run several agents so one is always free to talk to you.

I hit it exactly that way: paused and resumed a fresh install, then spent a while working out why replies had gone from ~5s to minutes. After the fix, a round trip measured 5s again.

## The test

`tests/test_thinker_set_coupling.sh` derives the thinker set from both starters and asserts they agree. This is deliberately in the spirit of `test_unit_name_couplings.sh` — the failure mode has the same shape, a string in one place that has to keep matching a string in another, with nothing to complain when it stops. Comments are stripped before matching so prose mentioning the command can't satisfy it.

It also:
- names the responder explicitly, so removing it from *both* starters still fails rather than silently agreeing on the wrong set;
- checks every named thinker actually ships a `step` script, since a starter naming a thinker that isn't there is another silent no-op.

5/5 with this change, 2 of the 5 fail without it.

`shellcheck -S warning` clean. `tests/run-all.sh` green.

(As in #72: `test_llm_retry.sh` fails locally when a real `~/.headlong/.env` is visible, because `bin/llm` sources the state `.env` and falls back to `$HOME/.headlong`. With `HOME` and `HEADLONG_HOME` pointed at a scratch dir it's 70/70 on this branch and on pristine `main`. This branch touches only `tools/persona`, nothing llm-related.)
