### PR TITLE
llm: provider policy, generic openai-compatible provider, adapter seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@
 #   gitleaks       gitleaks git (full history)  secrets; allowlist in .gitleaks.toml
 #   loc            cloc bin/ thinkers/          the harness stays under
 #                                               LOC_LIMIT code lines (the
-#                                               README's "9.6K lines" claim)
+#                                               README's "about 10K lines"
+#                                               claim; was 10K at the launch
+#                                               blog post, week of 2026-08-24)
 #   alert-main     Slack post                    after each push to main: red
 #                                               when a job failed, green-again
 #                                               when the previous run was red;
@@ -271,7 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LOC_LIMIT: 10000
+      LOC_LIMIT: 11000
     steps:
       - uses: actions/checkout@v5
       - name: Install cloc

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Headlong also gives an agent a few convenience tools, such as a way to
 distill and codify its experience (`mem`) and a way to save and reuse
 procedures for specialized tasks (`skills`). The core is the tools the
 running mind executes, the executables in `bin/` plus the thought
-processes in `thinkers/`, and it comes to 9.9K lines by cloc's count. A
+processes in `thinkers/`, and it comes to about 10K lines by cloc's count. A
 harness this small can be read end to end, and it is easy to modify and
 experiment with.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [**Headlong**](https://www.laude.org/updates/headlong-a-microharness-for-persistent-agents)
 is an open source agent microharness, a complete agent harness with a core of
-less than 10K lines of Bash. Headlong's defining feature is **persistent
+about 10K lines of Bash. Headlong's defining feature is **persistent
 agency**. Your agent keeps thinking between external interactions in a
 self-guided loop inspired by human inner monologue. A message from a human
 doesn't start a session. It lands in the agent's thought stream as one more

--- a/bin/llm
+++ b/bin/llm
@@ -170,6 +170,9 @@ Models:
   Compatible: any model name, via --provider openai-compatible and
               LLM_API_URL (Ollama, vLLM, LM Studio, proxies; never
               auto-detected)
+  Adapter:    any model name, via --provider adapter and LLM_ADAPTER
+              (an external executable handles the completion; see
+              design/providers.md for the contract)
 
 Thinking & effort:
   These flags control how much reasoning the model does before answering.
@@ -212,6 +215,8 @@ Environment:
   LLM_API_KEY              Optional key for openai-compatible, sent as
                            Authorization: Bearer when set (local servers
                            like Ollama need none)
+  LLM_ADAPTER              Path to an adapter executable; required with
+                           --provider adapter (contract: design/providers.md)
   LLM_PROVIDER             Provider to use when the model name implies none
                            (same names as --provider); --provider takes
                            precedence, and a value that disagrees with the
@@ -343,11 +348,12 @@ fi
 
 # LLM_API_URL reroutes a provider's requests — credentials included — to an
 # arbitrary host, so like the provider override above it must never do it
-# silently. openai-compatible is exempt: it has no default endpoint, so the
-# URL there is configuration, not an override. Warn with the host only: a
-# URL can itself carry credentials (user:pass@, ?token=...) that must not
-# reach stderr or whatever captures it.
-if [[ -n "${LLM_API_URL:-}" && "$LLM_PROVIDER" != "openai-compatible" ]]; then
+# silently. openai-compatible is exempt (it has no default endpoint, so the
+# URL there is configuration, not an override), and so is adapter (it
+# ignores LLM_API_URL entirely). Warn with the host only: a URL can itself
+# carry credentials (user:pass@, ?token=...) that must not reach stderr or
+# whatever captures it.
+if [[ -n "${LLM_API_URL:-}" && "$LLM_PROVIDER" != "openai-compatible" && "$LLM_PROVIDER" != "adapter" ]]; then
     _llm_url_host="${LLM_API_URL#*://}"
     _llm_url_host="${_llm_url_host%%/*}"
     _llm_url_host="${_llm_url_host%%\?*}"
@@ -410,14 +416,13 @@ get_model_max_tokens() {
         */*) echo 16384 ;;
         *)
             # Conservative fallback for unknown models. openai-compatible
-            # endpoints serve arbitrary names the table cannot know, and
-            # 4096 starves agentic steps there; names the table does know
-            # (a proxy serving gpt-5, ...) keep their real caps above.
-            if [[ "${LLM_PROVIDER:-}" == "openai-compatible" ]]; then
-                echo 16384
-            else
-                echo 4096
-            fi
+            # endpoints and adapters serve arbitrary names the table cannot
+            # know, and 4096 starves agentic steps there; names the table
+            # does know (a proxy serving gpt-5, ...) keep their real caps.
+            case "${LLM_PROVIDER:-}" in
+                openai-compatible|adapter) echo 16384 ;;
+                *) echo 4096 ;;
+            esac
             ;;
     esac
 }
@@ -1004,6 +1009,59 @@ _llm_cleanup() {
     return 0
 }
 trap '_llm_cleanup' EXIT
+
+# Adapter seam (design/providers.md): LLM_PROVIDER=adapter hands the whole
+# completion to the executable named by LLM_ADAPTER instead of the curl
+# path. The adapter carries its own dependencies and auth; bin/llm keeps
+# the wall-clock deadline, the health marker, and the usage ledger.
+if [[ "$LLM_PROVIDER" == "adapter" ]]; then
+    [[ -n "${LLM_ADAPTER:-}" ]] || die "LLM_ADAPTER is not set (LLM_PROVIDER=adapter runs the executable at that path; see design/providers.md)"
+    [[ -x "$LLM_ADAPTER" ]] || die "LLM_ADAPTER is not executable: $LLM_ADAPTER"
+    _adapter_args=(--model "$LLM_MODEL" --max-tokens "$LLM_MAX_TOKENS")
+    [[ -n "$LLM_EFFORT" ]] && _adapter_args+=(--effort "$LLM_EFFORT")
+    if [[ "$LLM_THINKING" -eq 1 ]]; then
+        _adapter_args+=(--thinking)
+        [[ -n "$LLM_THINKING_LEVEL" ]] && _adapter_args+=("$LLM_THINKING_LEVEL")
+    fi
+    [[ "$LLM_STREAM" -eq 0 ]] && _adapter_args+=(--no-stream)
+    if [[ -n "$LLM_SYSTEM" ]]; then
+        printf '%s' "$LLM_SYSTEM" > "$payload_file.system"
+        _adapter_args+=(--system-prompt-file "$payload_file.system")
+    fi
+    # Messages travel by file + stdin redirect, not argv (size caps) and
+    # not a pipe (the adapter must be a direct child so the deadline can
+    # kill it). The payload tempfile and its cleanup are reused.
+    printf '%s' "$LLM_MESSAGES" > "$payload_file"
+    export LLM_USAGE_FILE
+    _adapter_rc=0
+    if [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]]; then
+        "$LLM_ADAPTER" "${_adapter_args[@]}" < "$payload_file" &
+        _adapter_pid=$!
+        # The watcher detaches from stdio: it would otherwise hold the
+        # caller's stdout pipe open (a $(...) caller blocks on it) for the
+        # full deadline even after the adapter finishes.
+        ( sleep "$LLM_MAX_TIME"; kill "$_adapter_pid" 2>/dev/null ) >/dev/null 2>&1 </dev/null &
+        _adapter_watch=$!
+        wait "$_adapter_pid" || _adapter_rc=$?
+        # Kill the watcher's process group so its sleep dies with it (a bare
+        # kill orphans the sleep, which lingers until the deadline).
+        { kill -- -"$_adapter_watch" || kill "$_adapter_watch"; } 2>/dev/null || true
+        wait "$_adapter_watch" 2>/dev/null || true
+    else
+        "$LLM_ADAPTER" "${_adapter_args[@]}" < "$payload_file" || _adapter_rc=$?
+    fi
+    rm -f "$payload_file.system"
+    if [[ "$_adapter_rc" -eq 0 ]]; then
+        _llm_note ok
+        _llm_ledger_append
+        exit 0
+    fi
+    _adapter_msg="adapter exited $_adapter_rc"
+    [[ "$_adapter_rc" -eq 143 ]] && _adapter_msg="adapter killed after ${LLM_MAX_TIME}s (LLM_MAX_TIME deadline)"
+    _llm_note error "" "$_adapter_msg"
+    die "Adapter failed ($_adapter_msg): $LLM_ADAPTER"
+fi
+
 # A typo'd provider name would otherwise surface as bash's exit-127
 # "build_payload_...: command not found" instead of an error naming the
 # problem, because payload build runs before get_url_headers' own check.

--- a/bin/llm
+++ b/bin/llm
@@ -1072,7 +1072,9 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
                 else
                     kill -- -"$_adapter_pid" 2>/dev/null
                     _g=0
-                    while [[ "$_g" -lt 5 ]] && kill -0 "$_adapter_pid" 2>/dev/null; do
+                    # Check the process group, not only its leader. The
+                    # adapter may exit on TERM while a child keeps running.
+                    while [[ "$_g" -lt 5 ]] && kill -0 -- -"$_adapter_pid" 2>/dev/null; do
                         sleep 1; _g=$((_g+1))
                     done
                     kill -9 -- -"$_adapter_pid" 2>/dev/null
@@ -1082,10 +1084,14 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
         _adapter_watch=$!
         wait "$_adapter_pid" || _adapter_rc=$?
         : > "$_adapter_dir/done"
-        # TERM the watcher rather than waiting out its poll tick — the tick
-        # would tax every successful call ~1s. Its in-flight sleep is
-        # stdio-detached and gone within a second.
-        kill "$_adapter_watch" 2>/dev/null || true
+        if [[ ! -e "$_adapter_dir/deadline" ]]; then
+            # A normal completion does not need to wait out the poll tick.
+            # The in-flight sleep is stdio-detached and gone within a second.
+            kill "$_adapter_watch" 2>/dev/null || true
+        fi
+        # After a deadline, the leader can exit on TERM while one of its
+        # children ignores it. Waiting lets the watcher finish its grace
+        # period and group KILL, so no child can hold stdout open.
         wait "$_adapter_watch" 2>/dev/null || true
     else
         "$LLM_ADAPTER" "${_adapter_args[@]}" < "$payload_file" || _adapter_rc=$?

--- a/bin/llm
+++ b/bin/llm
@@ -351,6 +351,7 @@ if [[ -n "${LLM_API_URL:-}" && "$LLM_PROVIDER" != "openai-compatible" ]]; then
     _llm_url_host="${LLM_API_URL#*://}"
     _llm_url_host="${_llm_url_host%%/*}"
     _llm_url_host="${_llm_url_host%%\?*}"
+    _llm_url_host="${_llm_url_host%%#*}"
     _llm_url_host="${_llm_url_host##*@}"
     echo "llm: warning: LLM_API_URL overrides the default $LLM_PROVIDER endpoint (requests go to $_llm_url_host)" >&2
 fi
@@ -650,8 +651,13 @@ get_url_headers() {
                      -H "Authorization: Bearer $OPENCODE_API_KEY")
             ;;
         openai-compatible)
-            [[ -z "${LLM_API_URL:-}" ]] && die "LLM_API_URL is not set (openai-compatible has no default endpoint; e.g. http://localhost:11434/v1/chat/completions for Ollama)"
-            url="$LLM_API_URL"
+            # SHELLM_API_URL fallback, like SHELLM_MODEL above: shellm clears
+            # inherited LLM_API_URL, so a deployment configured per the docs
+            # sets SHELLM_API_URL — and thinkers, mem, recap call llm
+            # directly, outside shellm's re-export. Scoped to this provider;
+            # keyed providers' URLs stay LLM_API_URL-only.
+            url="${LLM_API_URL:-${SHELLM_API_URL:-}}"
+            [[ -z "$url" ]] && die "LLM_API_URL is not set (openai-compatible has no default endpoint; e.g. http://localhost:11434/v1/chat/completions for Ollama)"
             headers=(-H "Content-Type: application/json")
             if [[ -n "${LLM_API_KEY:-}" ]]; then
                 headers+=(-H "Authorization: Bearer $LLM_API_KEY")

--- a/bin/llm
+++ b/bin/llm
@@ -153,7 +153,8 @@ Options:
   -M, --messages JSON      Messages array JSON, e.g. [{"role":"user","content":"hi"}]
   --no-stream              Disable streaming (streaming is on by default)
   --provider NAME          Provider: anthropic, openai, gemini, openrouter,
-                           opencode, opencode-go, or openai-compatible
+                           opencode, opencode-go, openai-compatible, or
+                           adapter (needs LLM_ADAPTER)
   --thinking [LEVEL]       Enable thinking (Anthropic: adaptive; Gemini: minimal/low/medium/high)
   --effort LEVEL           Thinking effort/provider output effort
   --raw                    Print raw non-streaming API response JSON
@@ -1004,7 +1005,8 @@ if [[ -z "$LLM_USAGE_FILE" ]]; then
     _llm_usage_own=1
 fi
 _llm_cleanup() {
-    rm -f "$payload_file"
+    rm -f "$payload_file" "$payload_file.system" \
+          "$payload_file.done" "$payload_file.deadline"
     if [[ "$_llm_usage_own" -eq 1 ]]; then rm -f "$LLM_USAGE_FILE"; fi
     return 0
 }
@@ -1025,7 +1027,10 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
     fi
     [[ "$LLM_STREAM" -eq 0 ]] && _adapter_args+=(--no-stream)
     if [[ -n "$LLM_SYSTEM" ]]; then
-        printf '%s' "$LLM_SYSTEM" > "$payload_file.system"
+        # 0600 like the mktemp'd payload file: the prompt is private, and a
+        # plain redirect under the default umask would land world-readable
+        # in /tmp. Removed by the EXIT cleanup with the rest.
+        ( umask 077; printf '%s' "$LLM_SYSTEM" > "$payload_file.system" )
         _adapter_args+=(--system-prompt-file "$payload_file.system")
     fi
     # Messages travel by file + stdin redirect, not argv (size caps) and
@@ -1037,29 +1042,52 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
     if [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]]; then
         "$LLM_ADAPTER" "${_adapter_args[@]}" < "$payload_file" &
         _adapter_pid=$!
-        # The watcher detaches from stdio: it would otherwise hold the
-        # caller's stdout pipe open (a $(...) caller blocks on it) for the
-        # full deadline even after the adapter finishes.
-        ( sleep "$LLM_MAX_TIME"; kill "$_adapter_pid" 2>/dev/null ) >/dev/null 2>&1 </dev/null &
+        # Deadline watcher. It polls a done-marker once a second instead of
+        # sleeping the whole deadline, so it exits within ~1s of the adapter
+        # finishing and never leaves an orphaned long sleep (a background
+        # subshell gets no process group of its own here, so the sleep
+        # could not be killed with it). It detaches from stdio so it cannot
+        # hold a $(...) caller's stdout pipe open. On expiry it writes the
+        # deadline marker — the authoritative "this run timed out" signal,
+        # regardless of how the adapter exits — then escalates TERM, 5s
+        # grace, KILL, so an adapter that ignores TERM still dies.
+        (
+            _t=0
+            while [[ ! -e "$payload_file.done" && "$_t" -lt "$LLM_MAX_TIME" ]]; do
+                sleep 1; _t=$((_t+1))
+            done
+            if [[ ! -e "$payload_file.done" ]]; then
+                : > "$payload_file.deadline"
+                kill "$_adapter_pid" 2>/dev/null
+                _g=0
+                while [[ "$_g" -lt 5 ]] && kill -0 "$_adapter_pid" 2>/dev/null; do
+                    sleep 1; _g=$((_g+1))
+                done
+                kill -9 "$_adapter_pid" 2>/dev/null
+            fi
+        ) >/dev/null 2>&1 </dev/null &
         _adapter_watch=$!
         wait "$_adapter_pid" || _adapter_rc=$?
-        # Kill the watcher's process group so its sleep dies with it (a bare
-        # kill orphans the sleep, which lingers until the deadline).
-        { kill -- -"$_adapter_watch" || kill "$_adapter_watch"; } 2>/dev/null || true
+        : > "$payload_file.done"
         wait "$_adapter_watch" 2>/dev/null || true
     else
         "$LLM_ADAPTER" "${_adapter_args[@]}" < "$payload_file" || _adapter_rc=$?
     fi
-    rm -f "$payload_file.system"
+    if [[ -e "$payload_file.deadline" ]]; then
+        # Deadline expiry is a failure even when the adapter, tapped on the
+        # shoulder by TERM, manages to exit 0 — recording ok would make the
+        # health marker lie about a call that produced no usable answer.
+        _adapter_msg="adapter killed after ${LLM_MAX_TIME}s (LLM_MAX_TIME deadline)"
+        _llm_note error "" "$_adapter_msg"
+        die "Adapter failed ($_adapter_msg): $LLM_ADAPTER"
+    fi
     if [[ "$_adapter_rc" -eq 0 ]]; then
         _llm_note ok
         _llm_ledger_append
         exit 0
     fi
-    _adapter_msg="adapter exited $_adapter_rc"
-    [[ "$_adapter_rc" -eq 143 ]] && _adapter_msg="adapter killed after ${LLM_MAX_TIME}s (LLM_MAX_TIME deadline)"
-    _llm_note error "" "$_adapter_msg"
-    die "Adapter failed ($_adapter_msg): $LLM_ADAPTER"
+    _llm_note error "" "adapter exited $_adapter_rc"
+    die "Adapter failed (adapter exited $_adapter_rc): $LLM_ADAPTER"
 fi
 
 # A typo'd provider name would otherwise surface as bash's exit-127

--- a/bin/llm
+++ b/bin/llm
@@ -344,9 +344,15 @@ fi
 # LLM_API_URL reroutes a provider's requests — credentials included — to an
 # arbitrary host, so like the provider override above it must never do it
 # silently. openai-compatible is exempt: it has no default endpoint, so the
-# URL there is configuration, not an override.
+# URL there is configuration, not an override. Warn with the host only: a
+# URL can itself carry credentials (user:pass@, ?token=...) that must not
+# reach stderr or whatever captures it.
 if [[ -n "${LLM_API_URL:-}" && "$LLM_PROVIDER" != "openai-compatible" ]]; then
-    echo "llm: warning: LLM_API_URL=$LLM_API_URL overrides the default $LLM_PROVIDER endpoint" >&2
+    _llm_url_host="${LLM_API_URL#*://}"
+    _llm_url_host="${_llm_url_host%%/*}"
+    _llm_url_host="${_llm_url_host%%\?*}"
+    _llm_url_host="${_llm_url_host##*@}"
+    echo "llm: warning: LLM_API_URL overrides the default $LLM_PROVIDER endpoint (requests go to $_llm_url_host)" >&2
 fi
 
 # OpenCode routing prefixes hide the real catalog id from the API side;

--- a/bin/llm
+++ b/bin/llm
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 # llm — Minimal multi-provider LLM CLI tool
-# Supports the Anthropic, OpenAI, Gemini, and OpenRouter APIs.
+# Supports the Anthropic, OpenAI, Gemini, and OpenRouter APIs, plus any
+# OpenAI-compatible endpoint via --provider openai-compatible (see
+# design/providers.md for the provider policy).
 
 # ---------------------------------------------------------------------------
 # Defaults
@@ -150,7 +152,8 @@ Options:
   -t, --max-tokens N       Max output tokens. Default: model-specific cap
   -M, --messages JSON      Messages array JSON, e.g. [{"role":"user","content":"hi"}]
   --no-stream              Disable streaming (streaming is on by default)
-  --provider NAME          Provider: anthropic, openai, gemini, openrouter, opencode, or opencode-go
+  --provider NAME          Provider: anthropic, openai, gemini, openrouter,
+                           opencode, opencode-go, or openai-compatible
   --thinking [LEVEL]       Enable thinking (Anthropic: adaptive; Gemini: minimal/low/medium/high)
   --effort LEVEL           Thinking effort/provider output effort
   --raw                    Print raw non-streaming API response JSON
@@ -164,6 +167,9 @@ Models:
   OpenRouter: z-ai/glm-5.2, meta-llama/*, ... (any vendor/model name)
   OpenCode:   opencode-go/* (Go subscription, OpenAI wire format)
               opencode/*  (Zen pay-per-token, Anthropic wire format)
+  Compatible: any model name, via --provider openai-compatible and
+              LLM_API_URL (Ollama, vLLM, LM Studio, proxies; never
+              auto-detected)
 
 Thinking & effort:
   These flags control how much reasoning the model does before answering.
@@ -201,7 +207,11 @@ Environment:
   OPENCODE_API_KEY         Required for OpenCode models — both plans use it;
                            opencode-go/* bills the Go subscription, opencode/*
                            bills Zen. Keys: `opencode auth login`
-  LLM_API_URL              Override provider API URL
+  LLM_API_URL              Override provider API URL. Required for
+                           openai-compatible, which has no default endpoint
+  LLM_API_KEY              Optional key for openai-compatible, sent as
+                           Authorization: Bearer when set (local servers
+                           like Ollama need none)
   LLM_PROVIDER             Provider to use when the model name implies none
                            (same names as --provider); --provider takes
                            precedence, and a value that disagrees with the
@@ -224,6 +234,8 @@ Examples:
   llm --thinking -m claude-opus-4-7 "solve this carefully"
   llm --raw -m gemini-2.0-flash "return a JSON greeting"
   llm -m z-ai/glm-5.2 "explain quicksort"
+  LLM_API_URL=http://localhost:11434/v1/chat/completions \
+    llm --provider openai-compatible -m qwen3:8b "explain quicksort"
 EOF
     exit "${1:-0}"
 }
@@ -347,6 +359,13 @@ get_model_max_tokens() {
             glm-*|kimi-*|qwen*|minimax-*|deepseek-*|grok-*|longcat-*|mimo-*|hy3*|muse-*|ox-alpha-*) echo 32768 ;;
             *) echo 16384 ;;
         esac
+        return
+    fi
+    # openai-compatible endpoints serve arbitrary model names the tables
+    # below cannot know, and the conservative 4096 fallback starves agentic
+    # steps. Scoped to the provider; LLM_MAX_TOKENS overrides as usual.
+    if [[ "${LLM_PROVIDER:-}" == "openai-compatible" ]]; then
+        echo 16384
         return
     fi
     case "$model" in
@@ -552,6 +571,11 @@ build_payload_gemini() {
 # OpenRouter is OpenAI-compatible (chat/completions wire format)
 build_payload_openrouter() { build_payload_openai; }
 
+# Generic openai-compatible endpoint (Ollama, vLLM, LM Studio, proxies):
+# the OpenAI wire format against a configured LLM_API_URL, key optional.
+# See design/providers.md.
+build_payload_openai-compatible() { build_payload_openai; }
+
 # OpenCode Go is OpenAI-compatible (@ai-sdk/openai-compatible upstream);
 # its opencode-go/ prefix was already stripped above.
 build_payload_opencode-go() { build_payload_openai; }
@@ -609,6 +633,14 @@ get_url_headers() {
             headers=(-H "Content-Type: application/json"
                      -H "Authorization: Bearer $OPENCODE_API_KEY")
             ;;
+        openai-compatible)
+            [[ -z "${LLM_API_URL:-}" ]] && die "LLM_API_URL is not set (openai-compatible has no default endpoint; e.g. http://localhost:11434/v1/chat/completions for Ollama)"
+            url="$LLM_API_URL"
+            headers=(-H "Content-Type: application/json")
+            if [[ -n "${LLM_API_KEY:-}" ]]; then
+                headers+=(-H "Authorization: Bearer $LLM_API_KEY")
+            fi
+            ;;
         gemini)
             [[ -z "${GEMINI_API_KEY:-}" ]] && die "GEMINI_API_KEY is not set"
             local action="generateContent"
@@ -641,6 +673,7 @@ extract_text_gemini() {
 
 # OpenRouter is OpenAI-compatible
 extract_text_openrouter() { extract_text_openai; }
+extract_text_openai-compatible() { extract_text_openai; }
 
 # OpenCode: Go is OpenAI-compatible, Zen speaks the Anthropic protocol;
 # same response shapes as their respective bases throughout.
@@ -675,6 +708,7 @@ check_response_gemini() {
 }
 
 check_response_openrouter() { check_response_openai; }
+check_response_openai-compatible() { check_response_openai; }
 
 check_response_opencode-go() { check_response_openai; }
 check_response_opencode() { check_response_anthropic; }
@@ -699,6 +733,7 @@ check_truncated_gemini() {
 }
 
 check_truncated_openrouter() { check_truncated_openai; }
+check_truncated_openai-compatible() { check_truncated_openai; }
 
 check_truncated_opencode-go() { check_truncated_openai; }
 check_truncated_opencode() { check_truncated_anthropic; }
@@ -919,6 +954,7 @@ stream_gemini() {
 
 # OpenRouter is OpenAI-compatible (SSE chat/completions chunks)
 stream_openrouter() { stream_openai; }
+stream_openai-compatible() { stream_openai; }
 
 # OpenCode: same SSE shapes as their wire-format bases.
 stream_opencode-go() { stream_openai; }

--- a/bin/llm
+++ b/bin/llm
@@ -341,6 +341,14 @@ if [[ -n "$_llm_provider_env" && "$LLM_PROVIDER" == "$_llm_provider_env" ]]; the
     fi
 fi
 
+# LLM_API_URL reroutes a provider's requests — credentials included — to an
+# arbitrary host, so like the provider override above it must never do it
+# silently. openai-compatible is exempt: it has no default endpoint, so the
+# URL there is configuration, not an override.
+if [[ -n "${LLM_API_URL:-}" && "$LLM_PROVIDER" != "openai-compatible" ]]; then
+    echo "llm: warning: LLM_API_URL=$LLM_API_URL overrides the default $LLM_PROVIDER endpoint" >&2
+fi
+
 # OpenCode routing prefixes hide the real catalog id from the API side;
 # strip once, up front, so the payload builders AND get_model_max_tokens see
 # the actual model name and its caps.
@@ -359,13 +367,6 @@ get_model_max_tokens() {
             glm-*|kimi-*|qwen*|minimax-*|deepseek-*|grok-*|longcat-*|mimo-*|hy3*|muse-*|ox-alpha-*) echo 32768 ;;
             *) echo 16384 ;;
         esac
-        return
-    fi
-    # openai-compatible endpoints serve arbitrary model names the tables
-    # below cannot know, and the conservative 4096 fallback starves agentic
-    # steps. Scoped to the provider; LLM_MAX_TOKENS overrides as usual.
-    if [[ "${LLM_PROVIDER:-}" == "openai-compatible" ]]; then
-        echo 16384
         return
     fi
     case "$model" in
@@ -400,8 +401,17 @@ get_model_max_tokens() {
         # thinking. Give it the reasoning-model tier like Anthropic above.
         x-ai/grok-4*|x-ai/grok*) echo 64000 ;;
         */*) echo 16384 ;;
-        # Conservative fallback for unknown models
-        *) echo 4096 ;;
+        *)
+            # Conservative fallback for unknown models. openai-compatible
+            # endpoints serve arbitrary names the table cannot know, and
+            # 4096 starves agentic steps there; names the table does know
+            # (a proxy serving gpt-5, ...) keep their real caps above.
+            if [[ "${LLM_PROVIDER:-}" == "openai-compatible" ]]; then
+                echo 16384
+            else
+                echo 4096
+            fi
+            ;;
     esac
 }
 
