### PR TITLE
llm: pass OpenRouter's provider routing through to the request

### DIFF
--- a/bin/llm
+++ b/bin/llm
@@ -50,6 +50,33 @@ LLM_THINKING_LEVEL=""
 LLM_EFFORT=""
 LLM_RAW=0
 LLM_PROMPT=""
+# OpenRouter provider routing. OpenRouter fans a single model id out over
+# several hosts (one openai/* id can be served by OpenAI, Azure and Amazon
+# Bedrock) and picks one per request, so where a prompt is sent is a routing
+# decision rather than a model choice, and without these it is not expressible
+# from here:
+#   LLM_OR_ONLY             comma-separated provider slugs. Emits
+#                           provider.only, which OpenRouter treats as a hard
+#                           allowlist: a host outside it is never used, and an
+#                           unsatisfiable pin returns 404 rather than quietly
+#                           rerouting. Availability *within* the list is a
+#                           separate question — allow_fallbacks is OpenRouter's
+#                           retry setting, not part of the allowlist, so it is
+#                           left at its default here.
+#   LLM_OR_DATA_COLLECTION  "allow" or "deny" hosts that may store the prompt.
+#   LLM_OR_ZDR              zero-data-retention endpoints only. Intersected
+#                           with the pin rather than layered on it: a model
+#                           whose only ZDR endpoint is a host the pin excludes
+#                           has no endpoints left and 404s.
+# All three apply when the effective provider is openrouter, whether named
+# with --provider/LLM_PROVIDER or inferred from the model name.
+LLM_OR_ONLY="${LLM_OR_ONLY:-}"
+LLM_OR_DATA_COLLECTION="${LLM_OR_DATA_COLLECTION:-}"
+LLM_OR_ZDR="${LLM_OR_ZDR:-}"
+# Whether any of the three arrived from the environment or a .env layer. A
+# routing constraint nobody typed on this command line still changes where the
+# prompt may go, so it is announced once rather than applied invisibly.
+_llm_or_env="$LLM_OR_ONLY$LLM_OR_DATA_COLLECTION$LLM_OR_ZDR"
 # Token usage is captured on every call. A caller that wants this call's
 # numbers sets LLM_USAGE_FILE and gets a one-line JSON record
 # ({in_tok, out_tok, think_tok}) written there after the call (bin/shellm
@@ -156,6 +183,11 @@ Options:
   --provider NAME          Provider: anthropic, openai, gemini, openrouter,
                            opencode, opencode-go, openai-compatible, or
                            adapter (needs LLM_ADAPTER)
+  --or-only SLUGS          Pin routing to these provider slugs
+  --or-data-collection X   "allow" or "deny" hosts that may store the prompt
+  --or-zdr                 Zero-data-retention endpoints only
+                           (the three apply when the effective provider is
+                           openrouter, named or inferred from the model)
   --thinking [LEVEL]       Enable thinking (Anthropic: adaptive; Gemini: minimal/low/medium/high)
   --effort LEVEL           Thinking effort/provider output effort
   --raw                    Print raw non-streaming API response JSON
@@ -209,6 +241,10 @@ Environment:
   OPENAI_API_KEY           Required for OpenAI models
   GEMINI_API_KEY           Required for Gemini models
   OPENROUTER_API_KEY       Required for OpenRouter models
