### PR TITLE
shellm: an env is only reusable for the image it was built from

### DIFF
--- a/bin/shellm
+++ b/bin/shellm
@@ -78,6 +78,12 @@ if [[ -n "$SHELLM_API_URL" ]]; then
 fi
 SHELLM_MAX_TOKENS="${SHELLM_MAX_TOKENS:-}"
 SHELLM_EFFORT="${SHELLM_EFFORT:-high}"
+# Whether the image was chosen for this run (environment here, --docker-image
+# below) rather than defaulted. A resume inherits the trajectory's image only
+# when it was not, so resuming never silently overrides what the caller asked
+# for, and never silently defaults away from what the run actually used.
+_SHELLM_DOCKER_IMAGE_EXPLICIT=0
+[[ -n "${SHELLM_DOCKER_IMAGE:-}" ]] && _SHELLM_DOCKER_IMAGE_EXPLICIT=1
 SHELLM_DOCKER_IMAGE="${SHELLM_DOCKER_IMAGE:-ubuntu:latest}"
 SHELLM_DOCKER_ACCESS="${SHELLM_DOCKER_ACCESS:-none}"
 SHELLM_DOCKER_BROKER_TRANSPORT="${SHELLM_DOCKER_BROKER_TRANSPORT:-auto}"
@@ -772,6 +778,16 @@ env_metadata_matches() {
         local stored_tool_mounts_version
         stored_tool_mounts_version=$(docker_metadata_value "$env_name" tool_mounts_version)
         [[ "$stored_tool_mounts_version" == "$_SHELLM_TOOL_MOUNTS_VERSION" ]] || return 1
+        # The image is part of an env's identity, not just provenance. Without
+        # this, a second run asking for a different --docker-image reuses the
+        # container built from the first one: the flag reads as accepted, the
+        # run happens on the old image, and the run record names the image that
+        # was asked for rather than the one that served it. An env from before
+        # the image was recorded has nothing to compare, and reusing it stays
+        # allowed rather than forcing everyone's running envs to be rebuilt.
+        local stored_image
+        stored_image=$(docker_metadata_value "$env_name" image)
+        [[ -z "$stored_image" || "$stored_image" == "$SHELLM_DOCKER_IMAGE" ]] || return 1
     fi
 
     # Compare --var directory mounts
@@ -805,6 +821,15 @@ env_metadata_mismatch_message() {
         if [[ "$stored_tool_mounts_version" != "$_SHELLM_TOOL_MOUNTS_VERSION" ]]; then
             printf 'Env %s was created before current shellm tool mounts. Use a different --env or remove %s/%s so shellm can recreate it with llm, shellm-explore, and sibling tools mounted.' \
                 "$env_name" "$SHELLM_ENVS_DIR" "$env_name"
+            return
+        fi
+    fi
+    if [[ "$stored_type" == "docker" ]]; then
+        local stored_image
+        stored_image=$(docker_metadata_value "$env_name" image)
+        if [[ -n "$stored_image" && "$stored_image" != "$SHELLM_DOCKER_IMAGE" ]]; then
+            printf 'Env %s was created from image %s, but this run requested %s. Use --new-env, a different --env, or remove %s/%s so shellm can recreate it from the requested image.' \
+                "$env_name" "$stored_image" "$SHELLM_DOCKER_IMAGE" "$SHELLM_ENVS_DIR" "$env_name"
             return
         fi
     fi
@@ -1261,6 +1286,29 @@ docker_container_can_reach_path() {
     return 1
 }
 
+# The image a resumed run should use. A run that used a custom image records it
+# in its trajectory; resuming without saying anything would otherwise ask for
+# the default, fail the image check, and build a second container beside the
+# one being resumed. An image the caller did choose always wins, so an explicit
+# --docker-image that disagrees still fails rather than being quietly replaced.
+_resume_docker_image() {   # _resume_docker_image EXPLICIT CHOSEN RECORDED
+    if [[ "$1" -eq 0 && -n "$3" ]]; then printf '%s' "$3"; else printf '%s' "$2"; fi
+}
+
+# Say why a running env was passed over when the reason is the image. Without
+# this, pointing SHELLM_DOCKER_IMAGE somewhere new leaves the old container
+# running and silently creates a second one beside it, with nothing on screen
+# connecting the two. Only reached when the image actually differs, so the
+# docker inspect is not on the common path.
+_env_note_image_skip() {   # _env_note_image_skip NAME ENV_DIR
+    local stored cid
+    stored=$(docker_metadata_value "$1" image)
+    [[ -n "$stored" && "$stored" != "$SHELLM_DOCKER_IMAGE" ]] || return 0
+    cid=$(cat "$2/container_id" 2>/dev/null) || return 0
+    [[ "$(docker inspect -f '{{.State.Status}}' "$cid" 2>/dev/null)" == "running" ]] || return 0
+    progress "Skipping running env $1: built from $stored, this run wants $SHELLM_DOCKER_IMAGE"
+}
+
 env_find_running() {
     local want_workdir="${1:-}"
     [[ -d "$SHELLM_ENVS_DIR" ]] || return 1
@@ -1268,7 +1316,10 @@ env_find_running() {
     for d in "$SHELLM_ENVS_DIR"/*/; do
         [[ -d "$d" ]] || continue
         name=$(basename "$d")
-        env_metadata_matches "$name" || continue
+        if ! env_metadata_matches "$name"; then
+            _env_note_image_skip "$name" "$d"
+            continue
+        fi
         [[ -f "$d/container_id" ]] || continue
         local cid
         cid=$(cat "$d/container_id" 2>/dev/null) || continue
@@ -2003,11 +2054,14 @@ run_loop() {
         _orig_meta=$(traj tail -n 50 --raw --traj_dir "$_run_traj_dir" "$_use_traj" \
             | jq -cR 'fromjson? | select(.type=="shellm-run")' 2>/dev/null | tail -1) || true
         if [[ -n "$_orig_meta" ]]; then
-            local _orig_workdir _orig_env
+            local _orig_workdir _orig_env _orig_image
             _orig_workdir=$(printf '%s' "$_orig_meta" | jq -r '.workdir // empty')
             _orig_env=$(printf '%s' "$_orig_meta" | jq -r '.env.name // empty')
+            _orig_image=$(printf '%s' "$_orig_meta" | jq -r '.env.docker_image // empty')
             [[ -z "$_SHELLM_WORKDIR_USER" && -n "$_orig_workdir" ]] && _SHELLM_WORKDIR_USER="$_orig_workdir"
             [[ -z "$_SHELLM_ENV_NAME" && -n "$_orig_env" ]] && _SHELLM_ENV_NAME="$_orig_env"
+            SHELLM_DOCKER_IMAGE=$(_resume_docker_image \
+                "$_SHELLM_DOCKER_IMAGE_EXPLICIT" "$SHELLM_DOCKER_IMAGE" "$_orig_image")
         fi
 
         # Resolve run_name from trajectory dir
@@ -2948,6 +3002,7 @@ main() {
                 ;;
             --docker-image)
                 SHELLM_DOCKER_IMAGE="${2:?--docker-image requires a value}"
+                _SHELLM_DOCKER_IMAGE_EXPLICIT=1
                 shift 2
                 ;;
             --docker-access)

--- a/tests/test_env_image_identity.sh
+++ b/tests/test_env_image_identity.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# test_env_image_identity.sh — a running env is only reusable for the image it
+# was built from.
+#
+# Usage: tests/test_env_image_identity.sh
+#
+# By default shellm reuses any running env that env_metadata_matches accepts,
+# so that predicate is the whole of what --docker-image means on a second run.
+# It already compares access mode, tool mounts, --var mounts and the workdirs
+# mount; the image was written to the env directory but never read back, so a
+# run asking for a different image silently got the first container. The flag
+# reads as accepted, and the run record then names the image that was requested
+# rather than the one that served the run.
+#
+# env_metadata_matches and its message are lifted out of bin/shellm with sed
+# (as tests/test_mem_frontmatter.sh does for bin/mem) so the predicate can be
+# put through its cases directly, with the env directory on disk as the only
+# input and no Docker daemon involved.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+eval "$(sed -n '/^docker_metadata_value()/,/^}/p'         "$REPO/bin/shellm")"
+eval "$(sed -n '/^_compute_var_mounts()/,/^}/p'           "$REPO/bin/shellm")"
+eval "$(sed -n '/^env_metadata_matches()/,/^}/p'          "$REPO/bin/shellm")"
+eval "$(sed -n '/^env_metadata_mismatch_message()/,/^}/p' "$REPO/bin/shellm")"
+eval "$(sed -n '/^_resume_docker_image()/,/^}/p'          "$REPO/bin/shellm")"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+SHELLM_ENVS_DIR="$WORK/envs"
+SHELLM_WORKDIRS_DIR="$WORK/workdirs"
+# shellcheck disable=SC2034  # read by env_metadata_matches, eval'd in above
+SHELLM_DOCKER_ACCESS="none"
+_SHELLM_TOOL_MOUNTS_VERSION="v1"
+
+# make_env NAME TYPE [IMAGE] — an env directory as env_register writes one.
+# Omitting IMAGE is an env from before the image was recorded.
+make_env() {
+    local name="$1" type="$2" image="${3-}"
+    local d="$SHELLM_ENVS_DIR/$name"
+    mkdir -p "$d"
+    printf '%s\n' "$type"                 > "$d/type"
+    printf 'none\n'                       > "$d/docker_access"
+    printf 'v1\n'                         > "$d/tool_mounts_version"
+    printf '%s\n' "$SHELLM_WORKDIRS_DIR"  > "$d/workdirs_dir"
+    : > "$d/var_mounts"
+    [[ -n "$image" ]] && printf '%s\n' "$image" > "$d/image"
+    return 0
+}
+
+matches() {  # matches ENV REQUESTED_IMAGE
+    SHELLM_DOCKER_IMAGE="$2" env_metadata_matches "$1"
+}
+
+# --- 1. same image: reuse is what it was always for ---------------------------
+make_env same docker "ubuntu:24.04"
+matches same "ubuntu:24.04" \
+    && ok "same image is reusable" \
+    || bad "same image is reusable"
+
+# --- 2. different image: the flag must not be silently voided -----------------
+make_env other docker "ubuntu:24.04"
+matches other "alpine:3.20" \
+    && bad "a different image is not reusable" "reused an env built from another image" \
+    || ok "a different image is not reusable"
+
+# A tag move is a different image to anyone who typed the tag.
+make_env tag docker "ubuntu:24.04"
+matches tag "ubuntu:latest" \
+    && bad "a different tag of the same repo is not reusable" \
+    || ok "a different tag of the same repo is not reusable"
+
+# --- 3. envs predating the recorded image still reattach ----------------------
+# There is nothing to compare, so this stays a match: the alternative is
+# forcing every already-running env to be rebuilt on upgrade.
+make_env legacy docker
+matches legacy "ubuntu:24.04" \
+    && ok "an env with no recorded image is still reusable" \
+    || bad "an env with no recorded image is still reusable"
+
+# --- 4. the image gate applies to docker envs only ----------------------------
+# The stored image disagrees here on purpose: without one, a local env would
+# pass this whatever the gate did, and the case would prove nothing.
+make_env plain local "ubuntu:24.04"
+matches plain "alpine:3.20" \
+    && ok "a local env is unaffected by the requested image" \
+    || bad "a local env is unaffected by the requested image"
+
+# --- 5. an explicit --env says which axis disagreed ---------------------------
+# env_resolve turns a mismatch into this message when the env was named
+# explicitly, so it has to name the image rather than fall through to the
+# access-mode sentence, which would send the reader somewhere unrelated.
+msg=$(SHELLM_DOCKER_IMAGE="alpine:3.20" env_metadata_mismatch_message other)
+[[ "$msg" == *"ubuntu:24.04"* && "$msg" == *"alpine:3.20"* ]] \
+    && ok "the mismatch message names both images" \
+    || bad "the mismatch message names both images" "got: $msg"
+[[ "$msg" != *"docker_access"* ]] \
+    && ok "the mismatch message does not blame access mode" \
+    || bad "the mismatch message does not blame access mode" "got: $msg"
+
+# --- 6. resuming a run that used a custom image -------------------------------
+# The image check above is what makes this necessary: a resume that quietly
+# asked for the default would now fail to match the very env it is resuming,
+# and build a second container beside it. _resume_docker_image is the decision,
+# and the assertions below run its answer back through the predicate.
+make_env custom docker "alpine:3.20"
+
+img=$(_resume_docker_image 0 "ubuntu:latest" "alpine:3.20")
+[[ "$img" == "alpine:3.20" ]] \
+    && ok "a resume with no image given inherits the trajectory's" \
+    || bad "a resume with no image given inherits the trajectory's" "got $img"
+matches custom "$img" \
+    && ok "the inherited image reattaches the env instead of rebuilding" \
+    || bad "the inherited image reattaches the env instead of rebuilding"
+
+# An image the caller did choose is never overridden, so a resume that names a
+# conflicting one still fails rather than being quietly corrected into working.
+img=$(_resume_docker_image 1 "ubuntu:24.04" "alpine:3.20")
+[[ "$img" == "ubuntu:24.04" ]] \
+    && ok "an explicit image survives a resume" \
+    || bad "an explicit image survives a resume" "got $img"
+matches custom "$img" \
+    && bad "an explicit conflicting image still fails on resume" "reused anyway" \
+    || ok "an explicit conflicting image still fails on resume"
+
+# A trajectory with no recorded image (a local run, or one from before the
+# field existed) leaves the caller's default alone.
+img=$(_resume_docker_image 0 "ubuntu:latest" "")
+[[ "$img" == "ubuntu:latest" ]] \
+    && ok "a trajectory with no recorded image changes nothing" \
+    || bad "a trajectory with no recorded image changes nothing" "got $img"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## The bug

`--docker-image` is silently ignored on any run that reuses an env.

By default `shellm` reuses any running env that `env_metadata_matches` accepts, so that predicate *is* what `--docker-image` means on a second run. It compares access mode, tool mounts, `--var` mounts and the workdirs mount. `env_register` writes the image to the env directory — under a comment saying "Save image metadata for reproducibility" — but nothing ever reads it back.

```bash
shellm --docker-image ubuntu:24.04 'cat /etc/os-release'   # creates the env
shellm --docker-image alpine:3.20  'cat /etc/os-release'   # reuses it; still Ubuntu
```

The second run is accepted, says nothing, and executes on the first image.

## Why it's worse than a silent no-op

The run record doesn't just omit this — it states the wrong thing. `shellm` takes `docker_image` from **what was requested** while taking `docker_image_digest` from **the env's stored metadata**:

```bash
_img_digest=$(docker_metadata_value "$ws_name" image_digest 2>/dev/null) || true
_env_json=$(jq -nc \
    --arg image "$SHELLM_DOCKER_IMAGE" \      # requested
    --arg digest "$_img_digest" \             # actually served
```

So a reused env with a different image produces a trajectory naming an image that did not serve the run, next to the digest of one that did. For a harness whose trajectories are the record of what an agent did, that's a provenance claim that is not merely incomplete but false.

## The fix

Compare the stored image in `env_metadata_matches`, and name it in `env_metadata_mismatch_message` so an explicit `--env` says which axis disagreed. Without the second half the message falls through to the access-mode sentence, which on the common path reads "Env other was created with docker_access=none, but this run requested docker_access=none."

**Envs recorded before the image was stored** have nothing to compare and stay reusable. The alternative is forcing every already-running env to be rebuilt on upgrade to fix a mismatch that may not exist.

## Changes from review

- **Resumes inherit the trajectory's image.** This was a real regression in the first version and it would have hit every custom-image resume: the resume asks for the default, fails the new check against the very env it's resuming, and builds a second container beside it. Confirmed against the predicate before and after — `alpine:3.20` env, resume with nothing given: rebuilds before, reattaches now. An image the caller *did* choose still wins, so a resume naming a conflicting one fails rather than being quietly corrected into working.
- **Skipping a running env over its image says so**, naming stored and requested. Otherwise setting `SHELLM_DOCKER_IMAGE` leaves the old container running and creates another with nothing connecting the two on screen. The `docker inspect` behind that line only runs once the images have already been seen to differ, so it stays off the common path.
- **The local-env case now carries a disagreeing stored image**, so it proves the check is gated on env type rather than passing for want of anything to compare. Fair hit — it was passing trivially.
- **Line-count changes removed and rebased** onto current main.

The hard failure for an explicit `--env` with a different image is unchanged, per your note.

## Testing

`tests/test_env_image_identity.sh` lifts the predicate and the resume decision out with `sed`, the way `tests/test_mem_frontmatter.sh` does for `bin/mem`, so the cases run against an env directory on disk with no Docker daemon involved. 12 assertions: same image, different image, a moved tag, the legacy no-image env, the local env, both properties of the mismatch message, and four covering resume.

A note on level: the resume cases test the decision, not a live container, because the suite has no Docker-mode harness to hang an end-to-end resume off. If you'd rather have one, I'm happy to build the `docker` stub — it's a bigger piece of scaffolding than this PR, so I didn't assume.

- `tests/run-all.sh` — 40 passed, 0 failed
- `shellcheck -S warning` over CI's file set — clean
- bash 3.2 (macOS gate) — 12/12

## Not included: digest-level identity

This compares the image *reference*, not the resolved digest. A mutable tag that moves under a live env (an out-of-band `docker pull ubuntu:latest`) still reattaches the old container — see the thread below. Short version: there the user asked for `ubuntu:latest` and got a container built from `ubuntu:latest`, and making digests count would mean any upstream tag move silently destroys and recreates every env pinned to it. It belongs behind an opt-in if you want it.

Found running the harness across two container images in the same workdir.