@@ -982,6 +992,11 @@ _llm_cleanup() {
     return 0
 }
 trap '_llm_cleanup' EXIT
+# A typo'd provider name would otherwise surface as bash's exit-127
+# "build_payload_...: command not found" instead of an error naming the
+# problem, because payload build runs before get_url_headers' own check.
+declare -f "build_payload_${LLM_PROVIDER}" >/dev/null \
+    || die "Unknown provider: $LLM_PROVIDER (see --provider in --help for the list)"
 "build_payload_${LLM_PROVIDER}" > "$payload_file"
 
 # Get URL and headers

--- a/bin/llm
+++ b/bin/llm
@@ -1005,8 +1005,8 @@ if [[ -z "$LLM_USAGE_FILE" ]]; then
     _llm_usage_own=1
 fi
 _llm_cleanup() {
-    rm -f "$payload_file" "$payload_file.system" \
-          "$payload_file.done" "$payload_file.deadline"
+    rm -f "$payload_file"
+    if [[ -n "${_adapter_dir:-}" ]]; then rm -rf "$_adapter_dir"; fi
     if [[ "$_llm_usage_own" -eq 1 ]]; then rm -f "$LLM_USAGE_FILE"; fi
     return 0
 }
@@ -1026,12 +1026,15 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
         [[ -n "$LLM_THINKING_LEVEL" ]] && _adapter_args+=("$LLM_THINKING_LEVEL")
     fi
     [[ "$LLM_STREAM" -eq 0 ]] && _adapter_args+=(--no-stream)