+  LLM_OR_ONLY, LLM_OR_DATA_COLLECTION, LLM_OR_ZDR
+                           Defaults for the matching --or-* flags. Applied
+                           when the effective provider is openrouter; setting
+                           one here prints the effective routing on stderr
   OPENCODE_API_KEY         Required for OpenCode models — both plans use it;
                            opencode-go/* bills the Go subscription, opencode/*
                            bills Zen. Keys: `opencode auth login`
@@ -263,6 +299,9 @@ while [[ $# -gt 0 ]]; do
         --stream)        LLM_STREAM=1; shift ;;
         --no-stream)     LLM_STREAM=0; shift ;;
         --provider)      LLM_PROVIDER="${2:?--provider requires a value}"; shift 2 ;;
+        --or-only)       LLM_OR_ONLY="${2:?--or-only requires a value}"; shift 2 ;;
+        --or-data-collection) LLM_OR_DATA_COLLECTION="${2:?--or-data-collection requires a value}"; shift 2 ;;
+        --or-zdr)        LLM_OR_ZDR=1; shift ;;
         --thinking)
             LLM_THINKING=1
             if [[ -n "${2:-}" && "$2" != -* ]]; then
@@ -369,6 +408,44 @@ fi
 # strip once, up front, so the payload builders AND get_model_max_tokens see
 # the actual model name and its caps.
 case "$LLM_PROVIDER" in opencode) LLM_MODEL="${LLM_MODEL#opencode/}" ;; opencode-go) LLM_MODEL="${LLM_MODEL#opencode-go/}" ;; esac
+
+# The --or-* knobs are OpenRouter routing controls and mean nothing to the
+# other providers, which are each a single host already. Clear them out loud
+# rather than silently: a stray LLM_OR_ZDR in a shell profile must not quietly
+# read as a residency guarantee on an Anthropic call, and must not kill it
+# either.
+if [[ "$LLM_PROVIDER" != "openrouter" ]]; then
+    if [[ -n "$LLM_OR_ONLY$LLM_OR_DATA_COLLECTION$LLM_OR_ZDR" ]]; then
+        echo "llm: warning: --or-*/LLM_OR_* are OpenRouter-only and ignored for provider '$LLM_PROVIDER'" >&2
+        LLM_OR_ONLY=""; LLM_OR_DATA_COLLECTION=""; LLM_OR_ZDR=""
+    fi
+else
+    # Normalise once, here, rather than at each use. A settings file saying
+    # LLM_OR_ZDR=true that read as false further down would drop a retention
+    # requirement without saying so, which is the one failure mode these knobs
+    # exist to prevent.
+    case "$(printf '%s' "$LLM_OR_ZDR" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|on) LLM_OR_ZDR=1 ;;
+        0|false|no|"") LLM_OR_ZDR="" ;;
+        *) die "--or-zdr/LLM_OR_ZDR must be 1/true/yes/on or 0/false/no/empty (got '$LLM_OR_ZDR')" ;;
+    esac
+    case "$LLM_OR_DATA_COLLECTION" in
+        ""|allow|deny) ;;
+        *) die "--or-data-collection/LLM_OR_DATA_COLLECTION must be allow or deny (got '$LLM_OR_DATA_COLLECTION')" ;;
+    esac
+    if [[ -n "$LLM_OR_ONLY" ]]; then
+        # OpenRouter matches slugs exactly, and case, padding and empty
+        # elements all come out of real .env files and shell profiles.
+        LLM_OR_ONLY=$(printf '%s' "$LLM_OR_ONLY" | tr '[:upper:]' '[:lower:]' \
+            | tr -d '[:space:]' | sed 's/,\{1,\}/,/g; s/^,//; s/,$//')
+        # A pin that normalises away is a typo, and treating it as "no pin"
+        # would route anywhere — the opposite of what was asked for.
+        [[ -n "$LLM_OR_ONLY" ]] || die "--or-only/LLM_OR_ONLY had no provider slugs left after normalization"
+    fi
+    if [[ -n "$_llm_or_env" && -n "$LLM_OR_ONLY$LLM_OR_DATA_COLLECTION$LLM_OR_ZDR" ]]; then
+        echo "llm: routing: openrouter${LLM_OR_ONLY:+ only=$LLM_OR_ONLY}${LLM_OR_DATA_COLLECTION:+ data_collection=$LLM_OR_DATA_COLLECTION}${LLM_OR_ZDR:+ zdr=true}" >&2
+    fi
+fi
 
 # Per-model max output token caps (synchronous APIs, no beta headers).
 # Used as the default when -t/--max-tokens is not given.
@@ -594,7 +671,28 @@ build_payload_gemini() {
 }
 
 # OpenRouter is OpenAI-compatible (chat/completions wire format)
