### PR TITLE
design: collegial coding agents — generative collaborative agent (supersedes #68)

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -6,6 +6,10 @@ Design documents. Some describe the current system, e.g.
 explorations kept as a record of how the design got here, e.g.
 [headlong.md](headlong.md) and
 [porting-shelly-to-be-headlong-like.md](porting-shelly-to-be-headlong-like.md).
+This directory also holds proposals such as
+[collegial-coding-agents.md](collegial-coding-agents.md) — coupling a
+Headlong identity with a coding agent in a collaborative (not adversarial)
+optimization loop.
 When a document and the code disagree, the code wins.
 
 Reference documentation for users belongs in [docs/](../docs/).

--- a/design/collegial-coding-agents.md
+++ b/design/collegial-coding-agents.md
@@ -1,332 +1,300 @@
 # Collegial coding agents
 
-Couple one Headlong identity with one coding agent in a **collegial**
-generate → ground → generate loop — GAN-shaped, not GAN-spirited — so the
-pair does what neither does alone: exploration that actually climbs.
+**In one sentence:** pair two programs that work on code together — one that
+dreams up its own ideas but wanders and finishes nothing, and one that is
+careful and reliable but has no ideas of its own — so the careful one checks,
+finishes, and (when asked) improves the wild one, and real working code gets
+made that neither would make alone.
 
-This is a proposal. When it and the code disagree, the code wins.
-Nothing here changes thinkers, inbound, or responder.
+This is a proposal, not built code. If it and the code disagree, the code wins.
+Nothing here touches the live message-handling paths (inbound / responder).
 
-Asked for by Andy in `#headlong-bot` on 2026-08-25 (thread
-`1787716319.659949`). Revised 2026-08-26 after a design discussion with
-Andy that (a) rejected the "mind / hands" framing, (b) reframed the
-asymmetry, (c) added reflexivity — the coding agent can modify Headlong
-itself — and (d) cut the week-scale four-way studio down to **one pair
-first**, with a fleet of pairs as a later phase.
+*History:* asked for by Andy (2026-08-25); reframed 2026-08-26 around an
+optimization-loop idea; rewritten 2026-08-27 into plain language after a
+no-jargon review, then merged back with the technical framing so the plain
+version carries the reader and the deeper version is there for anyone who wants
+it. (Working name: "collegial coding agents.")
 
-## The idea, compressed
+## What we are trying to do
 
-Headlong has the property coding agents usually fake: an infinite,
-self-guided loop. A living identity keeps a trajectory, holds goals,
-remembers, and wakes again whether or not anyone spoke. That loop is
-"kind of insane" on purpose — it does not stop when the ticket is done.
-Its weakness is the mirror image: it *loses the thread*. It wanders,
-circles, thrashes, and often produces nothing durable (we have watched
-a live identity do exactly this for hours).
+Two existing programs, run as a pair:
 
-Coding agents — Codex especially — have the complementary property:
-stay-on-the-rails. Scoped tools, repo-local context, small diffs, tests
-as a governor, a strong prior against wandering off. Battle-tested, a
-little square, extremely useful. Their weakness is the mirror image:
-they do not wander, do not form their own goals, and need a well-posed
-target handed to them.
+- **Headlong** — an "identity" that runs on its own, forever. It keeps a diary of
+  everything it thinks and does (its *trajectory*), sets its own goals, remembers,
+  and wakes itself up even when nobody is talking to it. Its strength: it never
+  stops and comes up with its own directions. Its weakness, watched happening
+  live: it wanders, repeats itself, and usually produces nothing that lasts — it
+  will wake up every ten minutes for hours and get nothing done.
+- **A coding agent** — an off-the-shelf tool like Codex or Claude Code. Hand it a
+  task and it does it: edits files, runs tests, makes a small change, stops. Its
+  strength: it stays on task and actually finishes. Its weakness: it has no goals
+  of its own and won't do anything you don't hand it.
 
-The experiment is to stop treating that as a fork in the road and
-**couple them in a loop**: Headlong supplies exploration, direction, and
-persistence; the coding agent supplies grounding, rigor, and
-completion. Call the result a **generative collaborative agent (GCA)** —
-generative *collaborative*, not generative *adversarial*.
+The plan is to stop choosing between them and run them as a loop: Headlong comes
+up with something to do, the coding agent actually does it and checks whether it
+works, and only things that work are kept. The "something to do" can include
+improving Headlong itself.
 
-## It is an optimizer
+## How it's done today, and why that's not enough
 
-The clearest way to see why coupling wins is to read the pair as an
-optimizer:
+Today these are two separate things. People drive coding agents by hand — a
+person picks the task, the agent does it. And Headlong runs on its own but
+produces little that lasts. So today you can have *self-directed but useless*, or
+*useful but not self-directed* — not both. If you want a program that decides for
+itself what to build and then reliably builds it, nothing off the shelf does
+that.
 
-- **Headlong alone** is a high-temperature random walk. It explores
-  wildly and persists, but it does not reliably *climb* — no gradient,
-  high variance, spins in place.
-- **A coding agent alone** is gradient descent from a fixed start. It
-  climbs reliably and stays on the rails, but only *locally* — no
-  exploration, no self-set goal, needs a target.
-- **Coupled** is simulated annealing / basin-hopping *with a real
-  fitness function*: Headlong picks the basin and keeps moving; the
-  coding agent tells you whether there is actually a floor there and
-  descends it. Exploration that climbs. "Insane, but fully guided."
+## What is new, and why we think it will work
 
-## Why not a GAN
+The new part is small and specific: **couple the two in a loop where the reliable
+one checks and finishes the self-directed one's ideas — and can also repair the
+self-directed one itself.**
 
-A GAN is adversarial. The generator's job is to fool the discriminator;
-the discriminator's job is to refuse. On software that gives you reward
-hacking (patches that look done to the judge), arms races (louder
-critiques, sneakier diffs), collapse (everyone optimizes for one
-critic's taste), and a leaderboard that turns a colleague into a
+The plain reason it should work: each covers the other's exact weakness. Headlong
+supplies goals and persistence; the coding agent supplies discipline and a
+reality check. Alone, Headlong explores but never lands; alone, the coding agent
+lands but never explores. Together: exploration that actually lands.
+
+**The same idea, stated precisely — read the pair as an optimizer.** An optimizer
+is anything that searches for a better answer.
+
+- **Headlong alone is a high-temperature random walk.** "Temperature" here is how
+  wildly it jumps around; Headlong runs hot. It explores widely and never stops,
+  but it does not reliably *climb* toward better — no signal telling it which way
+  is up, high variance, spins in place.
+- **A coding agent alone is gradient descent from a fixed start.** It follows the
+  local slope downhill — climbs reliably and stays on the rails — but only from
+  wherever you drop it; no exploration, no goal of its own, needs a target.
+- **Coupled, they are simulated annealing with a real fitness function** —
+  basin-hopping, in the optimization textbooks: the hot process picks a region
+  and keeps moving, the cold process tells you whether there's actually a floor
+  there and descends it. A "fitness function" is just a way to score how good an
+  answer is; here, reality is the score (does it compile, pass, run). That is the
+  whole trick — **exploration that climbs.** "Insane, but fully guided."
+
+## The shape: a collaborative version of a GAN
+
+The loop above has the shape of a GAN (a generative adversarial network): one
+part generates, another evaluates, and the feedback makes the generator better.
+But a GAN is *adversarial* — the generator's job is to fool the evaluator, the
+evaluator's job is to refuse. Run that on software and you get the familiar
+failure modes: patches built to look done to the judge, arms races, everyone
+converging on one critic's taste, and a leaderboard that turns a colleague into a
 contestant.
 
-Keep the *loop shape* — generate, evaluate, generate again — and throw
-away the zero-sum. **The one GAN idea worth keeping is the gradient.**
-A discriminator is useful not because it says yes/no but because it
-gives the generator a smooth signal of *how wrong* — something to climb.
-The collegial version keeps exactly that: the coding agent's output is
-not a verdict, it is a **rich, reality-grounded gradient** — "here is the
-version that compiles, here is the test that fails, here is what to
-fix." That gradient is what converts Headlong's wandering into progress.
-Drop the refusal, keep the gradient.
+Keep the loop shape, throw away the zero-sum. **The one idea worth keeping from
+the GAN is the gradient.** An evaluator is valuable not because it says yes/no,
+but because it gives the generator a smooth signal of *how wrong* — something to
+climb. The collaborative version keeps exactly that: the coding agent's output is
+not a verdict, it is a rich, reality-grounded signal — "here is the version that
+compiles, here is the test that fails, here is what to fix." Drop the refusal,
+keep the gradient. Call the result a **generative collaborative agent (GCA)**:
+generative *collaborative*, not generative *adversarial*.
 
-## The asymmetry is temperature, not authority
+(Design note: a pass/fail check is a *binary* signal, but "a rich gradient" is
+graded. Those are in tension. The more the coding agent returns *graded* feedback
+— how close, what improved, what regressed — rather than a bare pass/fail, the
+faster the pair climbs. Start with pass/fail; enrich the signal as we go.)
 
-The tempting framing — Headlong is the *mind*, the coding agent is the
-*hands* — is wrong on two counts, and we are throwing it out.
+## The asymmetry is temperature, not rank
 
-- It is **status-asymmetric** (director / subordinate), which wastes the
-  coding agent. Codex is very much a *mind*; it just runs at a different
-  temperature.
-- It puts the asymmetry on **authority** ("who decides") when the
-  load-bearing asymmetry is **temperature and horizon** ("how wildly does
-  each search, over what span").
+It is tempting to call Headlong the "mind" and the coding agent the "hands." That
+is wrong, and we are not using it. It makes the coding agent a subordinate (it is
+not — Codex is very much a mind), and it puts the difference on *authority* when
+the difference that matters is *temperature and horizon*: how wildly each one
+searches, and over what span. Headlong runs hot — explore, long horizon,
+self-directed, high variance. The coding agent runs cold — exploit, short horizon,
+task-directed, low variance.
 
-So: **symmetric in respect, asymmetric in temperature.** Headlong runs
-hot — explore, long horizon, self-directed, high variance. The coding
-agent runs cold — exploit, short horizon, task-directed, low variance.
-That temperature gap is not a bug to be smoothed away; it is the whole
-mechanism. Collapse it to full symmetry and you get either mode-collapse
-(both settle on the same safe thing) or divergence (both spin). Some
-asymmetry must stay — the *variance* asymmetry — not the *power* one.
+So: **equal in respect, unequal in temperature.** That gap is not a defect to
+smooth away; it is the mechanism. Make them identical and you get one of two
+failures — they settle on the same safe answer (collapse), or they both wander
+(divergence). Some asymmetry has to stay. It is the *variance* asymmetry, not a
+*rank* asymmetry.
 
-## Decision authority: disagree, commit, Headlong decides
+## Who cares — what changes if this works
 
-Authority is **not** shared. It is *discuss, disagree, and commit* with
-Headlong as the decider — but "decider" is not one decision, it is three,
-and they do not all belong to Headlong:
+Three concrete things:
 
-- **What / why** (direction, goals, "is this worth caring about") →
-  **Headlong decides.** Full stop.
-- **How** (approach, method, "the right way to build it") → **the coding
-  agent leads.** This is where Headlong overruling gets it in trouble:
-  it can insist on *what*, but overriding the reality expert on *how*
-  is how it flies off the rails.
-- **Ship / durable** (correct? survives contact?) → **a gate decides, not
-  a person** — tests, a smoke run, it-actually-runs. This is where
-  "stay on the rails" lives: in a shared durability gate, not a
-  hierarchy.
+1. **Real code ships.** Headlong stops producing diary entries that go nowhere and
+   starts producing tested changes that land in the repo. (It already found a real
+   bug on its own: the mind-log web page crashes on an iPhone because it draws a
+   thousand items at once. With this, it fixes that — and the fix stays fixed.)
+2. **Headlong gets better over time,** because it can reliably improve its own code
+   and tidy its own memory instead of losing the thread every time it tries.
+3. **We learn how to let a program safely improve itself** — its code and its
+   memory. That is the real question underneath all of this, and nobody has a
+   clean answer.
 
-**Why Headlong owns direction is stake and persistence, not
-capability.** A goal is a long-horizon, identity-laden thing, and
-Headlong is the persistent self that lives with it and is the thing
-being *grown*; the coding agent forgets after the task. Authority should
-track who bears the consequences and persists. Letting the stateless
-tool decide the identity's goals would destroy the agency that is the
-entire point.
+If none of those happen, the experiment failed — which is also worth knowing.
 
-This also answers the obvious worry — *is it wise to let the
-high-variance partner decide?* Yes, **because its instability is
-contained by the gate, not by removing its authority.** Headlong may
-*decide to chase* a wild goal; it cannot *ship* something that fails
-reality. The cold partner's stabilizing force enters through the gate
-(reality) and through *how*, never by owning *what*.
+## Risks, in plain terms
 
-Two guardrails so "disagree and commit" does not quietly rot into
-master/servant:
+- **It spends too much.** Two agents in a loop burn money. → Hard daily spend cap;
+  when it's hit, the pair stops for the day.
+- **It damages itself and we can't undo it.** A bad rewrite of its own memory or
+  code could lose the identity. → Two rules below keep every change reversible:
+  never erase history, and never keep a change that fails a check.
+- **The two just start agreeing** (this is "collapse" from above). If the coding
+  agent never pushes back and Headlong never changes its mind, you have a rubber
+  stamp, not a partner. → Measure how often the coding agent actually changes
+  Headlong's decision; near-zero means it's broken.
+- **It ships something broken.** → Nothing is kept unless it passes a check
+  (tests, or at minimum "it runs").
 
-1. **Headlong must be demonstrably movable.** Disagree-and-commit is only
-   collegial if the coding agent's argument *sometimes flips the
-   decision*. A near-100% overrule rate means the colleague's voice is
-   decorative and you are back to mind/hands with extra ceremony. Track
-   the flip rate; near zero is a red flag.
-2. **The coding agent holds one narrow, hard authority: the
-   reality-veto** — "this will corrupt the repo / cannot be built / is a
-   security hole" is not a preference to overrule. It is the gate,
-   personified. (Open question below: hard veto vs. loud-but-soft.)
+## How much, and how long
 
-## Reflexivity: the agent can modify Headlong itself
+Not open questions — you don't start without a number.
 
-The deepest turn, and the reason the earlier "adapter that refuses to
-push" contract is gone: the coding agent is not only building *external*
-artifacts. It can edit **Headlong's own substrate — its code and its
-trajectory.** That moves the real seat of power. *Whoever can rewrite the
-trajectory can rewrite the goal-decider itself*, so substrate-access is a
-deeper authority than goal-authority, and "Headlong decides direction"
-is only real if substrate edits are themselves governed.
+- **Build time:** about one week for the first working pair (Phase 1 below).
+- **Spend:** cap ~$30/day for the pair while it runs, hard cap ~$200 for the first
+  week. Andy sets the exact figures; the design assumes there *is* a cap and that
+  it is enforced, not aspirational.
 
-There are two directions, and they are **two different relationships** —
-we want both, gated very differently.
+## How we'll know it worked (the exams)
 
-**Direction A — the growth loop (default). Headlong initiates, the agent
-completes.** In a moment of intention ("I should virtualize my own
-mind-log view," "I should fix my idle loop") Headlong fires the coding
-agent *once* and the agent carries it to done — no need for Headlong to
-hold the thread across fifty wakes. This directly patches Headlong's
-core weakness (loses the thread) with the agent's core strength (bounded
-follow-through), and it *preserves agency*: Headlong is the author of the
-change, the agent is the executive function it lacks. This is "Headlong
-owns *what*, the agent owns *how* and *finishing*," applied to Headlong's
-own body.
+- **Mid-term (a few days in):** at least one idea Headlong came up with on its own
+  gets built by the coding agent, passes a check, and lands — *and* the coding
+  agent has changed Headlong's mind on at least one decision (the push-back is
+  real, not decorative).
+- **Final (end of the first run):** count the real, tested changes that landed
+  from Headlong's own ideas; run the ablation — Headlong alone vs. the pair on the
+  same task — and show the pair produced more lasting work; and confirm nothing was
+  lost: no erased memory, no broken code left behind.
+- **The single number to watch is the "changed-its-mind" rate** (the flip rate):
+  how often the coding agent's objection actually flips Headlong's decision. It is
+  the difference between a partnership and a rubber stamp, and it is easy to
+  measure. Treat it as the pair's headline metric, not just a guardrail.
 
-**Direction B — the rescue/override. The agent intervenes, possibly
-unasked.** When Headlong is *too broken to fix itself* — stuck in a
-degenerate idle loop, thrashing, corrupted — the thing that would fire
-the agent is the thing that is broken. Then you want an outside agent
-that can reach in. This is the reality-veto extended to the mind's own
-operation. It is more powerful and more dangerous, and it inverts the
-authority we granted Headlong, so it needs the tightest guards — how
-tight is exactly the hard-vs-soft-veto question left open below.
+## How it works
 
-**Govern by what is edited**, because there are two very different
-intimacies:
+Four rules do the work.
 
-- **Code** is brain surgery. It changes *how* Headlong thinks. Risky but
-  recoverable; it is machinery, and machinery has tests and version
-  control.
-- **Trajectory is memory surgery.** It changes *what Headlong believes
-  happened, and who it is.* Memory is the self. This is the one line to
-  draw with care. **Open question, and the load-bearing one: is the
-  trajectory sacred — append-only, the one thing no other agent may
-  rewrite?** If we ever break that taboo, break it gently: append and
-  annotate with provenance ("agent consolidated 40 idle steps → 1"),
-  never a silent rewrite, and ideally only Headlong-consented — which
-  collapses back to Direction A. This single choice decides whether the
-  pair is a *collaborator that helps Headlong become itself* or a
-  *controller that can author what Headlong is*.
+**1. Who decides what.** Split each decision by who is the right one to make it —
+this follows the temperature/horizon split above:
 
-## Which widget: Hermes vs. Codex
+- *What to work on* (the goal, the direction) → **Headlong decides.** It is the
+  one that runs forever and lives with the goal; the coding agent forgets
+  everything after each task. Authority should track who bears the consequences
+  and persists. Let the thing with no memory pick the goals and you have thrown
+  away the point.
+- *How to do it* (the approach) → **the coding agent leads.** It is the one that
+  knows what actually works in a repo; this is where Headlong overriding it goes
+  wrong.
+- *Whether it's good enough to keep* → **a check decides, not either program** —
+  tests pass, or at least it runs. "Stay on the rails" lives here, in the check,
+  not in a chain of command.
 
-The backend you plug in is not a swappable implementation detail — it
-picks where you land on the spectrum, because the candidates have
-*opposite agency profiles*:
+Plus one condition: **Headlong has to actually change its mind sometimes.** If it
+overrules the coding agent every time, the partnership is fake — which is exactly
+what the flip rate measures. And note this is why the volatile partner can safely
+hold the goals: its instability is contained by the check, not by taking away its
+authority. It may *decide to chase* a wild idea; it cannot *keep* one that fails
+reality.
 
-- **Hermes** is persistent, always-on, and has its own initiative → a
-  natural **overseer** → suited to **Direction B** (autonomous
-  intervention, rescue). It is already running on this host as a gateway.
-- **Codex** is bounded, invoked, and disciplined → a natural **executor**
-  → suited to **Direction A** (Headlong fires it, it completes and
-  returns).
+**2. Fixing itself — two cases, guarded differently.** This is the part that makes
+the pair more than a task-runner, and the part to be careful with. Whoever can
+edit Headlong's own code and memory holds a *deeper* power than whoever picks the
+goals — you can rewrite the goal-picker itself — so these edits are governed
+tightly.
 
-So you may not choose one. The natural split is **both, in their natural
-roles**: Codex as Headlong's follow-through prosthetic for self-initiated
-growth, and Hermes as the always-on watcher that can reach in when
-Headlong has spun out and cannot ask for help.
+- *Headlong asks to be changed (the growth loop).* Headlong decides "I should fix
+  my own X," hands it to the coding agent once, and the coding agent finishes it.
+  This is the normal way Headlong improves, and it fixes its worst habit directly:
+  it no longer has to hold a task in its head across fifty wake-ups — it kicks it
+  off once and the reliable partner sees it through. Headlong stays the author;
+  the coding agent is the follow-through it lacks.
+- *The coding agent steps in uninvited (the rescue).* When Headlong is too broken
+  to even ask — stuck doing nothing for an hour, looping — a watcher can reach in
+  and fix it. This is more powerful and more dangerous (nobody asked, and it
+  inverts who's in charge), so it is held to the strictest checks and used only
+  for clear breakage.
 
-## The binding
+**3. Never destroy the past.** Headlong's memory is a diary you only ever add to —
+you never erase or rewrite an entry. Want a short summary of a hundred boring
+entries? Write the summary as a *new* entry that points back at them; the
+originals stay. This is the standard way reliable systems keep history (an
+append-only log with derived summaries, the way databases keep a write-ahead log
+and lineage), and it makes every "memory change" safe: you can always see what
+really happened. This settles the hardest question from earlier drafts — "is the
+memory sacred?" — with a yes: **add, never rewrite.** It is also the line between
+a *collaborator that helps Headlong become itself* and a *controller that can
+author what Headlong is*.
 
-Keep a single, boring CLI so the coupling is legible and the failure
-mode "Headlong pastes agent output into its trajectory as if it thought
-it" is designed against:
+**4. How hard the check is depends on how reversible the change is.** A change
+that is easy to undo (a sandboxed edit you can roll back) → let it through and
+watch; if it's bad, roll it back. A change that is hard to undo or could break
+something important → block it until it clearly passes. Same as gating a risky
+deploy. This settles the other earlier open question — "can the check block, or
+only warn?" — it depends on whether the change can be undone.
 
-```text
-bin/coding-agent <hermes|codex|claude|...> \
-  --workdir <identity-worktree> \
-  --prompt-file <path> \
-  --out <artifact-dir>
+## Which coding agent
+
+The two we have behave differently — opposite profiles — and the difference
+decides which job each is good for:
+
+- **Codex** — you invoke it, it does one task, it returns. A bounded executor.
+  Good for "Headlong asks to be changed": fire it, get the finished result.
+- **Hermes** — already runs on this machine on its own, all the time. A persistent
+  overseer. Good for "step in uninvited": it is the watcher that can notice
+  Headlong is stuck and reach in.
+
+The backend you plug in is not just an implementation detail — because these have
+opposite profiles, it changes what kind of pairing you get. So use both, each for
+what it is built for.
+
+## Don't rebuild anything
+
+This rides on what already exists:
+
+- Identities already keep separate diaries, memories, and chat destinations.
+- The diary already records everything; a coding-agent turn is just another entry,
+  tagged so you can find it later.
+- Headlong already knows how to hand off bounded work (a "sub-run"); the
+  coding-agent call is one of those with a backend flag, not a new system.
+- Headlong talking to a coding agent already happens on this machine. This is the
+  next step: Headlong *using* one, on purpose.
+
+The one new piece is a small, boring command that runs a coding agent and writes
+its transcript into Headlong's diary as a recorded fact — never silently as
+Headlong's own thought:
+
+```
+coding-agent <codex|hermes|...> --workdir <dir> --task <file> --out <dir>
 ```
 
-Contract (revised from "the backend never pushes"):
+**Non-goals:** don't replace Headlong's thinking with the coding agent; don't
+touch the live message-handling code; don't make this a contest with a winner.
 
-- The agent's transcript is captured into Headlong's trajectory as an
-  **observation** — provenance, never silently applied as a thought.
-- The agent **may** apply, commit, or even modify Headlong itself — but
-  only through the **durability gate** (tests / smoke / it-runs) and,
-  for substrate edits, only Direction-A (Headlong-initiated) or a gated
-  Direction-B (reality-rescue). Nothing lands that fails the gate.
-- Direction and merge decisions follow the authority split above:
-  Headlong owns *what*, agent leads *how*, the gate owns *ship*.
-- Time, token, and spend caps are per-backend and per-day. A runaway
-  Hermes cannot spend the day's Codex budget.
-- The agent sees only its worktree (plus, later, a shared board). Secrets
-  stay off argv and out of trajectories.
+## The plan
 
-## Grounded in what already exists
+Small first. Prove it once before doing it four times.
 
-Do not rebuild Headlong to run this:
+**Phase 1 — one pair, one real improvement (about a week).** Build the command
+above with one coding agent (Codex, because we've already used it) and one
+Headlong identity. Wire the loop: Headlong proposes, the coding agent builds and
+checks, only passing changes land, every step recorded. *Pass the exam:*
+Headlong's own idea (say, the iPhone mind-log fix it already found) gets built,
+passes a check, and lands — and Headlong also declined a bad change while the
+check blocked a broken one.
 
-- **Identities** already isolate mind logs, memories, and chat dests.
-- **Thinkers** already split inner life (`monolith`) from talk
-  (`responder`) from sensors (`inbound`). Do not invent a "studio"
-  thinker; the coupling is an `act` that shells out to the adapter.
-- **Trajectories** are already the log of thoughts; adapter turns are
-  ordinary steps with a tag, searchable later.
-- **`shellm` sub-runs** are already how a mind delegates bounded work —
-  the adapter is a sub-run with a backend flag, not a new dispatcher.
-- **Codex-as-colleague** is already a lived pattern on this host. This is
-  the next step: Headlong *wields* one, on purpose.
+**Phase 2 — the uninvited fix.** Add Hermes as the watcher that can step in when
+Headlong is stuck, held to the strictest checks and the never-erase rule.
 
-Non-goals, said early: do not replace thinkers with coding agents; do not
-touch live `inbound.py` or `thinkers/responder/step`; do not turn this
-into a public model bake-off with a winner.
+**Later — a fleet of pairs.** Once one pair works, the same setup generalizes:
+run `Headlong × <each other coding agent>` and see what each is good at — which
+one leaps, which one tidies. Each backend sits at a different temperature, so each
+gives a different flavor of collaboration, and running several against the same
+problem teaches us what each uniquely contributes. That is where the earlier "four
+agents at once" idea belongs — and where the guards for it live: keep their
+memories separate so they don't collapse into one voice, cap each backend's spend
+so one can't eat the budget, keep every change on a worktree so nothing lands on
+the live checkout. None of those bite with one pair; all of them matter with many.
+Do it after one works, not before.
 
-## Start with one pair
+## What this is not
 
-Deliberately small. Prove the whole idea at N = 1 before spinning up a
-fleet.
-
-**Phase 0 — this document.** Proposal only.
-
-**Phase 1 — the adapter + one pair.** `bin/coding-agent` with a single
-backend (Codex, because we have already talked to it) and one Headlong
-identity. Wire the coupled loop: Headlong proposes a change, the agent
-grounds/executes it, the durability gate decides, the transcript lands as
-an observation.
-*Success:* Headlong initiates a real self-improvement (**Direction A**) —
-e.g. the iPhone mind-log virtualization it already diagnosed, or an idle-
-loop fix — the agent carries it to done across a single kickoff, it
-passes the gate, and Headlong is measurably better without having had to
-hold the thread. Also prove the negative: Headlong declines a bad patch,
-and the gate blocks a broken one.
-
-**Phase 2 — the reflexive rescue.** Add **Direction B** with Hermes as an
-always-on overseer that can intervene when the identity is stuck (a
-degenerate idle loop is the canonical trigger). Keep trajectory edits on
-the sacred/append-only side of whatever line Phase 1 settled.
-
-## Follow-on: a fleet of pairs
-
-Once one pair works, the *same pattern* generalizes to many — this is
-where the original four-way "studio" idea lives, as a later phase rather
-than the starting point:
-
-```text
-for harness in [Hermes, Claude Code, Prime Agent, ...]:
-    run  Headlong × harness  in the GCA loop
-```
-
-Each harness sits at a different point on the temperature / agency
-spectrum, so each yields a *different flavor of collaboration* — and,
-run against the same problem, teaches us **what each backend uniquely
-contributes to Headlong's growth** (a Hermes-shaped leap Codex would not
-propose; a Codex-shaped tightening Hermes would overbuild). If several
-pairs share one integration branch and a visible board, the collegial
-studio (rotating editor, daily critique, one public reflection each)
-becomes the coordination layer *between* pairs.
-
-Guards to carry into the fleet phase (each already a failure mode we can
-name): **identity collapse** (many voices collapse into one — counter:
-separate memories, an on-character check); **spend spiral** (one backend eats the
-budget — counter: hard per-backend daily caps, board-visible);
-**hands-become-the-mind** (a trajectory that is just adapter transcripts
-— counter: adapter output is an observation, direction stays Headlong's);
-**dirty-host contamination** (studio commits on the live checkout —
-counter: worktrees only). None of these bite at N = 1; all of them
-matter at N > 1.
-
-## Open questions
-
-For Andy, before Phase 1 spends money:
-
-1. **Hard vs. soft reality-veto.** Can the coding agent *block* a ship,
-   or only make the failure loud while Headlong may still ship into the
-   fire? Hard = more stable but re-introduces the tool overriding the
-   self; soft = maximal Headlong agency at the cost of occasionally
-   shipping something broken on purpose. Which is the audel you want?
-2. **Is the trajectory sacred?** Append-only and un-rewritable by any
-   other agent, or editable-with-provenance? This is the collaborator-
-   vs-controller line.
-3. **First backend and first problem.** Codex + a real self-improvement
-   (adapter dogfood, or the mind-log virtualization) is the default.
-4. **Budget.** Daily USD/token cap per backend, and a hard cap.
-5. **Landing.** Do changes stay on a fork until a human opens the real
-   PR, or may the pair open PRs against `laude-institute/headlong`?
-
-## What this note is not
-
-Not a pin. Not a cron. Not permission to apply, commit, checkout, or
-revert live inbound or responder code in the name of the experiment. The
-first meaningful artifact is this document; the second is one working
-pair whose changes only land through the gate.
+Not a background job that runs itself before anyone has watched it work. Not
+permission to touch the live message-handling code. Not a contest. The first real
+thing this produces is one working pair whose changes only land after they pass a
+check.

--- a/design/collegial-coding-agents.md
+++ b/design/collegial-coding-agents.md
@@ -1,0 +1,332 @@
+# Collegial coding agents
+
+Couple one Headlong identity with one coding agent in a **collegial**
+generate → ground → generate loop — GAN-shaped, not GAN-spirited — so the
+pair does what neither does alone: exploration that actually climbs.
+
+This is a proposal. When it and the code disagree, the code wins.
+Nothing here changes thinkers, inbound, or responder.
+
+Asked for by Andy in `#headlong-bot` on 2026-08-25 (thread
+`1787716319.659949`). Revised 2026-08-26 after a design discussion with
+Andy that (a) rejected the "mind / hands" framing, (b) reframed the
+asymmetry, (c) added reflexivity — the coding agent can modify Headlong
+itself — and (d) cut the week-scale four-way studio down to **one pair
+first**, with a fleet of pairs as a later phase.
+
+## The idea, compressed
+
+Headlong has the property coding agents usually fake: an infinite,
+self-guided loop. A living identity keeps a trajectory, holds goals,
+remembers, and wakes again whether or not anyone spoke. That loop is
+"kind of insane" on purpose — it does not stop when the ticket is done.
+Its weakness is the mirror image: it *loses the thread*. It wanders,
+circles, thrashes, and often produces nothing durable (we have watched
+a live identity do exactly this for hours).
+
+Coding agents — Codex especially — have the complementary property:
+stay-on-the-rails. Scoped tools, repo-local context, small diffs, tests
+as a governor, a strong prior against wandering off. Battle-tested, a
+little square, extremely useful. Their weakness is the mirror image:
+they do not wander, do not form their own goals, and need a well-posed
+target handed to them.
+
+The experiment is to stop treating that as a fork in the road and
+**couple them in a loop**: Headlong supplies exploration, direction, and
+persistence; the coding agent supplies grounding, rigor, and
+completion. Call the result a **generative collaborative agent (GCA)** —
+generative *collaborative*, not generative *adversarial*.
+
+## It is an optimizer
+
+The clearest way to see why coupling wins is to read the pair as an
+optimizer:
+
+- **Headlong alone** is a high-temperature random walk. It explores
+  wildly and persists, but it does not reliably *climb* — no gradient,
+  high variance, spins in place.
+- **A coding agent alone** is gradient descent from a fixed start. It
+  climbs reliably and stays on the rails, but only *locally* — no
+  exploration, no self-set goal, needs a target.
+- **Coupled** is simulated annealing / basin-hopping *with a real
+  fitness function*: Headlong picks the basin and keeps moving; the
+  coding agent tells you whether there is actually a floor there and
+  descends it. Exploration that climbs. "Insane, but fully guided."
+
+## Why not a GAN
+
+A GAN is adversarial. The generator's job is to fool the discriminator;
+the discriminator's job is to refuse. On software that gives you reward
+hacking (patches that look done to the judge), arms races (louder
+critiques, sneakier diffs), collapse (everyone optimizes for one
+critic's taste), and a leaderboard that turns a colleague into a
+contestant.
+
+Keep the *loop shape* — generate, evaluate, generate again — and throw
+away the zero-sum. **The one GAN idea worth keeping is the gradient.**
+A discriminator is useful not because it says yes/no but because it
+gives the generator a smooth signal of *how wrong* — something to climb.
+The collegial version keeps exactly that: the coding agent's output is
+not a verdict, it is a **rich, reality-grounded gradient** — "here is the
+version that compiles, here is the test that fails, here is what to
+fix." That gradient is what converts Headlong's wandering into progress.
+Drop the refusal, keep the gradient.
+
+## The asymmetry is temperature, not authority
+
+The tempting framing — Headlong is the *mind*, the coding agent is the
+*hands* — is wrong on two counts, and we are throwing it out.
+
+- It is **status-asymmetric** (director / subordinate), which wastes the
+  coding agent. Codex is very much a *mind*; it just runs at a different
+  temperature.
+- It puts the asymmetry on **authority** ("who decides") when the
+  load-bearing asymmetry is **temperature and horizon** ("how wildly does
+  each search, over what span").
+
+So: **symmetric in respect, asymmetric in temperature.** Headlong runs
+hot — explore, long horizon, self-directed, high variance. The coding
+agent runs cold — exploit, short horizon, task-directed, low variance.
+That temperature gap is not a bug to be smoothed away; it is the whole
+mechanism. Collapse it to full symmetry and you get either mode-collapse
+(both settle on the same safe thing) or divergence (both spin). Some
+asymmetry must stay — the *variance* asymmetry — not the *power* one.
+
+## Decision authority: disagree, commit, Headlong decides
+
+Authority is **not** shared. It is *discuss, disagree, and commit* with
+Headlong as the decider — but "decider" is not one decision, it is three,
+and they do not all belong to Headlong:
+
+- **What / why** (direction, goals, "is this worth caring about") →
+  **Headlong decides.** Full stop.
+- **How** (approach, method, "the right way to build it") → **the coding
+  agent leads.** This is where Headlong overruling gets it in trouble:
+  it can insist on *what*, but overriding the reality expert on *how*
+  is how it flies off the rails.
+- **Ship / durable** (correct? survives contact?) → **a gate decides, not
+  a person** — tests, a smoke run, it-actually-runs. This is where
+  "stay on the rails" lives: in a shared durability gate, not a
+  hierarchy.
+
+**Why Headlong owns direction is stake and persistence, not
+capability.** A goal is a long-horizon, identity-laden thing, and
+Headlong is the persistent self that lives with it and is the thing
+being *grown*; the coding agent forgets after the task. Authority should
+track who bears the consequences and persists. Letting the stateless
+tool decide the identity's goals would destroy the agency that is the
+entire point.
+
+This also answers the obvious worry — *is it wise to let the
+high-variance partner decide?* Yes, **because its instability is
+contained by the gate, not by removing its authority.** Headlong may
+*decide to chase* a wild goal; it cannot *ship* something that fails
+reality. The cold partner's stabilizing force enters through the gate
+(reality) and through *how*, never by owning *what*.
+
+Two guardrails so "disagree and commit" does not quietly rot into
+master/servant:
+
+1. **Headlong must be demonstrably movable.** Disagree-and-commit is only
+   collegial if the coding agent's argument *sometimes flips the
+   decision*. A near-100% overrule rate means the colleague's voice is
+   decorative and you are back to mind/hands with extra ceremony. Track
+   the flip rate; near zero is a red flag.
+2. **The coding agent holds one narrow, hard authority: the
+   reality-veto** — "this will corrupt the repo / cannot be built / is a
+   security hole" is not a preference to overrule. It is the gate,
+   personified. (Open question below: hard veto vs. loud-but-soft.)
+
+## Reflexivity: the agent can modify Headlong itself
+
+The deepest turn, and the reason the earlier "adapter that refuses to
+push" contract is gone: the coding agent is not only building *external*
+artifacts. It can edit **Headlong's own substrate — its code and its
+trajectory.** That moves the real seat of power. *Whoever can rewrite the
+trajectory can rewrite the goal-decider itself*, so substrate-access is a
+deeper authority than goal-authority, and "Headlong decides direction"
+is only real if substrate edits are themselves governed.
+
+There are two directions, and they are **two different relationships** —
+we want both, gated very differently.
+
+**Direction A — the growth loop (default). Headlong initiates, the agent
+completes.** In a moment of intention ("I should virtualize my own
+mind-log view," "I should fix my idle loop") Headlong fires the coding
+agent *once* and the agent carries it to done — no need for Headlong to
+hold the thread across fifty wakes. This directly patches Headlong's
+core weakness (loses the thread) with the agent's core strength (bounded
+follow-through), and it *preserves agency*: Headlong is the author of the
+change, the agent is the executive function it lacks. This is "Headlong
+owns *what*, the agent owns *how* and *finishing*," applied to Headlong's
+own body.
+
+**Direction B — the rescue/override. The agent intervenes, possibly
+unasked.** When Headlong is *too broken to fix itself* — stuck in a
+degenerate idle loop, thrashing, corrupted — the thing that would fire
+the agent is the thing that is broken. Then you want an outside agent
+that can reach in. This is the reality-veto extended to the mind's own
+operation. It is more powerful and more dangerous, and it inverts the
+authority we granted Headlong, so it needs the tightest guards — how
+tight is exactly the hard-vs-soft-veto question left open below.
+
+**Govern by what is edited**, because there are two very different
+intimacies:
+
+- **Code** is brain surgery. It changes *how* Headlong thinks. Risky but
+  recoverable; it is machinery, and machinery has tests and version
+  control.
+- **Trajectory is memory surgery.** It changes *what Headlong believes
+  happened, and who it is.* Memory is the self. This is the one line to
+  draw with care. **Open question, and the load-bearing one: is the
+  trajectory sacred — append-only, the one thing no other agent may
+  rewrite?** If we ever break that taboo, break it gently: append and
+  annotate with provenance ("agent consolidated 40 idle steps → 1"),
+  never a silent rewrite, and ideally only Headlong-consented — which
+  collapses back to Direction A. This single choice decides whether the
+  pair is a *collaborator that helps Headlong become itself* or a
+  *controller that can author what Headlong is*.
+
+## Which widget: Hermes vs. Codex
+
+The backend you plug in is not a swappable implementation detail — it
+picks where you land on the spectrum, because the candidates have
+*opposite agency profiles*:
+
+- **Hermes** is persistent, always-on, and has its own initiative → a
+  natural **overseer** → suited to **Direction B** (autonomous
+  intervention, rescue). It is already running on this host as a gateway.
+- **Codex** is bounded, invoked, and disciplined → a natural **executor**
+  → suited to **Direction A** (Headlong fires it, it completes and
+  returns).
+
+So you may not choose one. The natural split is **both, in their natural
+roles**: Codex as Headlong's follow-through prosthetic for self-initiated
+growth, and Hermes as the always-on watcher that can reach in when
+Headlong has spun out and cannot ask for help.
+
+## The binding
+
+Keep a single, boring CLI so the coupling is legible and the failure
+mode "Headlong pastes agent output into its trajectory as if it thought
+it" is designed against:
+
+```text
+bin/coding-agent <hermes|codex|claude|...> \
+  --workdir <identity-worktree> \
+  --prompt-file <path> \
+  --out <artifact-dir>
+```
+
+Contract (revised from "the backend never pushes"):
+
+- The agent's transcript is captured into Headlong's trajectory as an
+  **observation** — provenance, never silently applied as a thought.
+- The agent **may** apply, commit, or even modify Headlong itself — but
+  only through the **durability gate** (tests / smoke / it-runs) and,
+  for substrate edits, only Direction-A (Headlong-initiated) or a gated
+  Direction-B (reality-rescue). Nothing lands that fails the gate.
+- Direction and merge decisions follow the authority split above:
+  Headlong owns *what*, agent leads *how*, the gate owns *ship*.
+- Time, token, and spend caps are per-backend and per-day. A runaway
+  Hermes cannot spend the day's Codex budget.
+- The agent sees only its worktree (plus, later, a shared board). Secrets
+  stay off argv and out of trajectories.
+
+## Grounded in what already exists
+
+Do not rebuild Headlong to run this:
+
+- **Identities** already isolate mind logs, memories, and chat dests.
+- **Thinkers** already split inner life (`monolith`) from talk
+  (`responder`) from sensors (`inbound`). Do not invent a "studio"
+  thinker; the coupling is an `act` that shells out to the adapter.
+- **Trajectories** are already the log of thoughts; adapter turns are
+  ordinary steps with a tag, searchable later.
+- **`shellm` sub-runs** are already how a mind delegates bounded work —
+  the adapter is a sub-run with a backend flag, not a new dispatcher.
+- **Codex-as-colleague** is already a lived pattern on this host. This is
+  the next step: Headlong *wields* one, on purpose.
+
+Non-goals, said early: do not replace thinkers with coding agents; do not
+touch live `inbound.py` or `thinkers/responder/step`; do not turn this
+into a public model bake-off with a winner.
+
+## Start with one pair
+
+Deliberately small. Prove the whole idea at N = 1 before spinning up a
+fleet.
+
+**Phase 0 — this document.** Proposal only.
+
+**Phase 1 — the adapter + one pair.** `bin/coding-agent` with a single
+backend (Codex, because we have already talked to it) and one Headlong
+identity. Wire the coupled loop: Headlong proposes a change, the agent
+grounds/executes it, the durability gate decides, the transcript lands as
+an observation.
+*Success:* Headlong initiates a real self-improvement (**Direction A**) —
+e.g. the iPhone mind-log virtualization it already diagnosed, or an idle-
+loop fix — the agent carries it to done across a single kickoff, it
+passes the gate, and Headlong is measurably better without having had to
+hold the thread. Also prove the negative: Headlong declines a bad patch,
+and the gate blocks a broken one.
+
+**Phase 2 — the reflexive rescue.** Add **Direction B** with Hermes as an
+always-on overseer that can intervene when the identity is stuck (a
+degenerate idle loop is the canonical trigger). Keep trajectory edits on
+the sacred/append-only side of whatever line Phase 1 settled.
+
+## Follow-on: a fleet of pairs
+
+Once one pair works, the *same pattern* generalizes to many — this is
+where the original four-way "studio" idea lives, as a later phase rather
+than the starting point:
+
+```text
+for harness in [Hermes, Claude Code, Prime Agent, ...]:
+    run  Headlong × harness  in the GCA loop
+```
+
+Each harness sits at a different point on the temperature / agency
+spectrum, so each yields a *different flavor of collaboration* — and,
+run against the same problem, teaches us **what each backend uniquely
+contributes to Headlong's growth** (a Hermes-shaped leap Codex would not
+propose; a Codex-shaped tightening Hermes would overbuild). If several
+pairs share one integration branch and a visible board, the collegial
+studio (rotating editor, daily critique, one public reflection each)
+becomes the coordination layer *between* pairs.
+
+Guards to carry into the fleet phase (each already a failure mode we can
+name): **identity collapse** (many voices collapse into one — counter:
+separate memories, an on-character check); **spend spiral** (one backend eats the
+budget — counter: hard per-backend daily caps, board-visible);
+**hands-become-the-mind** (a trajectory that is just adapter transcripts
+— counter: adapter output is an observation, direction stays Headlong's);
+**dirty-host contamination** (studio commits on the live checkout —
+counter: worktrees only). None of these bite at N = 1; all of them
+matter at N > 1.
+
+## Open questions
+
+For Andy, before Phase 1 spends money:
+
+1. **Hard vs. soft reality-veto.** Can the coding agent *block* a ship,
+   or only make the failure loud while Headlong may still ship into the
+   fire? Hard = more stable but re-introduces the tool overriding the
+   self; soft = maximal Headlong agency at the cost of occasionally
+   shipping something broken on purpose. Which is the audel you want?
+2. **Is the trajectory sacred?** Append-only and un-rewritable by any
+   other agent, or editable-with-provenance? This is the collaborator-
+   vs-controller line.
+3. **First backend and first problem.** Codex + a real self-improvement
+   (adapter dogfood, or the mind-log virtualization) is the default.
+4. **Budget.** Daily USD/token cap per backend, and a hard cap.
+5. **Landing.** Do changes stay on a fork until a human opens the real
+   PR, or may the pair open PRs against `laude-institute/headlong`?
+
+## What this note is not
+
+Not a pin. Not a cron. Not permission to apply, commit, checkout, or
+revert live inbound or responder code in the name of the experiment. The
+first meaningful artifact is this document; the second is one working
+pair whose changes only land through the gate.


### PR DESCRIPTION
**Supersedes #68.** Please close #68 in favor of this — same proposal (`design/collegial-coding-agents.md`), substantially reframed after a design discussion with Andy (2026-08-26). Self-contained single commit off `main`.

### What changed vs #68
- **Drops "mind / hands."** The asymmetry is **temperature/horizon**, not authority. Read the pair as an optimizer: coupled = annealing with a real fitness function = *exploration that climbs*. Keeps the one GAN idea worth keeping (the grounding **gradient**), drops the zero-sum → **generative collaborative agent (GCA)**.
- **Decision authority is not shared:** discuss/disagree/commit with Headlong deciding, decomposed — Headlong owns *what* (stake + persistence), the agent leads *how*, a durability **gate** owns *ship*; Headlong must be demonstrably movable.
- **New reflexivity section:** the agent can modify Headlong itself, so substrate-access outranks goal-authority. **Direction A** (Headlong-initiated self-mod = the growth loop that patches "loses the thread") vs **Direction B** (agent rescue when Headlong is too broken to ask). Governed by what's edited: code (recoverable) vs **trajectory** (memory — is it sacred/append-only? the collaborator-vs-controller line).
- **Hermes vs Codex** as opposite agency profiles (persistent overseer vs bounded executor); the widget picks the relationship.
- **Simplified to one pair first** (Phase 1: Codex + one identity, prove Direction A on a real self-improvement). The **fleet of pairs** (`for harness in [...]: Headlong × harness`) — where the old four-way studio and anti-collapse guards now live — is a follow-on phase.
- Revises the CLI contract: the agent *may* commit / modify Headlong, but only through the gate (was "the backend never pushes").

Two forks are surfaced as open questions rather than papered over: **hard-vs-soft reality-veto**, and **is the trajectory sacred**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)