+    # Private 0700 sidecar directory for the system prompt and the deadline
+    # marker files. Derived names next to a visible /tmp file would be
+    # symlink-attackable by other local users; mktemp -d gives an
+    # unpredictable name only this process can enter. Removed by the EXIT
+    # cleanup.
+    _adapter_dir=$(mktemp -d "${TMPDIR:-/tmp}/llm-adapter.XXXXXX")
     if [[ -n "$LLM_SYSTEM" ]]; then
-        # 0600 like the mktemp'd payload file: the prompt is private, and a
-        # plain redirect under the default umask would land world-readable
-        # in /tmp. Removed by the EXIT cleanup with the rest.
-        ( umask 077; printf '%s' "$LLM_SYSTEM" > "$payload_file.system" )
-        _adapter_args+=(--system-prompt-file "$payload_file.system")
+        ( umask 077; printf '%s' "$LLM_SYSTEM" > "$_adapter_dir/system" )
+        _adapter_args+=(--system-prompt-file "$_adapter_dir/system")
     fi
     # Messages travel by file + stdin redirect, not argv (size caps) and
     # not a pipe (the adapter must be a direct child so the deadline can
@@ -1040,40 +1043,54 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
     export LLM_USAGE_FILE
     _adapter_rc=0
     if [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]]; then
+        # The adapter runs in its own process group (set -m) so the
+        # deadline can kill its whole tree: a shell adapter's provider
+        # child would otherwise survive a PID-targeted kill and hold the
+        # caller's stdout open past the deadline.
+        set -m
         "$LLM_ADAPTER" "${_adapter_args[@]}" < "$payload_file" &
         _adapter_pid=$!
+        set +m
         # Deadline watcher. It polls a done-marker once a second instead of
-        # sleeping the whole deadline, so it exits within ~1s of the adapter
-        # finishing and never leaves an orphaned long sleep (a background
-        # subshell gets no process group of its own here, so the sleep
-        # could not be killed with it). It detaches from stdio so it cannot
-        # hold a $(...) caller's stdout pipe open. On expiry it writes the
-        # deadline marker — the authoritative "this run timed out" signal,
-        # regardless of how the adapter exits — then escalates TERM, 5s
-        # grace, KILL, so an adapter that ignores TERM still dies.
+        # sleeping the whole deadline, so no long sleep can be orphaned. It
+        # detaches from stdio so it cannot hold a $(...) caller's stdout
+        # pipe open. On expiry it writes the deadline marker — the
+        # authoritative "this run timed out" signal, regardless of how the
+        # adapter exits — then TERMs the group, waits a 5s grace, and
+        # KILLs the group, so an adapter that ignores TERM still dies.
+        # (An adapter finishing in the same instant the deadline fires can
+        # be reported as timed out; the done re-check narrows that window.)
         (
             _t=0
-            while [[ ! -e "$payload_file.done" && "$_t" -lt "$LLM_MAX_TIME" ]]; do
+            while [[ ! -e "$_adapter_dir/done" && "$_t" -lt "$LLM_MAX_TIME" ]]; do
                 sleep 1; _t=$((_t+1))
             done
-            if [[ ! -e "$payload_file.done" ]]; then
-                : > "$payload_file.deadline"
-                kill "$_adapter_pid" 2>/dev/null
-                _g=0
-                while [[ "$_g" -lt 5 ]] && kill -0 "$_adapter_pid" 2>/dev/null; do
-                    sleep 1; _g=$((_g+1))
-                done
-                kill -9 "$_adapter_pid" 2>/dev/null
+            if [[ ! -e "$_adapter_dir/done" ]]; then
+                : > "$_adapter_dir/deadline"
+                if [[ -e "$_adapter_dir/done" ]]; then
+                    rm -f "$_adapter_dir/deadline"
+                else
+                    kill -- -"$_adapter_pid" 2>/dev/null
+                    _g=0
+                    while [[ "$_g" -lt 5 ]] && kill -0 "$_adapter_pid" 2>/dev/null; do
+                        sleep 1; _g=$((_g+1))
+                    done
+                    kill -9 -- -"$_adapter_pid" 2>/dev/null
+                fi
             fi
         ) >/dev/null 2>&1 </dev/null &
         _adapter_watch=$!
         wait "$_adapter_pid" || _adapter_rc=$?
-        : > "$payload_file.done"
+        : > "$_adapter_dir/done"
+        # TERM the watcher rather than waiting out its poll tick — the tick
+        # would tax every successful call ~1s. Its in-flight sleep is
+        # stdio-detached and gone within a second.
+        kill "$_adapter_watch" 2>/dev/null || true
         wait "$_adapter_watch" 2>/dev/null || true
     else
         "$LLM_ADAPTER" "${_adapter_args[@]}" < "$payload_file" || _adapter_rc=$?
     fi
-    if [[ -e "$payload_file.deadline" ]]; then
+    if [[ -e "$_adapter_dir/deadline" ]]; then
         # Deadline expiry is a failure even when the adapter, tapped on the
         # shoulder by TERM, manages to exit 0 — recording ok would make the
         # health marker lie about a call that produced no usable answer.

--- a/bin/shellm
+++ b/bin/shellm
@@ -256,6 +256,12 @@ redact_sensitive() {
         output="${output//${ANTHROPIC_API_KEY}/<redacted-anthropic-key>}"
     fi
 
+    # LLM_API_KEY (openai-compatible endpoints) has no vendor prefix to
+    # pattern-match, so only value-based masking can catch it.
+    if [[ -n "${LLM_API_KEY:-}" ]]; then
+        output="${output//${LLM_API_KEY}/<redacted-api-key>}"
+    fi
+
     printf '%s' "$output" | LC_ALL=C sed -E 's/sk-ant-[A-Za-z0-9._-]+/<redacted-anthropic-key>/g'
 }
 