-build_payload_openrouter() { build_payload_openai; }
+# OpenRouter is OpenAI-compatible (chat/completions wire format), plus an
+# optional "provider" object carrying the routing preferences above. Without
+# that object OpenRouter is free to pick any host serving the model.
+build_payload_openrouter() {
+    # Unpinned callers pay nothing: no extra jq pass, byte-identical to before.
+    if [[ -z "$LLM_OR_ONLY$LLM_OR_DATA_COLLECTION$LLM_OR_ZDR" ]]; then
+        build_payload_openai
+        return
+    fi
+    # Values are already normalised above, so this only assembles them. The sum
+    # is bound with `as $p` rather than written inline as the object's value:
+    # jq 1.7 (what ubuntu-latest, and therefore CI, runs) rejects a `+` chain of
+    # parenthesised ifs in that position, and only 1.8 relaxed the grammar.
+    build_payload_openai | jq -c \
+        --arg only "$LLM_OR_ONLY" \
+        --arg dc "$LLM_OR_DATA_COLLECTION" \
+        --arg zdr "$LLM_OR_ZDR" \
+        '((if $only != "" then {only: ($only | split(","))} else {} end)
+          + (if $dc != "" then {data_collection: $dc} else {} end)
+          + (if $zdr != "" then {zdr: true} else {} end)) as $p
+         | . + {provider: $p}'
+}
 
 # Generic openai-compatible endpoint (Ollama, vLLM, LM Studio, proxies):
 # the OpenAI wire format against a configured LLM_API_URL, key optional.