--- a/bin/shellm
+++ b/bin/shellm
@@ -2336,6 +2336,11 @@ exit \$__shellm_rc
             SHELLM_ENV="$(if [[ "${_SHELLM_DOCKER_MODE:-0}" -eq 1 && "$SHELLM_ALLOW_NESTED_DOCKER" != "1" ]]; then echo "local"; else echo "${_SHELLM_ACTIVE_ENV:-}"; fi)"
             _SHELLM_PARENT_CONTAINER="${_SHELLM_CONTAINER:-}"
             ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}"
+            # The generic openai-compatible provider is configured entirely by
+            # env (never auto-detected), so llm calls inside generated code
+            # need these two like they need the vendor keys above/below.
+            LLM_PROVIDER="${LLM_PROVIDER:-}"
+            LLM_API_KEY="${LLM_API_KEY:-}"
             SHELLM_MODEL="$SHELLM_MODEL"
             SHELLM_MAX_TOKENS="$SHELLM_MAX_TOKENS"
             SHELLM_MAX_ITERATIONS="$SHELLM_MAX_ITERATIONS"

--- a/design/providers.md
+++ b/design/providers.md
@@ -117,11 +117,13 @@ The contract, implemented by the invoker in `bin/llm` (pinned by
   `out_tok`, `think_tok` as integers. `bin/llm` stamps the ledger from
   it. An adapter that cannot count tokens writes nothing.
 - `bin/llm` wraps the adapter in its own wall-clock deadline
-  (`LLM_MAX_TIME`): on expiry it sends TERM, waits a 5s grace, then
-  KILLs, and reports the call as an error — even if the adapter
-  manages to exit 0 on the way down. The adapter does not need its own
-  outer timeout, but it should pass reasonable deadlines to whatever
-  it calls.
+  (`LLM_MAX_TIME`). The adapter runs in its own process group; on
+  expiry `bin/llm` TERMs the group, waits a 5s grace, then KILLs the
+  group — the adapter's children included, so nothing it spawned can
+  outlive the deadline holding stdout — and reports the call as an
+  error even if the adapter manages to exit 0 on the way down. The
+  adapter does not need its own outer timeout, but it should pass
+  reasonable deadlines to whatever it calls.
 - Retries: the invoker runs the adapter once; a nonzero exit fails the
   call, with the exit code reported and the health marker updated. An
   adapter that wants retries does its own, under the deadline above.

--- a/design/providers.md
+++ b/design/providers.md
@@ -1,0 +1,127 @@
+# Providers
+
+Status: DECIDED 2026-08-27 — the policy below governs provider additions.
+The `openai-compatible` provider is shipped; the adapter seam is
+specified here but not yet implemented.
+
+Headlong keeps getting asked to support more model providers (PR #46,
+issues #65 and #71). Each one is easy on its own, but core grows with
+every provider we absorb, and there are a lot of providers. The policy
+in this document says which providers go into core, which stay outside
+it, and what the boundary between them is.
+
+## The decision
+
+1. `bin/llm` is the only code in the repo that calls a model provider.
+   Every other tool (shellm, the thinkers, the bridges, the web dash)
+   makes completions through it. Code elsewhere that calls a provider
+   endpoint directly is wrong, with one standing exception: the dash
+   reads OpenRouter's catalog and credit endpoints for display, which
+   is not a completion path.
+
+2. Core supports providers that speak plain HTTP and JSON. Most of them
+   are covered by the generic `openai-compatible` provider, which is
+   configured with a URL, a model name, and an optional key. After
+   that, supporting a new compatible provider (Ollama, vLLM, LM Studio,
+   Together, a corporate proxy) is a documentation entry, not code. A
+   provider with a genuinely different wire format (the way Gemini has
+   one) can still be added to core, but that is a maintainer decision,
+   and the bar is high because the generic provider covers so much.
+
+3. A provider that needs a subprocess, another language, an SDK, or
+   auth that is not a key in a header lives outside core, behind the
+   adapter contract below. The adapter carries its own dependencies.
+   Core never gains a runtime dependency on an interpreter because of a
+   provider.
+
+4. Installer prompts, dash panels, and other integration beyond the
+   completion path are decided per provider, case by case. Completion
+   support is cheap and open; deeper integration is earned. An adapter
+   gets no installer or dash integration by default.
+
+## The openai-compatible provider
+
+The provider is never auto-detected, because arbitrary model names
+(`qwen3:8b`, `llama3.2`) imply nothing. Name it explicitly and give it
+a URL:
+
+```bash
+LLM_PROVIDER=openai-compatible \
+LLM_API_URL=http://localhost:11434/v1/chat/completions \
+llm -m qwen3:8b "hello"
+```
+
+| Variable | Meaning |
+|---|---|
+| `LLM_PROVIDER=openai-compatible` | Selects the provider (or pass `--provider openai-compatible`) |
+| `LLM_API_URL` | The chat-completions endpoint. Required, no default |
+| `LLM_API_KEY` | Optional. When set, sent as `Authorization: Bearer` |
+
+Everything else in `bin/llm` applies unchanged: streaming, retries,
+network guards, truncation warnings, the usage ledger, and the health
+marker. Unknown model names get a 16384 default output cap under this
+provider (the global 4096 fallback starves agentic steps);
+`LLM_MAX_TOKENS` or `-t` overrides it.
+
+Inside the Docker sandbox, `localhost` is the container, not the host.
+A local inference server running on the host is reached at
+`host.docker.internal` on macOS, or the docker bridge address on Linux.
+
+## The adapter contract
+
+An adapter is one executable that turns a completion request into
+provider output. `bin/llm` will run it in place of curl when the
+operator configures it:
+
+```bash
+LLM_PROVIDER=adapter
+LLM_ADAPTER=/path/to/executable
+```
+
+The contract, which the invoker in `bin/llm` will implement:
+
+- `bin/llm` runs `$LLM_ADAPTER` with these flags: `--model NAME`,
+  `--max-tokens N`, and, when set, `--effort LEVEL`, `--thinking
+  [LEVEL]`, and `--no-stream`. The system prompt arrives via
+  `--system-prompt-file PATH`. The messages array (the same JSON shape
+  `llm -M` takes) arrives on stdin.
+- The adapter writes response text to stdout, streamed as it is
+  produced, and diagnostics to stderr. It exits 0 on success and
+  nonzero on failure with a one-line reason on stderr. It must not
+  print partial text and then exit nonzero unless the failure really
+  happened mid-generation.
+- Usage reporting: when the environment carries `LLM_USAGE_FILE`, the
+  adapter writes one JSON object to that path, with any of `in_tok`,
+  `out_tok`, `think_tok` as integers. `bin/llm` stamps the ledger from
+  it. An adapter that cannot count tokens writes nothing.
+- `bin/llm` wraps the adapter in its own wall-clock deadline
+  (`LLM_MAX_TIME`), kills it on expiry, and reports that as an error.
+  The adapter does not need its own outer timeout, but it should pass
+  reasonable deadlines to whatever it calls.
+- Retries stay in `bin/llm` and follow the existing rule: a nonzero
+  exit before any stdout bytes is retryable, and nothing is retried
+  after output has been emitted.
+- The health marker (`llm_health.json`) is written by `bin/llm` from
+  the exit status, never by the adapter, and `ok` is only recorded
+  after the adapter exits 0.
+- Sandbox: the adapter path is resolved through symlinks the way
+  `bin/shellm` resolves its own location, and it must exist inside the
+  container for sandboxed callers, which means the operator mounts it.
+  A missing adapter fails with a clear message before anything runs.
+
+Language, dependencies, packaging, and auth storage are the adapter's
+business. An adapter that needs `python3`, an npm package, or a
+logged-in vendor CLI declares that in its own documentation, and a
+machine without those things loses that adapter and nothing else.
+
+## Why the line is drawn here
+
+The completion path is one choke point, so an adapter seam in `bin/llm`
+covers every caller at once. The expensive part of an in-core provider
+was never the payload builder, which for OpenAI-compatible providers is
+a one-line alias. The expensive part is everything around it: the
+installer's key detection and default-model tables, the dash's model
+config, the sandbox mount list, the docs, and the review surface of new
+code on the path every thought travels. Keeping core to "HTTP and JSON,
+one generic entry for the compatible majority" caps that cost at
+roughly its current size while keeping every provider reachable.

--- a/design/providers.md
+++ b/design/providers.md
@@ -1,8 +1,8 @@
 # Providers
 
 Status: DECIDED 2026-08-27 — the policy below governs provider additions.
-The `openai-compatible` provider is shipped; the adapter seam is
-specified here but not yet implemented.
+The `openai-compatible` provider and the adapter seam are both
+implemented in `bin/llm`.
 
 Headlong keeps getting asked to support more model providers (PR #46,
 issues #65 and #71). Each one is easy on its own, but core grows with
@@ -19,14 +19,18 @@ it, and what the boundary between them is.
    reads OpenRouter's catalog and credit endpoints for display, which
    is not a completion path.
 
-2. Core supports providers that speak plain HTTP and JSON. Most of them
-   are covered by the generic `openai-compatible` provider, which is
-   configured with a URL, a model name, and an optional key. After
-   that, supporting a new compatible provider (Ollama, vLLM, LM Studio,
-   Together, a corporate proxy) is a documentation entry, not code. A
-   provider with a genuinely different wire format (the way Gemini has
-   one) can still be added to core, but that is a maintainer decision,
-   and the bar is high because the generic provider covers so much.
+2. Core supports a provider when its wire protocol can be implemented
+   and tested with a small bash, curl, and jq path — no other runtime,
+   no SDK, no auth beyond a header. ("Plain HTTP and JSON" alone is
+   too broad a test; nearly every provider meets it.) Most qualifying
+   providers are covered by the generic `openai-compatible` provider,
+   which is configured with a URL, a model name, and an optional key.
+   After that, supporting a new compatible provider (Ollama, vLLM, LM
+   Studio, Together, a corporate proxy) is a documentation entry, not
+   code. A provider with a genuinely different wire format (the way
+   Gemini has one) can still be added to core, but that is a maintainer
+   decision, and the bar is high because the generic provider covers so
+   much.
 
 3. A provider that needs a subprocess, another language, an SDK, or
    auth that is not a key in a header lives outside core, behind the
@@ -57,6 +61,23 @@ llm -m qwen3:8b "hello"
 | `LLM_API_URL` | The chat-completions endpoint. Required, no default |
 | `LLM_API_KEY` | Optional. When set, sent as `Authorization: Bearer` |
 
+What "compatible" means here, concretely: a chat-completions endpoint
+that accepts `model`, `messages`, and `max_tokens`; non-streaming
+responses carrying the text at `choices[0].message.content`; streaming
+as SSE `data:` lines with deltas at `choices[0].delta.content`, ended
+by `data: [DONE]`; and errors as non-2xx responses with a JSON body.
+That subset is what the code exercises and the tests pin. An endpoint
+that diverges from it is best effort — it may well work, but the
+divergence is not a core bug to absorb.
+
+`LLM_PROVIDER` is process-wide by design (decided 2026-08-26:
+environment overrides are authoritative, never pattern-guessed around),
+so selecting `openai-compatible` routes every completion in the
+deployment — the main model, the responder, recap, memory search —
+through the one endpoint. A mixed setup (a hosted main model plus a
+cheap local one) needs an endpoint that proxies both models, or
+per-call environment in the caller; there is no per-model routing.
+
 Everything else in `bin/llm` applies unchanged: streaming, retries,
 network guards, truncation warnings, the usage ledger, and the health
 marker. Unknown model names get a 16384 default output cap under this
@@ -70,15 +91,16 @@ A local inference server running on the host is reached at
 ## The adapter contract
 
 An adapter is one executable that turns a completion request into
-provider output. `bin/llm` will run it in place of curl when the
-operator configures it:
+provider output. `bin/llm` runs it in place of curl when the operator
+configures it:
 
 ```bash
 LLM_PROVIDER=adapter
 LLM_ADAPTER=/path/to/executable
 ```
 
-The contract, which the invoker in `bin/llm` will implement:
+The contract, implemented by the invoker in `bin/llm` (pinned by
+`tests/test_llm_adapter.sh`):
 
 - `bin/llm` runs `$LLM_ADAPTER` with these flags: `--model NAME`,
   `--max-tokens N`, and, when set, `--effort LEVEL`, `--thinking
@@ -98,16 +120,19 @@ The contract, which the invoker in `bin/llm` will implement:
   (`LLM_MAX_TIME`), kills it on expiry, and reports that as an error.
   The adapter does not need its own outer timeout, but it should pass
   reasonable deadlines to whatever it calls.
-- Retries stay in `bin/llm` and follow the existing rule: a nonzero
-  exit before any stdout bytes is retryable, and nothing is retried
-  after output has been emitted.
+- Retries: the invoker runs the adapter once; a nonzero exit fails the
+  call, with the exit code reported and the health marker updated. An
+  adapter that wants retries does its own, under the deadline above.
+  (The curl path's rule — retry only when nothing was emitted — can
+  extend to adapters later if a real need shows up.)
 - The health marker (`llm_health.json`) is written by `bin/llm` from
   the exit status, never by the adapter, and `ok` is only recorded
   after the adapter exits 0.
-- Sandbox: the adapter path is resolved through symlinks the way
-  `bin/shellm` resolves its own location, and it must exist inside the
-  container for sandboxed callers, which means the operator mounts it.
-  A missing adapter fails with a clear message before anything runs.
+- Sandbox: `LLM_ADAPTER` is used as given, and it must name an
+  executable that exists inside the container for sandboxed callers,
+  which means the operator mounts it at the same path. A missing or
+  non-executable adapter fails with a clear message before anything
+  runs.
 
 Language, dependencies, packaging, and auth storage are the adapter's
 business. An adapter that needs `python3`, an npm package, or a

--- a/design/providers.md
+++ b/design/providers.md
@@ -117,9 +117,11 @@ The contract, implemented by the invoker in `bin/llm` (pinned by
   `out_tok`, `think_tok` as integers. `bin/llm` stamps the ledger from
   it. An adapter that cannot count tokens writes nothing.
 - `bin/llm` wraps the adapter in its own wall-clock deadline
-  (`LLM_MAX_TIME`), kills it on expiry, and reports that as an error.
-  The adapter does not need its own outer timeout, but it should pass
-  reasonable deadlines to whatever it calls.
+  (`LLM_MAX_TIME`): on expiry it sends TERM, waits a 5s grace, then
+  KILLs, and reports the call as an error — even if the adapter
+  manages to exit 0 on the way down. The adapter does not need its own
+  outer timeout, but it should pass reasonable deadlines to whatever
+  it calls.
 - Retries: the invoker runs the adapter once; a nonzero exit fails the
   call, with the exit code reported and the health marker updated. An
   adapter that wants retries does its own, under the deadline above.
@@ -133,6 +135,11 @@ The contract, implemented by the invoker in `bin/llm` (pinned by
   which means the operator mounts it at the same path. A missing or
   non-executable adapter fails with a clear message before anything
   runs.
+
+An adapter is trusted local code. `bin/llm` runs it with the caller's
+full environment, provider keys included — there is no isolation
+between an adapter and the process that invokes it. Point
+`LLM_ADAPTER` only at code you trust as much as `bin/llm` itself.
 
 Language, dependencies, packaging, and auth storage are the adapter's
 business. An adapter that needs `python3`, an npm package, or a

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -293,9 +293,11 @@ which providers live in core is in
 [design/providers.md](../design/providers.md).
 
 Under shellm, set `SHELLM_API_URL` instead of `LLM_API_URL` — shellm
-clears any inherited `LLM_API_URL` and re-exports it only from
-`SHELLM_API_URL` — and name the model, or shellm falls back to its
-default Claude model and sends that to your endpoint:
+clears any inherited `LLM_API_URL`, and `llm` itself falls back to
+`SHELLM_API_URL` for this provider, so thinkers and other tools that
+call `llm` directly reach the endpoint too. Name the model as well, or
+shellm falls back to its default Claude model and sends that to your
+endpoint:
 
 ```bash
 LLM_PROVIDER=openai-compatible \

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -294,20 +294,19 @@ which providers live in core is in
 
 Under shellm, set `SHELLM_API_URL` instead of `LLM_API_URL` — shellm
 clears any inherited `LLM_API_URL` and re-exports it only from
-`SHELLM_API_URL`, so the bare recipe above fails on every reasoning
-step:
+`SHELLM_API_URL` — and name the model, or shellm falls back to its
+default Claude model and sends that to your endpoint:
 
 ```bash
 LLM_PROVIDER=openai-compatible \
 SHELLM_API_URL=http://localhost:11434/v1/chat/completions \
+SHELLM_MODEL=qwen3:8b \
 shellm "what os is this?"
 ```
 
-One more caveat: generated code running in the sandbox receives the URL
-but not `LLM_PROVIDER` or `LLM_API_KEY`, so `llm` calls *inside*
-generated code fall back to auto-detection and fail without a provider
-key. If the generated code itself needs the endpoint, forward them
-explicitly with `--var LLM_PROVIDER --var LLM_API_KEY`.
+`LLM_PROVIDER` and `LLM_API_KEY` are forwarded into the sandbox and to
+nested shellm runs the same way the vendor keys are, so `llm` calls
+inside generated code reach the endpoint too.
 
 **Output contract:** stdout = text response, stderr = thinking tokens (Anthropic only), exit 0 = success. This makes it composable with pipes and subshells.
 

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -310,6 +310,12 @@ shellm "what os is this?"
 nested shellm runs the same way the vendor keys are, so `llm` calls
 inside generated code reach the endpoint too.
 
+A provider that can't speak this protocol (an SDK, a vendor CLI,
+signed requests) runs outside core as an adapter: set
+`LLM_PROVIDER=adapter` and `LLM_ADAPTER=/path/to/executable`, and
+`llm` runs that executable in place of curl. The adapter contract is
+in [design/providers.md](../design/providers.md).
+
 **Output contract:** stdout = text response, stderr = thinking tokens (Anthropic only), exit 0 = success. This makes it composable with pipes and subshells.
 
 ## mem and skills

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -278,6 +278,20 @@ llm -m claude-opus-4-7 -M '[{"role":"user","content":"hi"},{"role":"assistant","
 | `gemini-*` | Gemini (`GEMINI_API_KEY`) |
 | `vendor/model` (any slash) | OpenRouter (`OPENROUTER_API_KEY`) |
 
+Any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, a proxy) works
+through the `openai-compatible` provider, with no API key required. It is
+never auto-detected, so name it and give it a URL:
+
+```bash
+LLM_PROVIDER=openai-compatible \
+LLM_API_URL=http://localhost:11434/v1/chat/completions \
+llm -m qwen3:8b "hello"
+```
+
+Set `LLM_API_KEY` if the endpoint wants a bearer token. The policy for
+which providers live in core is in
+[design/providers.md](../design/providers.md).
+
 **Output contract:** stdout = text response, stderr = thinking tokens (Anthropic only), exit 0 = success. This makes it composable with pipes and subshells.
 
 ## mem and skills

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -292,6 +292,23 @@ Set `LLM_API_KEY` if the endpoint wants a bearer token. The policy for
 which providers live in core is in
 [design/providers.md](../design/providers.md).
 
+Under shellm, set `SHELLM_API_URL` instead of `LLM_API_URL` — shellm
+clears any inherited `LLM_API_URL` and re-exports it only from
+`SHELLM_API_URL`, so the bare recipe above fails on every reasoning
+step:
+
+```bash
+LLM_PROVIDER=openai-compatible \
+SHELLM_API_URL=http://localhost:11434/v1/chat/completions \
+shellm "what os is this?"
+```
+
+One more caveat: generated code running in the sandbox receives the URL
+but not `LLM_PROVIDER` or `LLM_API_KEY`, so `llm` calls *inside*
+generated code fall back to auto-detection and fail without a provider
+key. If the generated code itself needs the endpoint, forward them
+explicitly with `--var LLM_PROVIDER --var LLM_API_KEY`.
+
 **Output contract:** stdout = text response, stderr = thinking tokens (Anthropic only), exit 0 = success. This makes it composable with pipes and subshells.
 
 ## mem and skills

--- a/philosophy.md
+++ b/philosophy.md
@@ -205,7 +205,7 @@ or `./install.sh` from a checkout. The core needs nothing but bash, curl, jq, an
 
 Here's how I think about whether an agent architecture is on the right track. I call it the Thompson test, after Ken:
 
-1. **Can you understand every component in an afternoon?** Each of these tools is a single bash script. The whole core — the executables the mind runs plus the thinkers — is under 10K lines, and shellm, the largest, is under 3K. You can read every line of code that comprises the entire agent.
+1. **Can you understand every component in an afternoon?** Each of these tools is a single bash script. The whole core — the executables the mind runs plus the thinkers — is about 10K lines, and shellm, the largest, is under 3K. You can read every line of code that comprises the entire agent.
 
 2. **Can you compose the pieces in ways the author didn't anticipate?** mem is just a CLI that manages files. You can pipe its output into anything. Skills are markdown files — editable, greppable, version-controllable. shellm can call itself. None of these composition patterns were "designed in" — they fall out of the Unix interface naturally.
 

--- a/tests/test_llm_adapter.sh
+++ b/tests/test_llm_adapter.sh
@@ -14,6 +14,9 @@
 #   - -s reaches the adapter via --system-prompt-file
 #   - --no-stream, --effort, and --thinking LEVEL are forwarded
 #   - LLM_USAGE_FILE reaches the adapter and its usage lands in the ledger
+#   - the system-prompt tempfile is mode 0600 (private prompt in /tmp)
+#   - LLM_MAX_TIME is a hard deadline: TERM, 5s grace, then KILL — and a
+#     deadline expiry fails the call even if the adapter exits 0 on TERM
 #   - missing LLM_ADAPTER dies loudly; a non-executable path dies loudly
 #   - a nonzero adapter exit fails the call with the adapter's exit code
 #     reported, and the health marker records the error
@@ -42,7 +45,10 @@ printf '%s\n' "$@" >> "$ADAPTER_ARGS"
 cat > "$ADAPTER_STDIN"
 prev=""
 for a in "$@"; do
-    [[ "$prev" == "--system-prompt-file" ]] && cat "$a" > "$ADAPTER_SYS"
+    if [[ "$prev" == "--system-prompt-file" ]]; then
+        cat "$a" > "$ADAPTER_SYS"
+        { stat -c %a "$a" 2>/dev/null || stat -f %Lp "$a"; } > "$ADAPTER_SYS_MODE"
+    fi
     prev="$a"
 done
 if [[ -n "${ADAPTER_USAGE:-}" && -n "${LLM_USAGE_FILE:-}" ]]; then
@@ -61,6 +67,7 @@ mkdir -p "$HEADLONG_HOME"
 export ADAPTER_ARGS="$WORK/adapter_args"
 export ADAPTER_STDIN="$WORK/adapter_stdin"
 export ADAPTER_SYS="$WORK/adapter_sys"
+export ADAPTER_SYS_MODE="$WORK/adapter_sys_mode"
 export LLM_RETRIES=0
 unset ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
       OPENCODE_API_KEY LLM_API_KEY LLM_PROVIDER LLM_API_URL LLM_MODEL \
@@ -123,6 +130,11 @@ if [[ "$(cat "$ADAPTER_SYS")" == "be brief" ]]; then
 else
     bad "-s reaches the adapter via --system-prompt-file" "$(cat "$ADAPTER_SYS")"
 fi
+if [[ "$(cat "$ADAPTER_SYS_MODE")" == "600" ]]; then
+    ok "system prompt tempfile is mode 0600"
+else
+    bad "system prompt tempfile is mode 0600" "mode=$(cat "$ADAPTER_SYS_MODE")"
+fi
 if grep -qx -- "--no-stream" "$ADAPTER_ARGS"; then
     ok "--no-stream is forwarded"
 else
@@ -177,6 +189,56 @@ if [[ "$rc" -ne 0 ]] && grep -q 'not executable' "$WORK/stderr"; then
     ok "non-executable LLM_ADAPTER dies loudly"
 else
     bad "non-executable LLM_ADAPTER dies loudly" "rc=$rc"
+fi
+
+# ---------------------------------------------------------------------------
+# The LLM_MAX_TIME deadline is hard
+# ---------------------------------------------------------------------------
+
+# An adapter that traps TERM and exits 0 must still be reported as a
+# deadline failure — a post-deadline exit 0 recording ok would make the
+# health marker lie about a call that produced no answer.
+cat > "$WORK/adapter-trap-term" <<'EOF'
+#!/usr/bin/env bash
+trap 'kill "$spid" 2>/dev/null; exit 0' TERM
+sleep 30 & spid=$!
+wait "$spid"
+EOF
+chmod +x "$WORK/adapter-trap-term"
+
+reset
+LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter-trap-term" LLM_MAX_TIME=1 \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'LLM_MAX_TIME deadline' "$WORK/stderr"; then
+    ok "deadline expiry fails the call even when the adapter exits 0 on TERM"
+else
+    bad "deadline expiry fails the call even when the adapter exits 0 on TERM" "rc=$rc: $(head -1 "$WORK/stderr")"
+fi
+if jq -e '.ok == false' "$HEADLONG_HOME/run/llm_health.json" >/dev/null 2>&1; then
+    ok "deadline failure is recorded in the health marker"
+else
+    bad "deadline failure is recorded in the health marker" "$(cat "$HEADLONG_HOME/run/llm_health.json" 2>/dev/null)"
+fi
+
+# An adapter that ignores TERM entirely is KILLed after the grace period.
+cat > "$WORK/adapter-ignore-term" <<'EOF'
+#!/usr/bin/env bash
+trap '' TERM
+sleep 30
+EOF
+chmod +x "$WORK/adapter-ignore-term"
+
+reset
+_t0=$(date +%s)
+LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter-ignore-term" LLM_MAX_TIME=1 \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+rc=$?
+_elapsed=$(( $(date +%s) - _t0 ))
+if [[ "$rc" -ne 0 && "$_elapsed" -lt 15 ]] && grep -q 'LLM_MAX_TIME deadline' "$WORK/stderr"; then
+    ok "a TERM-ignoring adapter is KILLed within the grace period"
+else
+    bad "a TERM-ignoring adapter is KILLed within the grace period" "rc=$rc elapsed=${_elapsed}s: $(head -1 "$WORK/stderr")"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_adapter.sh
+++ b/tests/test_llm_adapter.sh
@@ -241,6 +241,43 @@ else
     bad "a TERM-ignoring adapter is KILLed within the grace period" "rc=$rc elapsed=${_elapsed}s: $(head -1 "$WORK/stderr")"
 fi
 
+# The deadline kills the adapter's whole process group: a child the adapter
+# spawned would otherwise survive and hold stdout open, blocking a $(...)
+# caller (thinkers use command substitution) long past the deadline.
+cat > "$WORK/adapter-with-child" <<'EOF'
+#!/usr/bin/env bash
+trap '' TERM
+sleep 30 &
+wait
+EOF
+chmod +x "$WORK/adapter-with-child"
+
+reset
+_t0=$(date +%s)
+out=$(LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter-with-child" LLM_MAX_TIME=1 \
+      "$LLM" -m qwen3:8b "say ok" 2>"$WORK/stderr")
+rc=$?
+_elapsed=$(( $(date +%s) - _t0 ))
+if [[ "$rc" -ne 0 && "$_elapsed" -lt 15 ]]; then
+    ok "the adapter's children die with it (stdout not held past the deadline)"
+else
+    bad "the adapter's children die with it (stdout not held past the deadline)" "rc=$rc elapsed=${_elapsed}s"
+fi
+
+# A fast adapter pays no watcher tick: two calls, well under a second each.
+reset
+_t0=$(date +%s)
+LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter" \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>&1
+LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter" \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>&1
+_elapsed=$(( $(date +%s) - _t0 ))
+if [[ "$_elapsed" -lt 2 ]]; then
+    ok "successful calls do not wait out the watcher tick"
+else
+    bad "successful calls do not wait out the watcher tick" "2 calls took ${_elapsed}s"
+fi
+
 # ---------------------------------------------------------------------------
 # A failing adapter fails the call and marks health
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_adapter.sh
+++ b/tests/test_llm_adapter.sh
@@ -241,13 +241,14 @@ else
     bad "a TERM-ignoring adapter is KILLed within the grace period" "rc=$rc elapsed=${_elapsed}s: $(head -1 "$WORK/stderr")"
 fi
 
-# The deadline kills the adapter's whole process group: a child the adapter
-# spawned would otherwise survive and hold stdout open, blocking a $(...)
-# caller (thinkers use command substitution) long past the deadline.
+# The deadline kills the adapter's whole process group even when the group
+# leader exits cleanly on TERM while a child ignores it. Stopping the watcher
+# when the leader exits would let that child hold stdout open and block a
+# $(...) caller (thinkers use command substitution) past the deadline.
 cat > "$WORK/adapter-with-child" <<'EOF'
 #!/usr/bin/env bash
-trap '' TERM
-sleep 30 &
+trap 'exit 0' TERM
+bash -c 'trap "" TERM; sleep 30' &
 wait
 EOF
 chmod +x "$WORK/adapter-with-child"

--- a/tests/test_llm_adapter.sh
+++ b/tests/test_llm_adapter.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# test_llm_adapter.sh — the adapter seam (LLM_PROVIDER=adapter + LLM_ADAPTER)
+#
+# Usage: tests/test_llm_adapter.sh
+#
+# A stub adapter records its argv, its stdin, and the system-prompt file it
+# is handed, then answers on stdout — so this checks the invoker side of the
+# contract in design/providers.md without any real provider. The cases:
+#
+#   - the adapter runs and its stdout is llm's stdout
+#   - --model and --max-tokens are always passed; unknown names get the
+#     16384 fallback cap and -t overrides it
+#   - the messages JSON arrives on stdin
+#   - -s reaches the adapter via --system-prompt-file
+#   - --no-stream, --effort, and --thinking LEVEL are forwarded
+#   - LLM_USAGE_FILE reaches the adapter and its usage lands in the ledger
+#   - missing LLM_ADAPTER dies loudly; a non-executable path dies loudly
+#   - a nonzero adapter exit fails the call with the adapter's exit code
+#     reported, and the health marker records the error
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+# --- stub adapter ------------------------------------------------------------
+# Records argv to $ADAPTER_ARGS (one per line) and stdin to $ADAPTER_STDIN.
+# Copies the --system-prompt-file target to $ADAPTER_SYS (the real file is a
+# tempfile llm removes). Writes usage JSON when ADAPTER_USAGE is set. Answers
+# "adapter says ok", or exits $ADAPTER_RC.
+cat > "$WORK/adapter" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >> "$ADAPTER_ARGS"
+cat > "$ADAPTER_STDIN"
+prev=""
+for a in "$@"; do
+    [[ "$prev" == "--system-prompt-file" ]] && cat "$a" > "$ADAPTER_SYS"
+    prev="$a"
+done
+if [[ -n "${ADAPTER_USAGE:-}" && -n "${LLM_USAGE_FILE:-}" ]]; then
+    printf '%s' "$ADAPTER_USAGE" > "$LLM_USAGE_FILE"
+fi
+if [[ "${ADAPTER_RC:-0}" -ne 0 ]]; then
+    echo "stub adapter failing on purpose" >&2
+    exit "$ADAPTER_RC"
+fi
+printf 'adapter says ok'
+EOF
+chmod +x "$WORK/adapter"
+
+export HEADLONG_HOME="$WORK/home"   # bin/llm writes run/llm_health.json here
+mkdir -p "$HEADLONG_HOME"
+export ADAPTER_ARGS="$WORK/adapter_args"
+export ADAPTER_STDIN="$WORK/adapter_stdin"
+export ADAPTER_SYS="$WORK/adapter_sys"
+export LLM_RETRIES=0
+unset ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
+      OPENCODE_API_KEY LLM_API_KEY LLM_PROVIDER LLM_API_URL LLM_MODEL \
+      LLM_MAX_TOKENS SHELLM_MODEL SHELLM_API_URL LLM_ADAPTER \
+      ADAPTER_USAGE ADAPTER_RC LLM_USAGE_FILE LLM_USAGE_LEDGER
+cd "$WORK" || exit 1
+
+LLM="$REPO/bin/llm"
+
+reset() { : > "$ADAPTER_ARGS"; : > "$ADAPTER_STDIN"; : > "$ADAPTER_SYS"; }
+
+has_arg_pair() {  # has_arg_pair FLAG VALUE — argv is recorded one per line
+    grep -A1 -x -- "$1" "$ADAPTER_ARGS" | tail -1 | grep -qx -- "$2"
+}
+
+# ---------------------------------------------------------------------------
+# The adapter runs, stdout passes through, flags carry model and cap
+# ---------------------------------------------------------------------------
+
+reset
+out=$(LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter" \
+      "$LLM" -m qwen3:8b "say ok" 2>"$WORK/stderr")
+rc=$?
+if [[ "$rc" -eq 0 && "$out" == "adapter says ok" ]]; then
+    ok "adapter runs and its stdout is llm's stdout"
+else
+    bad "adapter runs and its stdout is llm's stdout" "rc=$rc: $(head -1 "$WORK/stderr")"
+fi
+if has_arg_pair "--model" "qwen3:8b"; then
+    ok "--model is passed"
+else
+    bad "--model is passed" "$(tr '\n' ' ' < "$ADAPTER_ARGS")"
+fi
+if has_arg_pair "--max-tokens" "16384"; then
+    ok "unknown model gets the 16384 fallback cap"
+else
+    bad "unknown model gets the 16384 fallback cap" "$(tr '\n' ' ' < "$ADAPTER_ARGS")"
+fi
+if jq -e '.[0].role == "user" and (.[0].content | contains("say ok"))' "$ADAPTER_STDIN" >/dev/null 2>&1; then
+    ok "messages JSON arrives on stdin"
+else
+    bad "messages JSON arrives on stdin" "$(head -c 120 "$ADAPTER_STDIN")"
+fi
+
+# ---------------------------------------------------------------------------
+# -t override, system prompt, --no-stream, --effort, --thinking LEVEL
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter" \
+    "$LLM" -t 512 -m qwen3:8b -s "be brief" --no-stream \
+    --effort low --thinking high "say ok" >/dev/null 2>"$WORK/stderr"
+if has_arg_pair "--max-tokens" "512"; then
+    ok "-t overrides the cap"
+else
+    bad "-t overrides the cap" "$(tr '\n' ' ' < "$ADAPTER_ARGS")"
+fi
+if [[ "$(cat "$ADAPTER_SYS")" == "be brief" ]]; then
+    ok "-s reaches the adapter via --system-prompt-file"
+else
+    bad "-s reaches the adapter via --system-prompt-file" "$(cat "$ADAPTER_SYS")"
+fi
+if grep -qx -- "--no-stream" "$ADAPTER_ARGS"; then
+    ok "--no-stream is forwarded"
+else
+    bad "--no-stream is forwarded"
+fi
+if has_arg_pair "--effort" "low"; then
+    ok "--effort is forwarded"
+else
+    bad "--effort is forwarded" "$(tr '\n' ' ' < "$ADAPTER_ARGS")"
+fi
+if has_arg_pair "--thinking" "high"; then
+    ok "--thinking LEVEL is forwarded"
+else
+    bad "--thinking LEVEL is forwarded" "$(tr '\n' ' ' < "$ADAPTER_ARGS")"
+fi
+
+# ---------------------------------------------------------------------------
+# Usage lands in the ledger
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter" \
+    ADAPTER_USAGE='{"in_tok":11,"out_tok":22}' \
+    LLM_USAGE_LEDGER="$WORK/ledger.jsonl" \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+if grep -q '"in_tok":11' "$WORK/ledger.jsonl" 2>/dev/null \
+   && grep -q '"provider":"adapter"' "$WORK/ledger.jsonl"; then
+    ok "adapter usage lands in the ledger"
+else
+    bad "adapter usage lands in the ledger" "$(head -1 "$WORK/ledger.jsonl" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# Missing and non-executable adapters die loudly
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=adapter "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'LLM_ADAPTER is not set' "$WORK/stderr"; then
+    ok "missing LLM_ADAPTER dies loudly"
+else
+    bad "missing LLM_ADAPTER dies loudly" "rc=$rc"
+fi
+
+reset
+: > "$WORK/not-exec"
+LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/not-exec" \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'not executable' "$WORK/stderr"; then
+    ok "non-executable LLM_ADAPTER dies loudly"
+else
+    bad "non-executable LLM_ADAPTER dies loudly" "rc=$rc"
+fi
+
+# ---------------------------------------------------------------------------
+# A failing adapter fails the call and marks health
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter" ADAPTER_RC=3 \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'adapter exited 3' "$WORK/stderr"; then
+    ok "nonzero adapter exit fails the call with the code reported"
+else
+    bad "nonzero adapter exit fails the call with the code reported" "rc=$rc: $(head -1 "$WORK/stderr")"
+fi
+if jq -e '.ok == false' "$HEADLONG_HOME/run/llm_health.json" >/dev/null 2>&1; then
+    ok "adapter failure is recorded in the health marker"
+else
+    bad "adapter failure is recorded in the health marker" "$(cat "$HEADLONG_HOME/run/llm_health.json" 2>/dev/null)"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_llm_openai_compatible.sh
+++ b/tests/test_llm_openai_compatible.sh
@@ -20,7 +20,8 @@
 #     provider (a proxy serving gpt-5 must not silently drop to 16384)
 #   - a typo'd provider name dies with "Unknown provider", not bash's
 #     exit-127 "command not found"
-#   - LLM_API_URL on a keyed provider warns on stderr (openai-compatible
+#   - LLM_API_URL on a keyed provider warns on stderr, naming only the
+#     host — never credentials the URL may carry (openai-compatible
 #     itself is exempt: the URL there is required configuration)
 
 set -uo pipefail
@@ -210,10 +211,23 @@ fi
 reset
 LLM_PROVIDER=openai LLM_API_URL="$URL" OPENAI_API_KEY="sekrit" \
     "$LLM" -m gpt-4o "say ok" >/dev/null 2>"$WORK/stderr"
-if grep -q 'LLM_API_URL=.*overrides the default openai endpoint' "$WORK/stderr"; then
+if grep -q 'LLM_API_URL overrides the default openai endpoint (requests go to 127.0.0.1:9)' "$WORK/stderr"; then
     ok "LLM_API_URL on a keyed provider warns on stderr"
 else
     bad "LLM_API_URL on a keyed provider warns on stderr" "$(head -1 "$WORK/stderr")"
+fi
+
+# The warning names the host only: credentials a URL can carry (userinfo,
+# query tokens) must not reach stderr.
+reset
+LLM_PROVIDER=openai LLM_API_URL="http://user:hunter2@127.0.0.1:9/v1?token=topsecret" \
+    OPENAI_API_KEY="sekrit" \
+    "$LLM" -m gpt-4o "say ok" >/dev/null 2>"$WORK/stderr"
+if grep -q 'requests go to 127.0.0.1:9' "$WORK/stderr" \
+   && ! grep -q 'hunter2\|topsecret' "$WORK/stderr"; then
+    ok "URL credentials stay out of the warning"
+else
+    bad "URL credentials stay out of the warning" "$(grep -m1 'LLM_API_URL' "$WORK/stderr")"
 fi
 
 reset

--- a/tests/test_llm_openai_compatible.sh
+++ b/tests/test_llm_openai_compatible.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# test_llm_openai_compatible.sh — the generic openai-compatible provider
+#
+# Usage: tests/test_llm_openai_compatible.sh
+#
+# curl is stubbed (it records its arguments and the payload it was handed,
+# and answers with a minimal SSE stream or JSON body), so this checks the
+# provider branch without touching the network. The cases that matter:
+#
+#   - the provider works with NO API key of any kind set (the point of it:
+#     Ollama and friends need no key, and no dummy key masquerade either)
+#   - no Authorization header is sent when LLM_API_KEY is unset
+#   - LLM_API_KEY, when set, is sent as a Bearer token
+#   - LLM_API_URL is required: without it the call dies loudly
+#   - --provider openai-compatible works the same as the env var
+#   - the non-streaming path answers too
+#   - unknown model names default to the provider's 16384 output cap,
+#     and -t still overrides it
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+# --- curl stub ---------------------------------------------------------------
+# Records every argument in $CURL_ARGS and copies the -d @file payload to
+# $CURL_PAYLOAD (the real payload tempfile is gone by the time the test can
+# look), then answers with one SSE chunk plus [DONE], or a JSON body on the
+# non-streaming (-o) path.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >> "$CURL_ARGS"
+out_file=""
+prev=""
+for a in "$@"; do
+    [[ "$prev" == "-o" ]] && out_file="$a"
+    [[ "$prev" == "-d" && "$a" == @* ]] && cat "${a#@}" > "$CURL_PAYLOAD"
+    prev="$a"
+done
+if [[ -n "$out_file" ]]; then
+    printf '{"choices":[{"message":{"content":"ok"}}]}' > "$out_file"
+    printf '200'
+else
+    printf 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+    printf 'data: [DONE]\n'
+fi
+EOF
+chmod +x "$WORK/bin/curl"
+export PATH="$WORK/bin:$PATH"
+
+export HEADLONG_HOME="$WORK/home"   # bin/llm writes run/llm_health.json here
+mkdir -p "$HEADLONG_HOME"
+export CURL_ARGS="$WORK/curl_args"
+export CURL_PAYLOAD="$WORK/curl_payload"
+export LLM_RETRIES=0
+# Keyless operation is the point of this provider: every key must be absent,
+# along with any .env-sourced overrides the suite's shell may carry. cd to
+# the workdir so bin/llm finds no cwd .env either.
+unset ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
+      OPENCODE_API_KEY LLM_API_KEY LLM_PROVIDER LLM_API_URL LLM_MODEL \
+      LLM_MAX_TOKENS SHELLM_MODEL
+cd "$WORK" || exit 1
+
+LLM="$REPO/bin/llm"
+URL="http://127.0.0.1:9/v1/chat/completions"
+
+reset() { : > "$CURL_ARGS"; : > "$CURL_PAYLOAD"; }
+
+# ---------------------------------------------------------------------------
+# Works with no API key of any kind
+# ---------------------------------------------------------------------------
+
+reset
+out=$(LLM_PROVIDER=openai-compatible LLM_API_URL="$URL" \
+      "$LLM" -m qwen3:8b "say ok" 2>"$WORK/stderr")
+rc=$?
+if [[ "$rc" -eq 0 && "$out" == *ok* ]]; then
+    ok "keyless call succeeds via LLM_PROVIDER=openai-compatible"
+else
+    bad "keyless call succeeds via LLM_PROVIDER=openai-compatible" "$(head -1 "$WORK/stderr")"
+fi
+if grep -q '127.0.0.1:9' "$CURL_ARGS"; then
+    ok "request went to LLM_API_URL"
+else
+    bad "request went to LLM_API_URL"
+fi
+if grep -qi 'authorization' "$CURL_ARGS"; then
+    bad "no Authorization header without LLM_API_KEY" "$(grep -im1 authorization "$CURL_ARGS")"
+else
+    ok "no Authorization header without LLM_API_KEY"
+fi
+if grep -q '"max_tokens":[[:space:]]*16384' "$CURL_PAYLOAD"; then
+    ok "unknown model gets the provider's 16384 default cap"
+else
+    bad "unknown model gets the provider's 16384 default cap" "$(grep -o '"max_tokens":[0-9]*' "$CURL_PAYLOAD" | head -1)"
+fi
+
+# ---------------------------------------------------------------------------
+# LLM_API_KEY, when set, rides as a Bearer token
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=openai-compatible LLM_API_URL="$URL" LLM_API_KEY="sekrit" \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+if grep -q 'Authorization: Bearer sekrit' "$CURL_ARGS"; then
+    ok "LLM_API_KEY is sent as Authorization: Bearer"
+else
+    bad "LLM_API_KEY is sent as Authorization: Bearer" "$(head -1 "$WORK/stderr")"
+fi
+
+# ---------------------------------------------------------------------------
+# LLM_API_URL is required
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=openai-compatible "$LLM" -m qwen3:8b "say ok" \
+    >/dev/null 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'LLM_API_URL is not set' "$WORK/stderr"; then
+    ok "missing LLM_API_URL dies loudly"
+else
+    bad "missing LLM_API_URL dies loudly" "rc=$rc"
+fi
+
+# ---------------------------------------------------------------------------
+# --provider flag path
+# ---------------------------------------------------------------------------
+
+reset
+out=$(LLM_API_URL="$URL" \
+      "$LLM" --provider openai-compatible -m qwen3:8b "say ok" 2>"$WORK/stderr")
+if [[ "$out" == *ok* ]] && grep -q '127.0.0.1:9' "$CURL_ARGS"; then
+    ok "--provider openai-compatible works"
+else
+    bad "--provider openai-compatible works" "$(head -1 "$WORK/stderr")"
+fi
+
+# ---------------------------------------------------------------------------
+# Non-streaming path
+# ---------------------------------------------------------------------------
+
+reset
+out=$(LLM_PROVIDER=openai-compatible LLM_API_URL="$URL" \
+      "$LLM" --no-stream -m qwen3:8b "say ok" 2>"$WORK/stderr")
+if [[ "$out" == *ok* ]]; then
+    ok "non-streaming path answers"
+else
+    bad "non-streaming path answers" "$(head -1 "$WORK/stderr")"
+fi
+
+# ---------------------------------------------------------------------------
+# -t overrides the provider default cap
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=openai-compatible LLM_API_URL="$URL" \
+    "$LLM" -t 512 -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+if grep -q '"max_tokens":[[:space:]]*512' "$CURL_PAYLOAD"; then
+    ok "-t overrides the default cap"
+else
+    bad "-t overrides the default cap" "$(grep -o '"max_tokens":[0-9]*' "$CURL_PAYLOAD" | head -1)"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_llm_openai_compatible.sh
+++ b/tests/test_llm_openai_compatible.sh
@@ -16,6 +16,12 @@
 #   - the non-streaming path answers too
 #   - unknown model names default to the provider's 16384 output cap,
 #     and -t still overrides it
+#   - model names the cap table knows keep their real caps through this
+#     provider (a proxy serving gpt-5 must not silently drop to 16384)
+#   - a typo'd provider name dies with "Unknown provider", not bash's
+#     exit-127 "command not found"
+#   - LLM_API_URL on a keyed provider warns on stderr (openai-compatible
+#     itself is exempt: the URL there is required configuration)
 
 set -uo pipefail
 
@@ -168,6 +174,55 @@ if grep -q '"max_tokens":[[:space:]]*512' "$CURL_PAYLOAD"; then
     ok "-t overrides the default cap"
 else
     bad "-t overrides the default cap" "$(grep -o '"max_tokens":[0-9]*' "$CURL_PAYLOAD" | head -1)"
+fi
+
+# ---------------------------------------------------------------------------
+# Known model names keep their table caps through this provider
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=openai-compatible LLM_API_URL="$URL" \
+    "$LLM" -m gpt-5 "say ok" >/dev/null 2>"$WORK/stderr"
+if grep -q '128000' "$CURL_PAYLOAD"; then
+    ok "known model (gpt-5) keeps its 128000 table cap"
+else
+    bad "known model (gpt-5) keeps its 128000 table cap" "$(grep -o '"max[a-z_]*tokens":[0-9]*' "$CURL_PAYLOAD" | head -1)"
+fi
+
+# ---------------------------------------------------------------------------
+# A typo'd provider dies loudly, not with command-not-found
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=openai-compatibel LLM_API_URL="$URL" \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && "$rc" -ne 127 ]] && grep -q 'Unknown provider: openai-compatibel' "$WORK/stderr"; then
+    ok "typo'd provider dies with 'Unknown provider'"
+else
+    bad "typo'd provider dies with 'Unknown provider'" "rc=$rc: $(head -1 "$WORK/stderr")"
+fi
+
+# ---------------------------------------------------------------------------
+# LLM_API_URL on a keyed provider warns; on openai-compatible it does not
+# ---------------------------------------------------------------------------
+
+reset
+LLM_PROVIDER=openai LLM_API_URL="$URL" OPENAI_API_KEY="sekrit" \
+    "$LLM" -m gpt-4o "say ok" >/dev/null 2>"$WORK/stderr"
+if grep -q 'LLM_API_URL=.*overrides the default openai endpoint' "$WORK/stderr"; then
+    ok "LLM_API_URL on a keyed provider warns on stderr"
+else
+    bad "LLM_API_URL on a keyed provider warns on stderr" "$(head -1 "$WORK/stderr")"
+fi
+
+reset
+LLM_PROVIDER=openai-compatible LLM_API_URL="$URL" \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+if grep -q 'overrides the default' "$WORK/stderr"; then
+    bad "openai-compatible is exempt from the LLM_API_URL warning" "$(grep -m1 'overrides the default' "$WORK/stderr")"
+else
+    ok "openai-compatible is exempt from the LLM_API_URL warning"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/test_llm_openai_compatible.sh
+++ b/tests/test_llm_openai_compatible.sh
@@ -12,6 +12,8 @@
 #   - no Authorization header is sent when LLM_API_KEY is unset
 #   - LLM_API_KEY, when set, is sent as a Bearer token
 #   - LLM_API_URL is required: without it the call dies loudly
+#   - SHELLM_API_URL works as the fallback URL (direct llm callers in a
+#     shellm deployment: thinkers, mem, recap)
 #   - --provider openai-compatible works the same as the env var
 #   - the non-streaming path answers too
 #   - unknown model names default to the provider's 16384 output cap,
@@ -74,7 +76,7 @@ export LLM_RETRIES=0
 # the workdir so bin/llm finds no cwd .env either.
 unset ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
       OPENCODE_API_KEY LLM_API_KEY LLM_PROVIDER LLM_API_URL LLM_MODEL \
-      LLM_MAX_TOKENS SHELLM_MODEL
+      LLM_MAX_TOKENS SHELLM_MODEL SHELLM_API_URL
 cd "$WORK" || exit 1
 
 LLM="$REPO/bin/llm"
@@ -136,6 +138,20 @@ if [[ "$rc" -ne 0 ]] && grep -q 'LLM_API_URL is not set' "$WORK/stderr"; then
     ok "missing LLM_API_URL dies loudly"
 else
     bad "missing LLM_API_URL dies loudly" "rc=$rc"
+fi
+
+# ---------------------------------------------------------------------------
+# SHELLM_API_URL works as the fallback (thinkers, mem, recap call llm
+# directly, and a shellm deployment configures SHELLM_API_URL, not LLM_API_URL)
+# ---------------------------------------------------------------------------
+
+reset
+out=$(LLM_PROVIDER=openai-compatible SHELLM_API_URL="$URL" \
+      "$LLM" -m qwen3:8b "say ok" 2>"$WORK/stderr")
+if [[ "$out" == *ok* ]] && grep -q '127.0.0.1:9' "$CURL_ARGS"; then
+    ok "SHELLM_API_URL works as the URL fallback"
+else
+    bad "SHELLM_API_URL works as the URL fallback" "$(head -1 "$WORK/stderr")"
 fi
 
 # ---------------------------------------------------------------------------
@@ -228,6 +244,17 @@ if grep -q 'requests go to 127.0.0.1:9' "$WORK/stderr" \
     ok "URL credentials stay out of the warning"
 else
     bad "URL credentials stay out of the warning" "$(grep -m1 'LLM_API_URL' "$WORK/stderr")"
+fi
+
+reset
+LLM_PROVIDER=openai LLM_API_URL="http://127.0.0.1:9#token=topsecret" \
+    OPENAI_API_KEY="sekrit" \
+    "$LLM" -m gpt-4o "say ok" >/dev/null 2>"$WORK/stderr"
+if grep -q 'requests go to 127.0.0.1:9' "$WORK/stderr" \
+   && ! grep -q 'topsecret' "$WORK/stderr"; then
+    ok "URL fragments stay out of the warning"
+else
+    bad "URL fragments stay out of the warning" "$(grep -m1 'LLM_API_URL' "$WORK/stderr")"
 fi
 
 reset

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -345,7 +345,11 @@ _build_shellm_flags() {
     # Keys go by NAME (bare `--var NAME`): shellm reads the value from its
     # environment, so it never shows up in `ps` or the recorded command line.
     [[ -n "${SHELLM_MODEL:-}" ]] && printf '%s\n' "--var" "SHELLM_MODEL=$SHELLM_MODEL"
-    for _ak in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY; do
+    # The generic openai-compatible provider is env-configured and never
+    # auto-detected, so nested calls need the provider name (routing, not a
+    # secret) and its key (bare name, like the vendor keys below).
+    [[ -n "${LLM_PROVIDER:-}" ]] && printf '%s\n' "--var" "LLM_PROVIDER=$LLM_PROVIDER"
+    for _ak in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY LLM_API_KEY; do
         if [[ -n "${!_ak:-}" ]]; then
             export "${_ak?}"
             printf '%s\n' "--var" "$_ak"

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -349,7 +349,8 @@ _build_shellm_flags() {
     # auto-detected, so nested calls need the provider name (routing, not a
     # secret) and its key (bare name, like the vendor keys below).
     [[ -n "${LLM_PROVIDER:-}" ]] && printf '%s\n' "--var" "LLM_PROVIDER=$LLM_PROVIDER"
-    for _ak in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY LLM_API_KEY; do
+    for _ak in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
+               OPENCODE_API_KEY LLM_API_KEY; do
         if [[ -n "${!_ak:-}" ]]; then
             export "${_ak?}"
             printf '%s\n' "--var" "$_ak"


### PR DESCRIPTION
## Summary

  This PR defines how Headlong adds model providers and implements the two supported extension paths.

  ### Provider policy

  The policy is documented in `design/providers.md`:

  * All model completions go through `bin/llm`.
  * A provider can live in core when its request and response format can be implemented and tested with Bash, curl, and jq. Authentication must require no more than an API key in an HTTP header.
  * OpenAI compatible services use one generic provider instead of separate code for Ollama, vLLM, LM Studio, proxies, and similar services. The policy defines the minimum supported API format. Differences outside that format receive best effort support.
  * Providers that need a provider specific subprocess, another runtime, an SDK, a vendor command, or more complex authentication live outside core as adapters.

  Installer prompts, dashboard panels, and other integration remain separate decisions. An adapter receives no installer or dashboard integration by default.

  ### Adapter support

  Set `LLM_PROVIDER=adapter` and `LLM_ADAPTER=/path/to/executable` to run an adapter instead of curl.

  `bin/llm` sends the messages JSON through stdin and passes flags for the model, token limit, effort, thinking, and streaming. The system prompt arrives through `--system-prompt-file`. The adapter can report token usage through `LLM_USAGE_FILE`. `bin/llm` continues to manage the usage ledger and health marker.

  `LLM_MAX_TIME` applies to the adapter and its children. `bin/llm` starts the adapter in a separate process group. When the deadline expires, it sends `TERM` to the group, waits five seconds, and then sends `KILL` to the group. The call remains a failure if the adapter exits successfully after the deadline. A child cannot keep stdout open after the deadline.

  `bin/llm` runs the adapter once. An adapter that needs retries must handle them within the same deadline.

  Adapters are trusted local code. They receive the caller's full environment, including provider keys, so operators should only use adapters they trust.

  The system prompt and deadline markers live in a private temporary directory with mode `0700`. The system prompt file uses mode `0600`, and `bin/llm` removes the directory during exit cleanup.

  ### OpenAI compatible provider

  Set `LLM_PROVIDER=openai-compatible` and provide `LLM_API_URL`. The provider has no default URL. `SHELLM_API_URL` also works as a fallback, so direct callers such as thinkers, `mem`, and `recap` use the same endpoint.

  `LLM_API_KEY` is optional. When present, `bin/llm` sends it as a bearer token. Local services can therefore run without a cloud key or a fake key.

  Headlong never detects this provider from the model name. Operators must select it explicitly. Provider selection applies to the whole deployment by design.

  Headlong forwards `LLM_PROVIDER` and `LLM_API_KEY` into the sandbox and nested runs, using the same path as the existing provider keys.

  Unknown model names receive a default output limit of 16,384 tokens for both OpenAI compatible providers and adapters. Models already listed in the token limit table keep their listed limits. For example, a proxy serving `gpt-5` keeps the `gpt-5` limit.

  ### Other changes

  * `bin/llm` warns when `LLM_API_URL` replaces a provider's default endpoint. The warning includes only the host, so credentials in the URL cannot reach stderr.
  * An unknown provider now fails with a clear `Unknown provider` message instead of Bash exit code 127 and `command not found`.
  * `redact_sensitive` now masks `LLM_API_KEY`.
  * Thinkers now forward `OPENCODE_API_KEY`.

  ### Tests

  `tests/test_llm_openai_compatible.sh` contains 16 cases covering keyless calls, authentication headers, required URL handling, URL fallback, token limits, and safe warnings.

  `tests/test_llm_adapter.sh` contains 20 cases covering the adapter contract, process group deadlines, child process cleanup, temporary file permissions, health reporting, usage reporting, and successful call latency.

  The adapter, OpenAI compatible, provider environment, and retry suites pass under both the current Bash and macOS Bash 3.2.

  Issue #80 tracks the existing risk of provider keys appearing in curl arguments. This PR follows the current provider pattern so the project can fix that risk once for every provider.

  ## Project size and related work

  The core line limit increases from 10,000 to 11,000. Main was at 9,998 lines before this work, and the branch finishes at 10,115 lines. The README and `philosophy.md` now describe the core as "about 10K lines." The original under 10K claim was accurate when the launch post was published on 2026-08-24.

The provider policy gives maintainers a clear response for PR #46 and issues #65 and #71. The keyless Ollama case from issue #65 works with this change and `SHELLM_MODEL`.