--- a/tests/test_llm_openrouter_routing.sh
+++ b/tests/test_llm_openrouter_routing.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# test_llm_openrouter_routing.sh — the OpenRouter provider routing block
+#
+# Usage: tests/test_llm_openrouter_routing.sh
+#
+# OpenRouter serves one model id from several hosts and picks one per request,
+# so `provider` is the only thing in the payload that says where a prompt may
+# go. curl is stubbed (it keeps the payload file bin/llm hands it and answers
+# with a minimal SSE stream), so what is under test is the JSON that would have
+# been sent, without touching the network.
+#
+# Three things are checked. The shape: the block appears only when a knob is
+# set, `only` is emitted without touching allow_fallbacks (OpenRouter treats
+# `only` as a hard allowlist, and allow_fallbacks is a separate retry setting),
+# and slugs are normalised. The parsing: every knob is normalised once, so a
+# settings file saying `LLM_OR_ZDR=true` cannot read as false, and a value that
+# means neither is refused rather than guessed at.
+#
+# And that the filter compiles at all: the payload builders are the one part of
+# bin/llm the rest of the suite never reaches, because every other test stubs
+# `llm` itself. That gap is not hypothetical — `{provider: (if … end) + (if …
+# end)}` parses under jq 1.8 and is a syntax error under jq 1.7, which is what
+# ubuntu-latest ships and therefore what CI runs, so a filter only ever tried on
+# a 1.8 dev box can be broken for every CI run and every container user. Any
+# such error turns the pinned cases below red.
+#
+# Every run happens in a scratch cwd with HEADLONG_HOME pointed at an empty
+# directory, so the checkout's own .env and the developer's ~/.headlong/.env
+# cannot reach into the results.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+command -v jq >/dev/null 2>&1 || { echo "FAIL jq not found — bin/llm needs it, so this proves nothing"; exit 1; }
+
+# --- curl stub ---------------------------------------------------------------
+# bin/llm passes the payload as -d @FILE (never on argv), so the stub copies
+# that file aside and answers with one SSE chunk plus [DONE].
+mkdir -p "$WORK/bin" "$WORK/run" "$WORK/home/.headlong"
+cat > "$WORK/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+for a in "$@"; do
+    [[ "$a" == "-d@"* ]] && cp "${a#-d@}" "$PAYLOAD_OUT" 2>/dev/null
+    [[ "$a" == @* ]] && cp "${a#@}" "$PAYLOAD_OUT" 2>/dev/null
+done
+printf 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+printf 'data: [DONE]\n'
+EOF
+chmod +x "$WORK/bin/curl"
+export PATH="$WORK/bin:$PATH"
+export PAYLOAD_OUT="$WORK/payload.json"
+
+# run_llm [VAR=VAL ...] -- [llm args ...]
+# Runs from a scratch cwd with an empty state home, so only what a case sets
+# is in play. Leaves the payload in $PAYLOAD_OUT, stderr in $WORK/err.
+run_llm() {
+    local -a envs=()
+    while [[ $# -gt 0 && "$1" != "--" ]]; do envs+=("$1"); shift; done
+    shift || true
+    : > "$PAYLOAD_OUT"
+    ( cd "$WORK/run" && printf 'hi' | env -u LLM_OR_ONLY -u LLM_OR_DATA_COLLECTION \
+        -u LLM_OR_ZDR -u SHELLM_HOME -u LLM_PROVIDER \
+        HOME="$WORK/home" HEADLONG_HOME="$WORK/home/.headlong" \
+        OPENROUTER_API_KEY="test-key" OPENAI_API_KEY="test-key" \
+        "${envs[@]+"${envs[@]}"}" \
+        "$REPO/bin/llm" -m "openai/gpt-4o-mini" "$@" ) \
+        > "$WORK/out" 2> "$WORK/err"
+}
+
+q() { jq -r "$1" "$PAYLOAD_OUT" 2>/dev/null; }
+
+# --- 1. unpinned callers are unchanged ---------------------------------------
+run_llm -- 
+[[ "$(q 'has("provider")')" == "false" ]] \
+    && ok "no knobs: payload carries no provider block" \
+    || bad "no knobs: payload carries no provider block" "got $(q 'has("provider")')"
+
+# --- 2. the pin, and only the pin ---------------------------------------------
+run_llm -- --or-only openai
+[[ "$(q '.provider.only | join(",")')" == "openai" ]] \
+    && ok "--or-only pins provider.only" \
+    || bad "--or-only pins provider.only" "got $(q '.provider.only')"
+# OpenRouter documents `only` as the allowlist and allow_fallbacks as a
+# separate retry setting; coupling them would refuse failover between two hosts
+# the caller explicitly allowed, and buy nothing, since a host outside `only`
+# is never used either way.
+[[ "$(q '.provider | has("allow_fallbacks")')" == "false" ]] \
+    && ok "--or-only leaves allow_fallbacks alone" \
+    || bad "--or-only leaves allow_fallbacks alone" "got $(q '.provider.allow_fallbacks')"
+
+# --- 3. the slug list is normalised ------------------------------------------
+run_llm -- --or-only " OpenAI , Azure ,, "
+[[ "$(q '.provider.only | join(",")')" == "openai,azure" ]] \
+    && ok "slug list is downcased, trimmed and de-blanked" \
+    || bad "slug list is downcased, trimmed and de-blanked" "got $(q '.provider.only | join(",")')"
+
+# A pin that normalises to nothing is a typo. Treating it as "no pin" would
+# route anywhere, which is the opposite of what was asked for.
+run_llm -- --or-only " , ,"
+[[ $? -ne 0 ]] && grep -q "no provider slugs left" "$WORK/err" \
+    && ok "a pin that normalises away is refused" \
+    || bad "a pin that normalises away is refused" "stderr: $(head -c160 "$WORK/err")"
+
+# --- 4. data_collection is allow or deny -------------------------------------
+run_llm -- --or-data-collection deny
+[[ "$(q '.provider.data_collection')" == "deny" ]] \
+    && ok "--or-data-collection deny is passed through" \
+    || bad "--or-data-collection deny is passed through" "got $(q '.provider.data_collection')"
+
+run_llm -- --or-data-collection nope
+[[ $? -ne 0 ]] && grep -q "must be allow or deny" "$WORK/err" \
+    && ok "an unknown data_collection value is refused" \
+    || bad "an unknown data_collection value is refused" "stderr: $(head -c160 "$WORK/err")"
+
+# --- 5. zdr is parsed once, not re-guessed at each use -----------------------
+run_llm -- --or-zdr
+[[ "$(q '.provider.zdr')" == "true" ]] \
+    && ok "--or-zdr requests zero-data-retention endpoints" \
+    || bad "--or-zdr requests zero-data-retention endpoints" "got $(q '.provider.zdr')"
+
+bads=""
+for v in true yes on 1 TRUE On; do
+    run_llm "LLM_OR_ZDR=$v" --
+    [[ "$(q '.provider.zdr')" == "true" ]] || bads="$bads $v"
+done
+[[ -z "$bads" ]] \
+    && ok "LLM_OR_ZDR accepts true/yes/on/1 in any case" \
+    || bad "LLM_OR_ZDR accepts true/yes/on/1 in any case" "not honoured:$bads"
+
+bads=""
+for v in false no 0 FALSE ""; do
+    run_llm "LLM_OR_ZDR=$v" --
+    [[ "$(q 'has("provider")')" == "false" ]] || bads="$bads '$v'"
+done
+[[ -z "$bads" ]] \
+    && ok "LLM_OR_ZDR accepts false/no/0/empty as off" \
+    || bad "LLM_OR_ZDR accepts false/no/0/empty as off" "still on for:$bads"
+
+run_llm "LLM_OR_ZDR=maybe" --
+[[ $? -ne 0 ]] && grep -q "must be 1/true/yes/on" "$WORK/err" \
+    && ok "an unparseable LLM_OR_ZDR is refused, not read as false" \
+    || bad "an unparseable LLM_OR_ZDR is refused, not read as false" "stderr: $(head -c160 "$WORK/err")"
+
+# --- 6. all three compose ----------------------------------------------------
+run_llm -- --or-only openai --or-data-collection deny --or-zdr
+[[ "$(q '[.provider.only[0], .provider.data_collection, (.provider.zdr|tostring)] | join(" ")')" \
+   == "openai deny true" ]] \
+    && ok "all three knobs compose into one provider block" \
+    || bad "all three knobs compose into one provider block" "got $(q '.provider')"
+
+# --- 7. a constraint nobody typed here is announced --------------------------
+# An LLM_OR_* out of a .env or a shell profile still decides where the prompt
+# goes, so the effective routing is stated once on stderr.
+run_llm "LLM_OR_ONLY=azure" --
+[[ "$(q '.provider.only | join(",")')" == "azure" ]] \
+    && ok "LLM_OR_ONLY is honoured like --or-only" \
+    || bad "LLM_OR_ONLY is honoured like --or-only" "got $(q '.provider.only')"
+grep -q "^llm: routing: openrouter only=azure$" "$WORK/err" \
+    && ok "an environment-supplied constraint is announced on stderr" \
+    || bad "an environment-supplied constraint is announced on stderr" "stderr: $(head -c160 "$WORK/err")"
+
+run_llm -- --or-only azure
+grep -q "llm: routing:" "$WORK/err" \
+    && bad "a constraint typed on the command line is not announced" "stderr: $(head -c160 "$WORK/err")" \
+    || ok "a constraint typed on the command line is not announced"
+
+# --- 8. a .env layer reaches the knobs, and the test owns that file ----------
+# Also the isolation check: every other case runs in this same cwd and sees no
+# provider block, which only holds because nothing else put a .env here.
+printf 'LLM_OR_ONLY=fromenvfile\n' > "$WORK/run/.env"
+run_llm --
+[[ "$(q '.provider.only | join(",")')" == "fromenvfile" ]] \
+    && ok "a .env in the working directory supplies the knobs" \
+    || bad "a .env in the working directory supplies the knobs" "got $(q '.provider.only')"
+rm -f "$WORK/run/.env"
+
+# --- 9. named and inferred providers behave the same -------------------------
+run_llm -- --provider openrouter --or-only openai
+[[ "$(q '.provider.only | join(",")')" == "openai" ]] \
+    && ok "an explicitly named openrouter provider takes the knobs" \
+    || bad "an explicitly named openrouter provider takes the knobs" "got $(q '.provider.only')"
+
+# --- 10. other providers are told, not silently pinned -----------------------
+# A stray LLM_OR_ZDR in a shell profile must neither read as a residency
+# guarantee on a single-host provider nor kill the call. Kept on an
+# OpenAI-compatible model so the stub's SSE is understood and what fails here
+# can only be the guard, not the stream parser.
+run_llm -- --provider openai -m gpt-4o-mini --or-zdr
+rc=$?
+[[ "$rc" -eq 0 ]] \
+    && ok "an --or-* flag does not fail a non-OpenRouter call" \
+    || bad "an --or-* flag does not fail a non-OpenRouter call" "exit $rc"
+grep -q "OpenRouter-only" "$WORK/err" \
+    && ok "an --or-* flag on another provider warns on stderr" \
+    || bad "an --or-* flag on another provider warns on stderr" "stderr: $(head -c200 "$WORK/err")"
+[[ "$(q 'has("provider")')" != "true" ]] \
+    && ok "an --or-* flag adds no provider block for another provider" \
+    || bad "an --or-* flag adds no provider block for another provider" "got $(q '.provider')"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## What

`build_payload_openrouter` was a bare alias for the OpenAI builder, so the payload never carried OpenRouter's `provider` object. OpenRouter serves one model id from several hosts — a single `openai/*` id can come from OpenAI, Azure or Amazon Bedrock — and picks one per request, so without that object there is no way from here to say where a prompt may go. Anyone with a data-residency constraint can't use the OpenRouter provider at all.

Three routing knobs, each with a matching `LLM_OR_*` default so a thinker or a bridge can set one without threading a flag through every call site:

| Flag | Effect |
|------|--------|
| `--or-only SLUGS` | Pins routing to those provider slugs |
| `--or-data-collection allow\|deny` | Whether hosts that may store the prompt are allowed |
| `--or-zdr` | Zero-data-retention endpoints only |

All three apply when the effective provider is `openrouter`, whether named with `--provider`/`LLM_PROVIDER` or inferred from the model name. OpenRouter enforces them server-side — an unsatisfiable pin returns 404 rather than quietly rerouting — so this is a real constraint, not a hint.

Unpinned callers are byte-identical to before and pay no extra `jq` pass. On a non-OpenRouter provider the knobs warn on stderr and clear: the other providers are each a single host already, so a stray `LLM_OR_ZDR` in a shell profile mustn't kill every Anthropic call — but it also mustn't read as a residency guarantee, so it isn't silent.

## Changes from review

- **Rebased onto main; the line-count changes are gone.** They were written against `LOC_LIMIT: 10000` and would have lowered today's 11000.
- **`only` no longer touches `allow_fallbacks`.** You were right and my reasoning was wrong: I had them coupled on the theory that a pin which can be rerouted isn't a pin. OpenRouter's docs say `only` is the allowlist and `allow_fallbacks` is a separate retry setting, and a host outside `only` is never used either way — so the coupling bought no residency safety and cost failover *between* two hosts the caller had explicitly allowed. No replacement flag; `only` alone is what residency needs. Happy to add one if you want fallback control for its own sake.
- **Every value is normalised once, where it's read.** `1/true/yes/on` and `0/false/no/empty` for `LLM_OR_ZDR`, anything else refused — a settings file saying `LLM_OR_ZDR=true` that read as false further down would drop a retention requirement silently, which is the one failure these knobs exist to prevent. `data_collection` must be `allow` or `deny`. A pin that normalises away to nothing is now an error rather than being treated as "no pin", which would have routed anywhere.
- **An `LLM_OR_*` from the environment or a `.env` prints the effective routing once on stderr.** A constraint that decides where the prompt goes without appearing on the command line shouldn't apply invisibly. A knob typed as a flag doesn't print — you already know.
- **Help text says the settings apply to the effective provider**, named or inferred.
- **The test runs in a scratch cwd with an empty state home**, so the checkout's `.env` and `~/.headlong/.env` can't reach the results. One case writes its own `.env` to prove the layer still works and that the test owns that file.

## The jq 1.7 problem the test caught

`tests/test_llm_openrouter_routing.sh` stubs `curl` and asserts on the JSON that would have been sent. It's the first test to exercise a payload builder — every other test stubs `llm` itself, so the `jq` filters in `bin/llm` are compiled nowhere in CI.

The obvious spelling of this filter parses under jq 1.8 and is a **syntax error under jq 1.7** (`unexpected '+', expecting '}'`) — 1.7's grammar won't take a `+` chain of parenthesised `if`s as an object value. `ubuntu-latest` ships jq 1.7, so a filter only ever tried on a 1.8 dev box would be broken for every CI run and every container user. The committed form binds the sum with `as $p`, which both accept.

## Testing

- `tests/run-all.sh` — 40 passed, 0 failed
- `tests/test_llm_openrouter_routing.sh` — 20/20, and 20/20 again under jq 1.7 in a `ubuntu:24.04` container
- `shellcheck -S warning` over CI's file set — clean
- bash 3.2 parse check (macOS gate) — clean

Found running the harness against OpenRouter under a data-residency requirement.

