### PR TITLE
llm: add Amazon Bedrock and Mantle inference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,12 +32,18 @@ trajectory.
 ## Install without a tty
 
 With no tty the installer asks nothing; every answer comes from an
-environment variable or a default. A key must be in the environment:
+environment variable or a default. A provider credential must be in the environment:
 
 ```bash
-export OPENROUTER_API_KEY=sk-or-...   # or ANTHROPIC_/OPENAI_/GEMINI_API_KEY
+export OPENROUTER_API_KEY=sk-or-...   # or another provider's *_API_KEY
 curl -fsSL https://headlong.ai/install.sh | bash
 ```
+
+Amazon Bedrock uses `AWS_BEARER_TOKEN_BEDROCK` plus `AWS_REGION` (or standard
+AWS environment credentials). `AWS_PROFILE` is also accepted and refreshes
+`credential_process` credentials through AWS CLI on each call. `openai.gpt-*`
+model IDs route to the Mantle Responses API; Bedrock-prefixed Anthropic and
+OpenAI IDs route to Bedrock Runtime.
 
 Optional variables: `HEADLONG_IDENTITY_NAME`, `HEADLONG_IDENTITY_VIBE`,
 `HEADLONG_IDENTITY_FOCUS`, `HEADLONG_IDENTITY_USER` (the interview answers),

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ curl -fsSL https://headlong.ai/install.sh | bash
 ```
 
 You'll need bash 3.2+, git, curl, jq, and an LLM API key (Anthropic,
-OpenAI, Gemini, or OpenRouter); the dashboard also needs
+OpenAI, Gemini, OpenRouter, OpenCode, or Amazon Bedrock); the dashboard also
+needs
 [uv](https://docs.astral.sh/uv/) and bun or node, and the installer offers
 to fetch those. 
 
@@ -154,7 +155,7 @@ experiment with.
 | Tool | What it does |
 |------|-------------|
 | **shellm** | The RLM core. It sends context to an LLM, runs the bash the LLM writes back, and repeats |
-| **llm** | Multi-provider LLM CLI. Anthropic, OpenAI, Gemini, and OpenRouter behind one interface |
+| **llm** | Multi-provider LLM CLI. Anthropic, OpenAI, Gemini, OpenRouter, OpenCode, and Amazon Bedrock behind one interface |
 | **traj** | Trajectory operations on append-only jsonl DAGs with fork and merge |
 | **context** | Renders a trajectory into an LLM messages array with tiered compaction |
 | **thinkers** | The mind. Reactive thought processes run by a dispatcher |

--- a/bin/llm
+++ b/bin/llm
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # llm — Minimal multi-provider LLM CLI tool
-# Supports the Anthropic, OpenAI, Gemini, and OpenRouter APIs.
+# Supports Anthropic, OpenAI, Gemini, OpenRouter, OpenCode, and Amazon Bedrock.
 
 # ---------------------------------------------------------------------------
 # Defaults
@@ -36,8 +36,11 @@ _llm_load_env "$_llm_home/.env" || true
 LLM_MODEL="${LLM_MODEL:-}"
 LLM_SYSTEM=""
 LLM_MAX_TOKENS="${LLM_MAX_TOKENS:-}"
+_llm_max_tokens_explicit=0
+[[ -z "$LLM_MAX_TOKENS" ]] || _llm_max_tokens_explicit=1
 LLM_MESSAGES=""
 LLM_STREAM=1
+_llm_stream_explicit=0
 LLM_PROVIDER="${LLM_PROVIDER:-}"
 # Remember whether the provider came from the environment (or a .env layer
 # above): honored as authoritative, like LLM_API_URL, but never silently —
@@ -144,13 +147,15 @@ Usage:
 
 Options:
   -m, --model MODEL        Model to use. Default: picked for whichever API
-                           key is set (Anthropic, then OpenAI, Gemini, OpenRouter)
+                           key is set (Anthropic, OpenAI, Gemini, OpenRouter,
+                           OpenCode, then Amazon Bedrock)
   -s, --system-prompt TEXT System prompt text
   --system-prompt-file F   Read system prompt from file
   -t, --max-tokens N       Max output tokens. Default: model-specific cap
   -M, --messages JSON      Messages array JSON, e.g. [{"role":"user","content":"hi"}]
   --no-stream              Disable streaming (streaming is on by default)
-  --provider NAME          Provider: anthropic, openai, gemini, openrouter, opencode, or opencode-go
+  --provider NAME          Provider: anthropic, openai, gemini, openrouter,
+                           opencode, opencode-go, or bedrock
   --thinking [LEVEL]       Enable thinking (Anthropic: adaptive; Gemini: minimal/low/medium/high)
   --effort LEVEL           Thinking effort/provider output effort
   --raw                    Print raw non-streaming API response JSON
@@ -164,6 +169,8 @@ Models:
   OpenRouter: z-ai/glm-5.2, meta-llama/*, ... (any vendor/model name)
   OpenCode:   opencode-go/* (Go subscription, OpenAI wire format)
               opencode/*  (Zen pay-per-token, Anthropic wire format)
+  Bedrock:    bedrock/<model>, *.anthropic.claude*, openai.gpt-*
+              Mantle OpenAI models use the Responses API and stream normally.
 
 Thinking & effort:
   These flags control how much reasoning the model does before answering.
@@ -201,6 +208,13 @@ Environment:
   OPENCODE_API_KEY         Required for OpenCode models — both plans use it;
                            opencode-go/* bills the Go subscription, opencode/*
                            bills Zen. Keys: `opencode auth login`
+  AWS_BEARER_TOKEN_BEDROCK Amazon Bedrock API key (preferred)
+  AWS_ACCESS_KEY_ID        SigV4 fallback; requires AWS_SECRET_ACCESS_KEY
+  AWS_SECRET_ACCESS_KEY    Secret key for SigV4. AWS_SESSION_TOKEN is optional
+  AWS_PROFILE              AWS CLI profile/credential_process for refreshed
+                           SigV4 credentials
+  AWS_REGION               Bedrock region (AWS_DEFAULT_REGION also accepted;
+                           then the profile region; default: us-east-1)
   LLM_API_URL              Override provider API URL
   LLM_PROVIDER             Provider to use when the model name implies none
                            (same names as --provider); --provider takes
@@ -224,6 +238,7 @@ Examples:
   llm --thinking -m claude-opus-4-7 "solve this carefully"
   llm --raw -m gemini-2.0-flash "return a JSON greeting"
   llm -m z-ai/glm-5.2 "explain quicksort"
+  AWS_BEARER_TOKEN_BEDROCK=... llm -m openai.gpt-5.6-sol "hello"
 EOF
     exit "${1:-0}"
 }
@@ -238,9 +253,9 @@ while [[ $# -gt 0 ]]; do
         -m|--model)      LLM_MODEL="${2:?--model requires a value}"; shift 2 ;;
         -s|--system-prompt) LLM_SYSTEM="${2:?--system-prompt requires a value}"; shift 2 ;;
         --system-prompt-file) _spf="${2:?--system-prompt-file requires a path}"; [[ -f "$_spf" ]] || die "System prompt file not found: $_spf"; LLM_SYSTEM=$(cat "$_spf"); shift 2 ;;
-        -t|--max-tokens) LLM_MAX_TOKENS="${2:?--max-tokens requires a value}"; shift 2 ;;
+        -t|--max-tokens) LLM_MAX_TOKENS="${2:?--max-tokens requires a value}"; _llm_max_tokens_explicit=1; shift 2 ;;
         -M|--messages)   LLM_MESSAGES="${2:?--messages requires a value}"; shift 2 ;;
-        --stream)        LLM_STREAM=1; shift ;;
+        --stream)        LLM_STREAM=1; _llm_stream_explicit=1; shift ;;
         --no-stream)     LLM_STREAM=0; shift ;;
         --provider)      LLM_PROVIDER="${2:?--provider requires a value}"; shift 2 ;;
         --thinking)
@@ -284,8 +299,10 @@ if [[ -z "$LLM_MODEL" ]]; then
         # them, so default to the flat-rate subscription; Zen models are one
         # `-m opencode/<model>` away.
         LLM_MODEL="opencode-go/deepseek-v4-flash"
+    elif [[ -n "${AWS_BEARER_TOKEN_BEDROCK:-}${AWS_PROFILE:-}" || ( -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ) ]]; then
+        LLM_MODEL="us.anthropic.claude-sonnet-4-6"
     else
-        die "No model specified and no API key found. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY, or OPENCODE_API_KEY, or pass -m MODEL."
+        die "No model specified and no provider credential found. Set a provider API key, AWS_PROFILE, or pass -m MODEL."
     fi
 fi
 
@@ -306,6 +323,12 @@ detect_provider() {
         #   opencode/<model>    -> Zen pay-per-token (anthropic wire format)
         opencode-go/*)                   echo "opencode-go" ;;
         opencode/*)                      echo "opencode" ;;
+        # Explicit Bedrock routing wins before the generic vendor/model rule.
+        bedrock/*)                       echo "bedrock" ;;
+        # Mantle model IDs are in-region and unprefixed; geographic/global
+        # OpenAI and Anthropic IDs use the Bedrock Runtime endpoint.
+        openai.gpt-*|*.openai.gpt-*)     echo "bedrock" ;;
+        anthropic.claude*|*.anthropic.claude*) echo "bedrock" ;;
         # Vendor-prefixed names (z-ai/glm-5.2, meta-llama/..., etc.) are
         # OpenRouter's model-naming convention.
         */*)                             echo "openrouter" ;;
@@ -332,12 +355,46 @@ fi
 # OpenCode routing prefixes hide the real catalog id from the API side;
 # strip once, up front, so the payload builders AND get_model_max_tokens see
 # the actual model name and its caps.
-case "$LLM_PROVIDER" in opencode) LLM_MODEL="${LLM_MODEL#opencode/}" ;; opencode-go) LLM_MODEL="${LLM_MODEL#opencode-go/}" ;; esac
+case "$LLM_PROVIDER" in
+    opencode)    LLM_MODEL="${LLM_MODEL#opencode/}" ;;
+    opencode-go) LLM_MODEL="${LLM_MODEL#opencode-go/}" ;;
+    bedrock)     LLM_MODEL="${LLM_MODEL#bedrock/}" ;;
+esac
+
+# Bedrock exposes two useful protocol families. Mantle and Bedrock Runtime's
+# OpenAI endpoint speak the Responses API over ordinary JSON/SSE. Claude's
+# InvokeModel response body speaks the Anthropic Messages format, but its
+# streaming endpoint uses AWS's binary event-stream framing; keep that one on
+# the reliable non-streaming path until bin/llm has a binary frame decoder.
+_bedrock_wire=""
+if [[ "$LLM_PROVIDER" == "bedrock" ]]; then
+    case "$LLM_MODEL" in
+        openai.gpt-*)             _bedrock_wire="mantle-responses" ;;
+        *.openai.gpt-*)           _bedrock_wire="runtime-responses" ;;
+        anthropic.claude*|*.anthropic.claude*) _bedrock_wire="invoke-anthropic" ;;
+        *) die "Unsupported Bedrock model '$LLM_MODEL'. Use an Anthropic Claude or OpenAI GPT Bedrock model ID." ;;
+    esac
+    if [[ "$_bedrock_wire" == "invoke-anthropic" && "$LLM_STREAM" -eq 1 ]]; then
+        [[ "$_llm_stream_explicit" -eq 0 ]] || echo "llm: note: Bedrock Claude streaming uses AWS binary event frames; using InvokeModel without streaming" >&2
+        LLM_STREAM=0
+    fi
+fi
 
 # Per-model max output token caps (synchronous APIs, no beta headers).
 # Used as the default when -t/--max-tokens is not given.
 get_model_max_tokens() {
     local model="$1"
+    if [[ "${LLM_PROVIDER:-}" == "bedrock" ]]; then
+        case "$model" in
+            *anthropic.claude-opus-4-[6-9]*|*anthropic.claude-sonnet-4-[6-9]*) echo 128000 ;;
+            *anthropic.claude-opus-4-*|*anthropic.claude-sonnet-4-*|*anthropic.claude-haiku-4-*) echo 64000 ;;
+            *anthropic.claude-3-5-*) echo 8192 ;;
+            *anthropic.claude-3-*) echo 4096 ;;
+            *openai.gpt-*) echo 128000 ;;
+            *) echo 16384 ;;
+        esac
+        return
+    fi
     # OpenCode Go catalog — frontier-class models with large outputs; the
     # generic tiers starve agentic shellm steps. Scoped to the provider so
     # identically-named models reached through other providers (OpenRouter's
@@ -392,6 +449,15 @@ if [[ ! "$LLM_MAX_TOKENS" =~ ^[0-9]+$ ]]; then
     LLM_MAX_TOKENS=$(get_model_max_tokens "$LLM_MODEL")
 fi
 
+# InvokeModel requires streaming above 21,333 output tokens for Claude 4, but
+# Bedrock's stream is binary AWS event-stream rather than the SSE bin/llm can
+# parse. Keep this path valid; Mantle/Runtime Responses models are unaffected.
+if [[ "$_bedrock_wire" == "invoke-anthropic" && "$LLM_MAX_TOKENS" -gt 21333 ]]; then
+    [[ "$_llm_max_tokens_explicit" -eq 0 ]] \
+        || echo "llm: warning: Bedrock Claude non-streaming caps max_tokens at 21333; requested $LLM_MAX_TOKENS" >&2
+    LLM_MAX_TOKENS=21333
+fi
+
 # ---------------------------------------------------------------------------
 # Build messages JSON
 # ---------------------------------------------------------------------------
@@ -425,7 +491,7 @@ supports_anthropic_thinking() {
     # Pre-4 ids all start "claude-3" and stay outside these patterns.
     case "$LLM_MODEL" in
         claude-opus-*|claude-sonnet-*|claude-haiku-*) return 0 ;;
-        claude-fable-*|claude-mythos-*) return 0 ;;
+        claude-fable-*|claude-mythos-*|*anthropic.claude-*) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -433,7 +499,7 @@ supports_anthropic_thinking() {
 supports_openai_reasoning() {
     [[ "${LLM_ASSUME_THINKING:-0}" == 1 ]] && return 0
     case "$LLM_MODEL" in
-        gpt-[5-9]*|o[1-9]*) return 0 ;;
+        gpt-[5-9]*|o[1-9]*|openai.gpt-[5-9]*|*.openai.gpt-[5-9]*) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -571,9 +637,133 @@ build_payload_opencode() {
     LLM_THINKING=0; LLM_EFFORT=""; build_payload_anthropic
 }
 
+# Amazon Bedrock's OpenAI endpoints implement the Responses API rather than
+# Chat Completions. Keep state disabled: llm already sends the complete message
+# history, and silently retaining every agent turn for 30 days is surprising.
+build_payload_bedrock_responses() {
+    local -a jq_args=(
+        --arg model "$LLM_MODEL"
+        --argjson max_tokens "$LLM_MAX_TOKENS"
+        --argjson stream "$( [[ "$LLM_STREAM" -eq 1 ]] && echo true || echo false )"
+    )
+    local jq_filter='{model:$model, input:., max_output_tokens:$max_tokens, stream:$stream, store:false}'
+
+    if [[ -n "$LLM_SYSTEM" ]]; then
+        jq_args+=(--arg instructions "$LLM_SYSTEM")
+        jq_filter="${jq_filter} + {instructions:\$instructions}"
+    fi
+
+    # shellm supplies bare --thinking plus --effort; a direct llm call can use
+    # --thinking LEVEL. Both map to the Responses API reasoning configuration.
+    local reasoning_level="$LLM_THINKING_LEVEL"
+    [[ -z "$reasoning_level" && "$LLM_THINKING" -eq 1 ]] && reasoning_level="$LLM_EFFORT"
+    if [[ -n "$reasoning_level" ]]; then
+        if supports_openai_reasoning; then
+            jq_args+=(--arg reasoning_level "$reasoning_level")
+            jq_filter="${jq_filter} + {reasoning:{effort:\$reasoning_level, summary:\"auto\"}}"
+        else
+            echo "llm: --thinking ignored: $LLM_MODEL not in the known-reasoning model list (LLM_ASSUME_THINKING=1 to send anyway)" >&2
+        fi
+    fi
+
+    printf '%s' "$LLM_MESSAGES" | jq "${jq_args[@]}" "$jq_filter"
+}
+
+build_payload_bedrock() {
+    case "$_bedrock_wire" in
+        mantle-responses|runtime-responses) build_payload_bedrock_responses ;;
+        invoke-anthropic)
+            case "$LLM_MODEL" in
+                # These generations support adaptive thinking and output
+                # effort. Bedrock summarizes thinking by default, so omit the
+                # Anthropic API's display selector.
+                *anthropic.claude-opus-4-[6-9]*|*anthropic.claude-sonnet-4-[6-9]*|\
+                *anthropic.claude-opus-5*|*anthropic.claude-sonnet-5*|\
+                *anthropic.claude-haiku-5*|*anthropic.claude-mythos-5*|*anthropic.claude-fable-5*)
+                    build_payload_anthropic | jq 'del(.model, .stream, .thinking.display) + {anthropic_version:"bedrock-2023-05-31"}'
+                    ;;
+                # Older Claude 4 and 3.7 models require a fixed token budget
+                # and reject output_config. Translate shellm's effort tier to
+                # a conservative budget below max_tokens.
+                *anthropic.claude-*-4-*|*anthropic.claude-3-7-sonnet*)
+                    local budget=8192
+                    case "$LLM_EFFORT" in
+                        low) budget=2048 ;; medium) budget=4096 ;; high|"") budget=8192 ;;
+                        xhigh) budget=12288 ;; max) budget=16384 ;;
+                    esac
+                    (( budget < LLM_MAX_TOKENS )) || budget=$(( LLM_MAX_TOKENS - 1 ))
+                    if [[ "$LLM_THINKING" -eq 1 && "$budget" -ge 1024 ]]; then
+                        build_payload_anthropic | jq --argjson budget "$budget" '
+                            del(.model, .stream, .output_config)
+                            | .thinking = {type:"enabled", budget_tokens:$budget}
+                            | . + {anthropic_version:"bedrock-2023-05-31"}'
+                    else
+                        [[ "$LLM_THINKING" -eq 0 ]] || echo "llm: --thinking ignored: Bedrock fixed thinking requires max_tokens above 1024" >&2
+                        build_payload_anthropic | jq 'del(.model, .stream, .thinking, .output_config) + {anthropic_version:"bedrock-2023-05-31"}'
+                    fi
+                    ;;
+                *)
+                    build_payload_anthropic | jq 'del(.model, .stream, .thinking, .output_config) + {anthropic_version:"bedrock-2023-05-31"}'
+                    ;;
+            esac
+            ;;
+    esac
+}
+
 # ---------------------------------------------------------------------------
 # URL and headers per provider
 # ---------------------------------------------------------------------------
+
+_bedrock_load_profile_credentials() {
+    [[ -n "${AWS_PROFILE:-}" ]] || return 1
+    command -v aws >/dev/null 2>&1 \
+        || die "AWS_PROFILE is set, but the AWS CLI is not installed"
+
+    local credential_json
+    credential_json=$(aws configure export-credentials --profile "$AWS_PROFILE" --format process) \
+        || die "Could not resolve AWS_PROFILE '$AWS_PROFILE' with 'aws configure export-credentials'"
+
+    local -a credential_parts=()
+    local credential_part
+    while IFS= read -r credential_part; do
+        credential_parts+=("$credential_part")
+    done < <(printf '%s' "$credential_json" | jq -r \
+        '.AccessKeyId // "", .SecretAccessKey // "", .SessionToken // ""')
+    unset credential_json
+
+    AWS_ACCESS_KEY_ID="${credential_parts[0]:-}"
+    AWS_SECRET_ACCESS_KEY="${credential_parts[1]:-}"
+    AWS_SESSION_TOKEN="${credential_parts[2]:-}"
+    [[ -n "$AWS_ACCESS_KEY_ID" && -n "$AWS_SECRET_ACCESS_KEY" ]] \
+        || die "AWS_PROFILE '$AWS_PROFILE' returned incomplete credentials"
+}
+
+_bedrock_auth() { # service name used by SigV4
+    local service="$1"
+    if [[ -n "${AWS_BEARER_TOKEN_BEDROCK:-}" ]]; then
+        headers+=(-H "Authorization: Bearer $AWS_BEARER_TOKEN_BEDROCK")
+        return
+    fi
+    if [[ "${HEADLONG_AWS_PROFILE_CREDENTIALS:-0}" == "1" \
+          || ( -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ) ]]; then
+        _bedrock_load_profile_credentials || true
+    fi
+    [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]] \
+        || die "Amazon Bedrock requires AWS_BEARER_TOKEN_BEDROCK, AWS_PROFILE, or AWS_ACCESS_KEY_ID plus AWS_SECRET_ACCESS_KEY"
+
+    # curl's --user argument would expose the secret in ps. A mode-600 config
+    # keeps it off argv while retaining curl's native SigV4 implementation.
+    curl_config_file=$(mktemp "${TMPDIR:-/tmp}/llm-curl.XXXXXX")
+    chmod 600 "$curl_config_file"
+    {
+        printf 'aws-sigv4 = "aws:amz:%s:%s"\n' "$BEDROCK_REGION" "$service"
+        printf 'user = "%s:%s"\n' "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
+        if [[ -n "${AWS_SESSION_TOKEN:-}" ]]; then
+            printf 'header = "x-amz-security-token: %s"\n' "$AWS_SESSION_TOKEN"
+        fi
+    } > "$curl_config_file"
+    request_args+=(--config "$curl_config_file")
+}
 
 get_url_headers() {
     case "$LLM_PROVIDER" in
@@ -617,6 +807,34 @@ get_url_headers() {
             headers=(-H "Content-Type: application/json"
                      -H "x-goog-api-key: $GEMINI_API_KEY")
             ;;
+        bedrock)
+            BEDROCK_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+            if [[ -z "$BEDROCK_REGION" && -n "${AWS_PROFILE:-}" ]] && command -v aws >/dev/null 2>&1; then
+                BEDROCK_REGION=$(aws configure get region --profile "$AWS_PROFILE" 2>/dev/null || true)
+            fi
+            BEDROCK_REGION="${BEDROCK_REGION:-us-east-1}"
+            [[ "$BEDROCK_REGION" =~ ^[a-z0-9-]+$ ]] || die "Invalid AWS region '$BEDROCK_REGION'"
+            headers=(-H "Content-Type: application/json" -H "Accept: application/json")
+            case "$_bedrock_wire" in
+                mantle-responses)
+                    local mantle_base="https://bedrock-mantle.${BEDROCK_REGION}.api.aws/v1"
+                    [[ "$LLM_MODEL" == openai.gpt-oss* ]] \
+                        || mantle_base="https://bedrock-mantle.${BEDROCK_REGION}.api.aws/openai/v1"
+                    url="${LLM_API_URL:-${mantle_base}/responses}"
+                    _bedrock_auth "bedrock-mantle"
+                    ;;
+                runtime-responses)
+                    url="${LLM_API_URL:-https://bedrock-runtime.${BEDROCK_REGION}.amazonaws.com/openai/v1/responses}"
+                    _bedrock_auth "bedrock"
+                    ;;
+                invoke-anthropic)
+                    local encoded_model
+                    encoded_model=$(printf '%s' "$LLM_MODEL" | jq -sRr @uri)
+                    url="${LLM_API_URL:-https://bedrock-runtime.${BEDROCK_REGION}.amazonaws.com/model/${encoded_model}/invoke}"
+                    _bedrock_auth "bedrock"
+                    ;;
+            esac
+            ;;
         *)
             die "Unknown provider: $LLM_PROVIDER"
             ;;
@@ -646,6 +864,17 @@ extract_text_openrouter() { extract_text_openai; }
 # same response shapes as their respective bases throughout.
 extract_text_opencode-go() { extract_text_openai; }
 extract_text_opencode() { extract_text_anthropic; }
+
+extract_text_bedrock() {
+    if [[ "$_bedrock_wire" == "invoke-anthropic" ]]; then
+        extract_text_anthropic
+    else
+        jq -r '
+            [.output[]? | select(.type == "message") | .content[]?
+             | select(.type == "output_text") | .text] | join("")
+        ' 2>/dev/null
+    fi
+}
 
 # ---------------------------------------------------------------------------
 # Response failure checks (non-streaming)
@@ -679,6 +908,19 @@ check_response_openrouter() { check_response_openai; }
 check_response_opencode-go() { check_response_openai; }
 check_response_opencode() { check_response_anthropic; }
 
+check_response_bedrock() {
+    if [[ "$_bedrock_wire" == "invoke-anthropic" ]]; then
+        jq -r 'if .type == "error" or .__type then .error.message // .message // "unknown error" else empty end' 2>/dev/null
+    else
+        jq -r '[
+            (.error.message // empty),
+            (if .status == "failed" then .error.message // "response failed" else empty end),
+            (if .status == "incomplete" and (.incomplete_details.reason // "") != "max_output_tokens"
+             then "response incomplete: " + (.incomplete_details.reason // "unknown reason") else empty end)
+          ] | map(select(length > 0)) | .[0] // empty' 2>/dev/null
+    fi
+}
+
 # Truncation is its own silent failure mode: a 200 whose finish reason says
 # the output hit max_tokens looks complete to a caller reading stdout, and on
 # reasoning models the budget includes the (invisible) thinking tokens, so the
@@ -702,6 +944,14 @@ check_truncated_openrouter() { check_truncated_openai; }
 
 check_truncated_opencode-go() { check_truncated_openai; }
 check_truncated_opencode() { check_truncated_anthropic; }
+
+check_truncated_bedrock() {
+    if [[ "$_bedrock_wire" == "invoke-anthropic" ]]; then
+        check_truncated_anthropic
+    else
+        jq -r 'if .status == "incomplete" and .incomplete_details.reason == "max_output_tokens" then "y" else empty end' 2>/dev/null
+    fi
+}
 
 # Shared by the non-streaming path and the streaming handlers (stderr passes
 # straight through the handler subshell, so this works from either).
@@ -924,6 +1174,80 @@ stream_openrouter() { stream_openai; }
 stream_opencode-go() { stream_openai; }
 stream_opencode() { stream_anthropic; }
 
+# Bedrock's OpenAI-compatible endpoints stream typed Responses API SSE events.
+# Claude never reaches this handler because its binary event-stream transport
+# is forced through InvokeModel above.
+stream_bedrock() {
+    local _saw_data=0 _err_buf="" _chunk="" _emitted_any=0
+    while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+        local line="${raw_line%$'\r'}"
+        if [[ "$line" == data:\ * ]]; then
+            _saw_data=1
+            local json="${line#data: }"
+            [[ "$json" == "[DONE]" ]] && continue
+            local event_type
+            event_type=$(printf '%s' "$json" | jq -r '.type // empty' 2>/dev/null) || event_type=""
+            case "$event_type" in
+                response.output_text.delta)
+                    _chunk=$(printf '%s' "$json" | jq -j '.delta // empty'; printf X)
+                    _chunk="${_chunk%X}"
+                    if [[ -n "$_chunk" ]]; then
+                        mark_emitted
+                        _emitted_any=1
+                        printf '%s' "$_chunk"
+                    fi
+                    ;;
+                response.reasoning_summary_text.delta)
+                    _chunk=$(printf '%s' "$json" | jq -j '.delta // empty'; printf X)
+                    _chunk="${_chunk%X}"
+                    if [[ -n "$_chunk" ]]; then
+                        mark_emitted
+                        _emitted_any=1
+                        printf '%s' "$_chunk" >&2
+                    fi
+                    ;;
+                response.completed)
+                    local _u=""
+                    _u=$(printf '%s' "$json" | jq -r '[
+                            (.response.usage.input_tokens // ""),
+                            (.response.usage.output_tokens // ""),
+                            (.response.usage.output_tokens_details.reasoning_tokens // "")
+                        ] | @tsv' 2>/dev/null) || _u=""
+                    if [[ -n "$_u" ]]; then
+                        local _u_in _u_out _u_think
+                        IFS=$'\t' read -r _u_in _u_out _u_think <<<"$_u"
+                        write_usage "$_u_in" "$_u_out" "$_u_think"
+                    fi
+                    ;;
+                response.incomplete)
+                    local incomplete_reason
+                    incomplete_reason=$(printf '%s' "$json" | jq -r '.response.incomplete_details.reason // "unknown reason"' 2>/dev/null) || incomplete_reason="unknown reason"
+                    if [[ "$incomplete_reason" == "max_output_tokens" ]]; then
+                        warn_truncated
+                    elif [[ "$_emitted_any" -eq 1 ]]; then
+                        die "API stream error: response incomplete: $incomplete_reason"
+                    else
+                        die_retryable "API stream error: response incomplete: $incomplete_reason"
+                    fi
+                    ;;
+                response.failed|error)
+                    local err_msg
+                    err_msg=$(printf '%s' "$json" | jq -r '.error.message // .response.error.message // .message // "unknown error"' 2>/dev/null) || err_msg="unknown error"
+                    if [[ "$_emitted_any" -eq 1 ]]; then
+                        die "API stream error: $err_msg"
+                    else
+                        die_retryable "API stream error: $err_msg"
+                    fi
+                    ;;
+            esac
+        elif [[ "$_saw_data" -eq 0 ]]; then
+            _err_buf="${_err_buf}${line}
+"
+        fi
+    done
+    _die_if_no_stream_data
+}
+
 # ---------------------------------------------------------------------------
 # Main execution
 # ---------------------------------------------------------------------------
@@ -933,6 +1257,7 @@ stream_opencode() { stream_anthropic; }
 # long" on a large one (Linux caps a single argument at 128 KiB, macOS caps
 # total argv at 1 MiB). The file is reused across retries and removed on exit.
 payload_file=$(mktemp "${TMPDIR:-/tmp}/llm-payload.XXXXXX")
+curl_config_file=""
 # No caller-provided usage file: a private one stands in (the ledger still
 # gets the record) and goes away with the payload file.
 _llm_usage_own=0
@@ -942,6 +1267,7 @@ if [[ -z "$LLM_USAGE_FILE" ]]; then
 fi
 _llm_cleanup() {
     rm -f "$payload_file"
+    [[ -z "$curl_config_file" ]] || rm -f "$curl_config_file"
     if [[ "$_llm_usage_own" -eq 1 ]]; then rm -f "$LLM_USAGE_FILE"; fi
     return 0
 }
@@ -951,6 +1277,7 @@ trap '_llm_cleanup' EXIT
 # Get URL and headers
 url=""
 headers=()
+request_args=()
 get_url_headers
 
 [[ "$LLM_RETRIES" =~ ^[0-9]+$ ]] || LLM_RETRIES=0
@@ -981,7 +1308,7 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         LLM_RETRY_ERR=$(mktemp)
         LLM_DATA_MARKER="${LLM_RETRY_ERR}.emitted"
         _rc=0
-        ( "stream_${LLM_PROVIDER}" < <(curl -sS -N ${_net_args[@]+"${_net_args[@]}"} "${headers[@]}" -d @"$payload_file" "$url" 2>"$_curl_err") ) || _rc=$?
+        ( "stream_${LLM_PROVIDER}" < <(curl -sS -N ${_net_args[@]+"${_net_args[@]}"} ${request_args[@]+"${request_args[@]}"} "${headers[@]}" -d @"$payload_file" "$url" 2>"$_curl_err") ) || _rc=$?
 
         _emitted=0
         [[ -e "$LLM_DATA_MARKER" ]] && _emitted=1
@@ -1022,6 +1349,7 @@ else
         local_resp=$(mktemp)
         http_code=$(curl -sS -o "$local_resp" -w '%{http_code}' \
             ${_net_args[@]+"${_net_args[@]}"} \
+            ${request_args[@]+"${request_args[@]}"} \
             "${headers[@]}" -d @"$payload_file" "$url" 2>/dev/null) || http_code="000"
 
         # Transient: network failure, timeout, rate limit, server error
@@ -1075,6 +1403,13 @@ else
     case "$LLM_PROVIDER" in
         # opencode (Zen) speaks the Anthropic wire protocol, usage shape included.
         anthropic|opencode) _u=$(jq -r '[(.usage.input_tokens // ""), (.usage.output_tokens // ""), ""] | @tsv' "$local_resp" 2>/dev/null) || _u="" ;;
+        bedrock)
+            if [[ "$_bedrock_wire" == "invoke-anthropic" ]]; then
+                _u=$(jq -r '[(.usage.input_tokens // ""), (.usage.output_tokens // ""), ""] | @tsv' "$local_resp" 2>/dev/null) || _u=""
+            else
+                _u=$(jq -r '[(.usage.input_tokens // ""), (.usage.output_tokens // ""), (.usage.output_tokens_details.reasoning_tokens // "")] | @tsv' "$local_resp" 2>/dev/null) || _u=""
+            fi
+            ;;
         gemini)    _u=$(jq -r '[(.usageMetadata.promptTokenCount // ""), (.usageMetadata.candidatesTokenCount // ""), (.usageMetadata.thoughtsTokenCount // "")] | @tsv' "$local_resp" 2>/dev/null) || _u="" ;;
         *)         _u=$(jq -r '[(.usage.prompt_tokens // ""), (.usage.completion_tokens // ""), (.usage.completion_tokens_details.reasoning_tokens // "")] | @tsv' "$local_resp" 2>/dev/null) || _u="" ;;
     esac
@@ -1087,6 +1422,14 @@ else
     if [[ "$LLM_RAW" -eq 1 ]]; then
         cat "$local_resp"
     else
+        if [[ "$LLM_PROVIDER" == "bedrock" ]]; then
+            if [[ "$_bedrock_wire" == "invoke-anthropic" ]]; then
+                jq -j '.content[]? | select(.type == "thinking") | .thinking // empty' "$local_resp" >&2 2>/dev/null || true
+            else
+                jq -j '.output[]? | select(.type == "reasoning") | .summary[]?
+                       | select(.type == "summary_text") | .text // empty' "$local_resp" >&2 2>/dev/null || true
+            fi
+        fi
         "extract_text_${LLM_PROVIDER}" < "$local_resp"
     fi
     rm -f "$local_resp"

--- a/bin/shellm
+++ b/bin/shellm
@@ -56,6 +56,8 @@ if [[ -z "${SHELLM_MODEL:-}" ]]; then
         # One env var covers both OpenCode plans; default to the Go
         # subscription (flat-rate). Zen models: SHELLM_MODEL=opencode/<model>.
         SHELLM_MODEL="opencode-go/deepseek-v4-flash"
+    elif [[ -n "${AWS_BEARER_TOKEN_BEDROCK:-}${AWS_PROFILE:-}" || ( -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ) ]]; then
+        SHELLM_MODEL="us.anthropic.claude-sonnet-4-6"
     else
         SHELLM_MODEL="claude-opus-4-7"
     fi
@@ -106,6 +108,43 @@ _SHELLM_EXTRA_BINS=()
 # ---------------------------------------------------------------------------
 
 die() { echo "shellm: error: $*" >&2; exit 1; }
+
+_shellm_model_uses_bedrock() {
+    case "$SHELLM_MODEL" in
+        bedrock/*|openai.gpt-*|*.openai.gpt-*|anthropic.claude*|*.anthropic.claude*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Resolve a profile once for sandbox propagation. bin/llm sees the marker and
+# refreshes the profile again on each top-level model call; generated code gets
+# only the temporary credential values, not host profile files or executables.
+_shellm_materialize_aws_profile_credentials() {
+    _shellm_model_uses_bedrock || return 0
+    [[ -n "${AWS_BEARER_TOKEN_BEDROCK:-}" ]] && return 0
+    [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]] && return 0
+    [[ -n "${AWS_PROFILE:-}" ]] || return 0
+    command -v aws >/dev/null 2>&1 \
+        || die "AWS_PROFILE is set, but the AWS CLI is not installed"
+
+    local credential_json
+    credential_json=$(aws configure export-credentials --profile "$AWS_PROFILE" --format process) \
+        || die "Could not resolve AWS_PROFILE '$AWS_PROFILE' with 'aws configure export-credentials'"
+    local -a credential_parts=()
+    local credential_part
+    while IFS= read -r credential_part; do
+        credential_parts+=("$credential_part")
+    done < <(printf '%s' "$credential_json" | jq -r \
+        '.AccessKeyId // "", .SecretAccessKey // "", .SessionToken // ""')
+    unset credential_json
+
+    export AWS_ACCESS_KEY_ID="${credential_parts[0]:-}"
+    export AWS_SECRET_ACCESS_KEY="${credential_parts[1]:-}"
+    export AWS_SESSION_TOKEN="${credential_parts[2]:-}"
+    export HEADLONG_AWS_PROFILE_CREDENTIALS=1
+    [[ -n "$AWS_ACCESS_KEY_ID" && -n "$AWS_SECRET_ACCESS_KEY" ]] \
+        || die "AWS_PROFILE '$AWS_PROFILE' returned incomplete credentials"
+}
 
 banner() {
     [[ "$QUIET" -eq 1 ]] && return
@@ -189,6 +228,8 @@ Options:
 Environment:
   <PROVIDER>_API_KEY      Key for SHELLM_MODEL's provider (ANTHROPIC_API_KEY
                           for claude-*, OPENROUTER_API_KEY for vendor/model, ...)
+  AWS_BEARER_TOKEN_BEDROCK Amazon Bedrock API key for Bedrock model IDs
+  AWS_PROFILE             AWS CLI profile/credential_process for Bedrock
   SHELLM_MODEL            Model to use
   SHELLM_FAST_MODEL       Cheap model class for utility calls (summaries,
                           mem search); defaults to SHELLM_MODEL's provider
@@ -255,6 +296,10 @@ redact_sensitive() {
     if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
         output="${output//${ANTHROPIC_API_KEY}/<redacted-anthropic-key>}"
     fi
+    local secret
+    for secret in "${AWS_BEARER_TOKEN_BEDROCK:-}" "${AWS_SECRET_ACCESS_KEY:-}" "${AWS_SESSION_TOKEN:-}"; do
+        [[ -z "$secret" ]] || output="${output//$secret/<redacted-aws-credential>}"
+    done
 
     printf '%s' "$output" | LC_ALL=C sed -E 's/sk-ant-[A-Za-z0-9._-]+/<redacted-anthropic-key>/g'
 }
@@ -2329,7 +2374,6 @@ exit \$__shellm_rc
             SHELLM_WORKDIR="$workdir"
             SHELLM_ENV="$(if [[ "${_SHELLM_DOCKER_MODE:-0}" -eq 1 && "$SHELLM_ALLOW_NESTED_DOCKER" != "1" ]]; then echo "local"; else echo "${_SHELLM_ACTIVE_ENV:-}"; fi)"
             _SHELLM_PARENT_CONTAINER="${_SHELLM_CONTAINER:-}"
-            ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}"
             SHELLM_MODEL="$SHELLM_MODEL"
             SHELLM_MAX_TOKENS="$SHELLM_MAX_TOKENS"
             SHELLM_MAX_ITERATIONS="$SHELLM_MAX_ITERATIONS"
@@ -2360,6 +2404,18 @@ exit \$__shellm_rc
             SHELLM_ACTIVITY_FILE="$rundir/.activity"
             PATH="$(dirname "$shellm_path"):$PATH"
         )
+        # Provider credentials reach generated code through the environment,
+        # never argv. Profile-backed Bedrock credentials were materialized on
+        # the host, so sandboxes do not need ~/.aws or credential_process.
+        local _provider_var
+        for _provider_var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY \
+                             OPENROUTER_API_KEY OPENCODE_API_KEY \
+                             AWS_BEARER_TOKEN_BEDROCK AWS_ACCESS_KEY_ID \
+                             AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_REGION \
+                             AWS_DEFAULT_REGION; do
+            [[ -n "${!_provider_var:-}" ]] \
+                && env_vars+=("$_provider_var=${!_provider_var}")
+        done
         # Forward --var values
         for _ev in "${_SHELLM_EXTRA_VARS[@]+"${_SHELLM_EXTRA_VARS[@]}"}"; do
             env_vars+=("$_ev")
@@ -2851,6 +2907,8 @@ main() {
     fi
 
     [[ -z "$prompt" && -z "$_use_traj" ]] && { usage; }
+
+    _shellm_materialize_aws_profile_credentials
 
     if [[ "${#context_files[@]}" -gt 0 ]]; then
         run_loop "$prompt" "${context_files[@]}"

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -140,6 +140,10 @@ cap at 4 KB — plenty for an env file.
 Which key(s) to include is a `SHELLM_MODEL` decision — e.g.
 `SHELLM_MODEL=openai/gpt-oss-120b` routes via OpenRouter and needs
 `OPENROUTER_API_KEY`; a `claude-*` model needs `ANTHROPIC_API_KEY`.
+An `openai.gpt-*` model routes through Amazon Bedrock Mantle and needs
+`AWS_BEARER_TOKEN_BEDROCK` plus the matching `AWS_REGION`.
+Host installs may instead use `AWS_PROFILE`; Headlong refreshes the profile's
+credentials through AWS CLI and inherits its configured Region.
 Switching providers is just a different parameter value. Optional:
 `SHELLM_FAST_MODEL` sets a cheap model class for utility calls (run
 summaries, `mem search`) — worth setting when `SHELLM_MODEL` is an
@@ -281,4 +285,3 @@ aws ec2 start-instances --region <your-region> \
 # destroy everything (instance, tunnel, DNS, Access app)
 terraform destroy
 ```
-

--- a/design/model-resolution.md
+++ b/design/model-resolution.md
@@ -2,7 +2,7 @@
 
 Status: COMPLETE — documents shipped behavior; the resolution chains match bin/llm, bin/shellm, bin/mem, and thinkers/_lib/common.sh.
 
-**Status:** Current behavior (documented 2026-07-15)
+**Status:** Current behavior (documented 2026-08-27)
 
 How every LLM call in shellm decides which model to use, and where the
 environment variables that feed that decision come from. Two layers:
@@ -14,8 +14,11 @@ environment variables that feed that decision come from. Two layers:
 
 There is no hard provider dependency anywhere: `bin/llm` picks the
 provider from the model name (`claude-*` → Anthropic, `vendor/model` →
-OpenRouter, `gpt-*`/`o*` → OpenAI, `gemini-*` → Gemini) and each provider
-needs only its own `<PROVIDER>_API_KEY`. A model name that implies no
+OpenRouter, `gpt-*`/`o*` → OpenAI, `gemini-*` → Gemini, `openai.gpt-*` →
+Bedrock Mantle, and Bedrock-prefixed Anthropic/OpenAI IDs → Bedrock Runtime)
+and each provider needs only its own credential. Bedrock accepts
+`AWS_BEARER_TOKEN_BEDROCK`, standard AWS environment credentials, or an
+`AWS_PROFILE` resolved afresh through AWS CLI. A model name that implies no
 provider — a local OpenAI-compatible alias, say — is reached by setting
 `LLM_PROVIDER` or passing `--provider`; an env value that contradicts a
 name the harness *can* classify is still honored, but says so on stderr. Hardcoded `claude-*` names below
@@ -31,6 +34,9 @@ are last-resort defaults, reached only when nothing is configured.
 | `SHELLM_SUMMARY_MODEL` | Run-summary override; beats `SHELLM_FAST_MODEL` |
 | `LLM_MODEL` | `bin/llm`'s own knob; equivalent to `-m` |
 | `LLM_PROVIDER` | `bin/llm`'s provider override; equivalent to `--provider`. Needed when the model name implies no provider. A value that disagrees with what the name implies is honored, but warns on stderr |
+| `AWS_BEARER_TOKEN_BEDROCK` | Amazon Bedrock API key; preferred Bedrock authentication |
+| `AWS_PROFILE` | AWS CLI profile used to refresh Bedrock SigV4 credentials on each call |
+| `AWS_REGION` / `AWS_DEFAULT_REGION` | Bedrock endpoint Region; then the AWS profile Region; defaults to `us-east-1` |
 
 ## Resolution chains
 
@@ -105,4 +111,12 @@ SHELLM_MODEL=openai/gpt-oss-120b
 # Mixed quality: smart actor, cheap utilities
 SHELLM_MODEL=z-ai/glm-5.2
 SHELLM_FAST_MODEL=openai/gpt-oss-120b
+
+# Amazon Bedrock Mantle (OpenAI Responses API)
+AWS_BEARER_TOKEN_BEDROCK=...
+AWS_REGION=us-east-1
+SHELLM_MODEL=openai.gpt-5.6-sol
+
+# Alternative: use a refreshable AWS CLI profile instead of the bearer vars
+AWS_PROFILE=codex-bedrock
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -95,7 +95,7 @@ With no tty, every question falls back to an environment variable or a
 default, so a script or a coding agent can install with no interaction:
 
 ```bash
-export OPENROUTER_API_KEY=sk-or-...   # or ANTHROPIC_/OPENAI_/GEMINI_API_KEY
+export OPENROUTER_API_KEY=sk-or-...   # or another provider's *_API_KEY
 export HEADLONG_IDENTITY_NAME=ada       # optional; the interview's answers
 export HEADLONG_IDENTITY_VIBE="curious, warm, and plainspoken"
 export HEADLONG_IDENTITY_FOCUS="learning how their own mind works"
@@ -103,8 +103,36 @@ export HEADLONG_IDENTITY_USER="I'm Sam, a programmer trying Headlong out"
 curl -fsSL https://headlong.ai/install.sh | bash
 ```
 
-A key must be in the environment; everything else is optional.
+A provider credential must be in the environment; everything else is optional.
 `HEADLONG_NO_DASH=1` and `HEADLONG_NO_THINKERS=1` skip those parts.
+
+For Amazon Bedrock, use a Bedrock API key and the Region where it was created:
+
+```bash
+export AWS_BEARER_TOKEN_BEDROCK=...
+export AWS_REGION=us-east-1
+# Optional: Mantle OpenAI instead of the default Bedrock Claude model
+export SHELLM_MODEL=openai.gpt-5.6-sol
+curl -fsSL https://headlong.ai/install.sh | bash
+```
+
+`AWS_ACCESS_KEY_ID` plus `AWS_SECRET_ACCESS_KEY` (and, for temporary
+credentials, `AWS_SESSION_TOKEN`) can replace the Bedrock API key. The curl
+used for SigV4 authentication must be version 7.75 or newer.
+
+An AWS CLI profile is the durable choice when credentials come from SSO or a
+`credential_process`; Headlong asks AWS CLI for fresh credentials on each
+model call and persists the profile's configured Region:
+
+```bash
+export AWS_PROFILE=codex-bedrock
+curl -fsSL https://headlong.ai/install.sh | bash
+```
+
+Profile-backed installs stay on the host because a standalone agent container
+cannot safely invoke a host credential process. Generated shell commands are
+still Docker-sandboxed. Use `AWS_BEARER_TOKEN_BEDROCK` for the fully
+containerized install option.
 
 With no tty there is nobody to answer the sandbox question, so on a
 machine without a working Docker daemon the install stops unless

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -265,6 +265,12 @@ llm -m gemini-2.5-pro "translate to French: hello world"
 # OpenRouter (any vendor/model name)
 llm -m openai/gpt-oss-120b "what wakes you up in the morning?"
 
+# Amazon Bedrock: Claude via Bedrock Runtime
+AWS_BEARER_TOKEN_BEDROCK=... llm -m us.anthropic.claude-sonnet-4-6 "hello"
+
+# Amazon Bedrock: OpenAI via the Mantle Responses API
+AWS_BEARER_TOKEN_BEDROCK=... llm -m openai.gpt-5.6-sol "hello"
+
 # Multi-turn conversation from JSON
 llm -m claude-opus-4-7 -M '[{"role":"user","content":"hi"},{"role":"assistant","content":"hello!"},{"role":"user","content":"what did I just say?"}]'
 ```
@@ -276,7 +282,21 @@ llm -m claude-opus-4-7 -M '[{"role":"user","content":"hi"},{"role":"assistant","
 | `claude-*` | Anthropic (`ANTHROPIC_API_KEY`) |
 | `gpt-*`, `o1-*`, `o3-*`, `o4-*` | OpenAI (`OPENAI_API_KEY`) |
 | `gemini-*` | Gemini (`GEMINI_API_KEY`) |
+| `bedrock/<model>`, `anthropic.claude*`, `*.anthropic.claude*` | Amazon Bedrock Runtime (`AWS_BEARER_TOKEN_BEDROCK`) |
+| `openai.gpt-*` | Amazon Bedrock Mantle Responses API (`AWS_BEARER_TOKEN_BEDROCK`) |
+| `us.openai.gpt-*`, `global.openai.gpt-*`, etc. | Amazon Bedrock Runtime Responses API (`AWS_BEARER_TOKEN_BEDROCK`) |
 | `vendor/model` (any slash) | OpenRouter (`OPENROUTER_API_KEY`) |
+
+Bedrock uses `AWS_REGION`, then `AWS_DEFAULT_REGION`, and defaults to
+`us-east-1`. Bedrock API keys are region-bound, so set the matching region.
+Standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` credentials (and an
+optional `AWS_SESSION_TOKEN`) are also accepted through curl's SigV4 support.
+Setting `AWS_PROFILE` instead makes `llm` resolve fresh credentials through
+AWS CLI on every call; `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` are
+honored. If no Region environment variable is set, the profile Region is used.
+Mantle OpenAI models stream normally. Claude's Bedrock streaming transport is
+binary AWS event-stream rather than SSE, so `llm` uses non-streaming
+`InvokeModel` and caps `max_tokens` at that API's 21,333-token limit.
 
 **Output contract:** stdout = text response, stderr = thinking tokens (Anthropic only), exit 0 = success. This makes it composable with pipes and subshells.
 

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,10 @@ TOOLS=("${BIN_TOOLS[@]}" "${AUX_TOOLS[@]}")
 
 _pkg_hint() {
     local pkg="$1"
+    if [[ "$pkg" == "aws" ]]; then
+        printf 'install AWS CLI v2: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html'
+        return
+    fi
     if [[ "$(uname -s)" == "Darwin" ]]; then
         printf 'brew install %s' "$pkg"
     elif command -v apt-get >/dev/null 2>&1; then
@@ -65,11 +69,18 @@ _require_deps() {
 
     # Already root with apt available — a fresh container, typically — so
     # just install them. Still no sudo anywhere: as a normal user we only
-    # print the hints below.
+    # print the hints below. AWS CLI v2 is not an apt package named `aws`, so
+    # leave that one for the explicit installation hint.
     if [[ "$(id -u)" -eq 0 ]] && command -v apt-get >/dev/null 2>&1; then
-        echo "==> Installing missing dependencies: ${missing[*]}"
-        apt-get update -qq >/dev/null && \
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates "${missing[@]}" >/dev/null || true
+        local installable=()
+        for dep in "${missing[@]}"; do
+            [[ "$dep" == "aws" ]] || installable+=("$dep")
+        done
+        if [[ "${#installable[@]}" -gt 0 ]]; then
+            echo "==> Installing missing dependencies: ${installable[*]}"
+            apt-get update -qq >/dev/null && \
+                DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates "${installable[@]}" >/dev/null || true
+        fi
     fi
 
     for dep in "${missing[@]}"; do
@@ -100,11 +111,13 @@ _docker_daemon_ok() {
 # container, NUL-delimited for the caller to read into an array: the interview
 # answers are free text, so a value may contain a newline.
 #
-# Keys go by NAME. `-e VAR=value` puts the value in the docker client's argv,
+# Credentials and region config go by NAME. `-e VAR=value` puts the value in
+# the docker client's argv,
 # where `ps` shows it to every other user on the machine for as long as the
-# client runs; thinkers/_lib/common.sh forwards keys the same way for the same
-# reason, and tests/test_var_secrets.sh pins the rule for shellm. Docker reads a name-only
-# `-e VAR` from its own environment, so the name must be exported, which is why
+# client runs; thinkers/_lib/common.sh forwards credentials the same way for
+# the same reason, and tests/test_var_secrets.sh pins the rule for shellm.
+# Docker reads a name-only `-e VAR` from its own environment, so the name must
+# be exported, which is why
 # the answers below do NOT use it: install.sh assigns HEADLONG_REPO and
 # HEADLONG_BRANCH itself without exporting them, so a bare name would forward
 # nothing and the container would clone the default repo instead of the
@@ -112,7 +125,10 @@ _docker_daemon_ok() {
 _docker_forward_args() {
     local var
     for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
-               OPENCODE_API_KEY; do
+               OPENCODE_API_KEY AWS_BEARER_TOKEN_BEDROCK AWS_ACCESS_KEY_ID \
+               AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE \
+               AWS_CONFIG_FILE AWS_SHARED_CREDENTIALS_FILE AWS_REGION \
+               AWS_DEFAULT_REGION; do
         if [[ -n "${!var:-}" ]]; then
             export "${var?}"
             printf '%s\0%s\0' "-e" "$var"
@@ -167,6 +183,17 @@ EOF
             *)    echo 'Please answer 1, 2, or 3.' >/dev/tty ;;
         esac
     done
+
+    if [[ -n "${AWS_PROFILE:-}" && -z "${AWS_BEARER_TOKEN_BEDROCK:-}" ]]; then
+        cat <<EOF
+
+AWS_PROFILE=$AWS_PROFILE uses a host credential process or AWS config that a
+standalone agent container cannot refresh safely. Continuing with the host
+install instead; the agent's generated shell commands will still use Docker.
+Use AWS_BEARER_TOKEN_BEDROCK if you want the entire agent inside one container.
+EOF
+        return 0
+    fi
 
     # An agent container already exists: that IS the install. Go back in
     # instead of failing on the taken name.
@@ -224,7 +251,11 @@ EOF
 }
 
 _bootstrap_and_reexec() {
-    _require_deps git curl jq
+    if [[ -n "${AWS_PROFILE:-}" ]]; then
+        _require_deps git curl jq aws
+    else
+        _require_deps git curl jq
+    fi
 
     cat <<'EOF'
 
@@ -480,7 +511,11 @@ main() {
         esac
     done
 
-    _require_deps jq curl
+    if [[ -n "${AWS_PROFILE:-}" ]]; then
+        _require_deps jq curl aws
+    else
+        _require_deps jq curl
+    fi
 
     mkdir -p "$PREFIX"
     _install_tools

--- a/skills/shellm/SKILL.md
+++ b/skills/shellm/SKILL.md
@@ -12,7 +12,7 @@ description: Reference for the shellm system — recursive LLM shell, identity m
 shellm is a set of composable bash scripts that turn an LLM into an autonomous agent living in a shell. The stack, bottom to top:
 
 ```
-llm              raw LLM calls (Anthropic, OpenAI, Gemini)
+llm              raw LLM calls (Anthropic, OpenAI, Gemini, Bedrock, and more)
 shellm           recursive execute-in-shell loop on top of llm
 traj / context   step log (DAG) + message assembly for multi-turn
 mem / skills     persistent memory + learnable capabilities
@@ -30,7 +30,7 @@ An agent activates an identity (`source .identities/<name>/activate`), which set
 | Script | Purpose |
 |--------|---------|
 | `shellm` | Recursive LLM-in-bash loop. Sends a prompt to the LLM, executes returned bash code blocks, feeds output back, repeats until `FINAL` is set. The heart of the system. |
-| `llm` | Multi-provider LLM CLI. `llm [options] prompt` or stdin. Supports Anthropic, OpenAI, Gemini. Key flags: `-m MODEL`, `-s SYSTEM`, `-M MESSAGES_JSON`, `--stream`, `--thinking`. |
+| `llm` | Multi-provider LLM CLI. `llm [options] prompt` or stdin. Supports Anthropic, OpenAI, Gemini, OpenRouter, OpenCode, and Amazon Bedrock. Key flags: `-m MODEL`, `-s SYSTEM`, `-M MESSAGES_JSON`, `--stream`, `--thinking`. |
 
 ### Identity & activation
 

--- a/status.sh
+++ b/status.sh
@@ -69,7 +69,9 @@ else
     fi
     if [[ -d "$HEADLONG_HOME" ]]; then
         keys=""
-        for k in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY; do
+        for k in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
+                 OPENCODE_API_KEY AWS_BEARER_TOKEN_BEDROCK AWS_ACCESS_KEY_ID \
+                 AWS_PROFILE; do
             grep -q "^$k=" "$HEADLONG_HOME/.env" 2>/dev/null && keys="$keys $k"
         done
         model=$(sed -n 's/^SHELLM_MODEL=//p' "$HEADLONG_HOME/.env" 2>/dev/null | tail -1)

--- a/tests/test_install_secret_argv.sh
+++ b/tests/test_install_secret_argv.sh
@@ -29,9 +29,18 @@ sed '$ d' "$REPO/install.sh" > "$WORK/install.lib"
 
 SECRET=sk-or-ARGVCANARY
 OPENCODE_SECRET=sk-OPENCODECANARY
+BEDROCK_SECRET=BEDROCK-ARGVCANARY
+AWS_SECRET=AWS-SECRET-ARGVCANARY
 args=$(
     export OPENROUTER_API_KEY="$SECRET"
     export OPENCODE_API_KEY="$OPENCODE_SECRET"
+    export AWS_BEARER_TOKEN_BEDROCK="$BEDROCK_SECRET"
+    export AWS_ACCESS_KEY_ID=AKIAARGVCANARY
+    export AWS_SECRET_ACCESS_KEY="$AWS_SECRET"
+    export AWS_SESSION_TOKEN=AWS-SESSION-ARGVCANARY
+    export AWS_PROFILE=bedrock-profile
+    export AWS_CONFIG_FILE=/tmp/aws-config
+    export AWS_REGION=us-east-1
     export HEADLONG_IDENTITY_NAME=ada
     # Set, deliberately NOT exported, which is how install.sh leaves them.
     # shellcheck disable=SC2034  # read by _docker_forward_args through ${!var}
@@ -49,6 +58,15 @@ flat=" $args "   # padded so a match at either end still has a boundary
 case "$flat" in
     *"$SECRET"*) bad "no API key value on the docker command line" "found $SECRET in: $flat" ;;
     *)           ok  "no API key value on the docker command line" ;;
+esac
+case "$flat" in
+    *"-e AWS_PROFILE "*"-e AWS_CONFIG_FILE "*) ok "AWS profile configuration is forwarded by name" ;;
+    *) bad "AWS profile configuration is forwarded by name" "got: $flat" ;;
+esac
+case "$flat" in
+    *"$BEDROCK_SECRET"*|*"$AWS_SECRET"*) bad "Bedrock credentials stay off the docker command line" "got: $flat" ;;
+    *"-e AWS_BEARER_TOKEN_BEDROCK "*"-e AWS_SECRET_ACCESS_KEY "*) ok "Bedrock credentials are forwarded by name" ;;
+    *) bad "Bedrock credentials are forwarded by name" "got: $flat" ;;
 esac
 case "$flat" in
     *"-e OPENROUTER_API_KEY "*) ok "the key is forwarded by name" ;;
@@ -95,6 +113,8 @@ exported=$(
 # fills in are forwarded, and no key name appears at all.
 none=$(
     unset OPENROUTER_API_KEY ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENCODE_API_KEY
+    unset AWS_BEARER_TOKEN_BEDROCK AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+    unset AWS_PROFILE AWS_CONFIG_FILE AWS_SHARED_CREDENTIALS_FILE AWS_REGION AWS_DEFAULT_REGION
     unset HEADLONG_IDENTITY_NAME HEADLONG_IDENTITY_VIBE HEADLONG_IDENTITY_FOCUS
     unset HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME
     # shellcheck disable=SC1090  # generated copy of the installer under test
@@ -102,7 +122,7 @@ none=$(
     _docker_forward_args | tr '\0' ' '
 )
 case "$none" in
-    *API_KEY*) bad "no key is forwarded when none is set" "got: $none" ;;
+    *API_KEY*|*AWS_ACCESS_KEY_ID*|*AWS_SECRET_ACCESS_KEY*|*AWS_PROFILE*) bad "no key is forwarded when none is set" "got: $none" ;;
     *)         ok  "no key is forwarded when none is set" ;;
 esac
 

--- a/tests/test_key_var_resolution.sh
+++ b/tests/test_key_var_resolution.sh
@@ -33,7 +33,15 @@ printf '#!/usr/bin/env bash\ncase "${1:-}" in info) exit 0 ;; *) exit 0 ;; esac\
 # llm: always fails, so init stops right after writing SHELLM_MODEL. Without a
 # tty that is a single fast failure, which is all these assertions need.
 printf '#!/usr/bin/env bash\nexit 1\n' > "$STUB/llm"
-chmod +x "$STUB/docker" "$STUB/llm"
+cat > "$STUB/aws" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "configure get region --profile test-profile" ]]; then
+    printf 'us-west-2\n'
+    exit 0
+fi
+exit 1
+EOF
+chmod +x "$STUB/docker" "$STUB/llm" "$STUB/aws"
 
 APP="$WORK/app"; mkdir -p "$APP/bin" "$APP/tools"
 : > "$APP/bin/shellm"
@@ -43,7 +51,10 @@ run_init() {
     local home="$1"; shift
     mkdir -p "$home"
     env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY \
-        -u OPENCODE_API_KEY -u SHELLM_MODEL -u HEADLONG_UNSANDBOXED \
+        -u OPENCODE_API_KEY -u AWS_BEARER_TOKEN_BEDROCK -u AWS_ACCESS_KEY_ID \
+        -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN -u AWS_REGION -u AWS_DEFAULT_REGION \
+        -u AWS_PROFILE -u AWS_CONFIG_FILE -u AWS_SHARED_CREDENTIALS_FILE \
+        -u SHELLM_MODEL -u HEADLONG_UNSANDBOXED \
         HOME="$home" HEADLONG_HOME="$home/.headlong" HEADLONG_APP_DIR="$APP" \
         HEADLONG_NO_TTY=1 HEADLONG_UNSANDBOXED=1 PATH="$STUB:$PATH" "$@" \
         bash "$REPO/tools/headlong-init" </dev/null > "$WORK/out" 2>&1
@@ -89,6 +100,40 @@ run_init "$WORK/h5" OPENAI_API_KEY=sk-ant-api03-EXAMPLE-NOT-A-REAL-KEY
 check "misplaced sk-ant- key: model follows the key" \
     grep -qx 'SHELLM_MODEL=claude-sonnet-4-5-20250929' "$WORK/h5/.headlong/.env"
 
+# --- Bedrock bearer tokens and SigV4 credentials pick the Bedrock default ----
+run_init "$WORK/h8" AWS_BEARER_TOKEN_BEDROCK=BEDROCK-EXAMPLE-NOT-A-REAL-KEY
+check "Bedrock API key: picks the Bedrock Claude default" \
+    grep -qx 'SHELLM_MODEL=us.anthropic.claude-sonnet-4-6' "$WORK/h8/.headlong/.env"
+check "Bedrock API key: key and default region persist" bash -c \
+    'grep -qx "AWS_BEARER_TOKEN_BEDROCK=BEDROCK-EXAMPLE-NOT-A-REAL-KEY" "$1" && grep -qx "AWS_REGION=us-east-1" "$1"' \
+    _ "$WORK/h8/.headlong/.env"
+
+run_init "$WORK/h9" AWS_ACCESS_KEY_ID=AKIAEXAMPLE AWS_SECRET_ACCESS_KEY=EXAMPLE-NOT-A-REAL-SECRET
+check "AWS credential pair: picks the Bedrock Claude default" \
+    grep -qx 'SHELLM_MODEL=us.anthropic.claude-sonnet-4-6' "$WORK/h9/.headlong/.env"
+check "AWS credential pair: credentials persist for later launches" bash -c \
+    'grep -qx "AWS_ACCESS_KEY_ID=AKIAEXAMPLE" "$1" && grep -qx "AWS_SECRET_ACCESS_KEY=EXAMPLE-NOT-A-REAL-SECRET" "$1"' \
+    _ "$WORK/h9/.headlong/.env"
+
+run_init "$WORK/h12" AWS_PROFILE=test-profile AWS_CONFIG_FILE="$WORK/aws-config"
+check "AWS profile: picks the Bedrock Claude default" \
+    grep -qx 'SHELLM_MODEL=us.anthropic.claude-sonnet-4-6' "$WORK/h12/.headlong/.env"
+check "AWS profile: profile and config path persist" bash -c \
+    'grep -qx "AWS_PROFILE=test-profile" "$1" && grep -qx "AWS_CONFIG_FILE=$2" "$1"' \
+    _ "$WORK/h12/.headlong/.env" "$WORK/aws-config"
+check "AWS profile: configured region persists" \
+    grep -qx 'AWS_REGION=us-west-2' "$WORK/h12/.headlong/.env"
+
+run_init "$WORK/h10" OPENAI_API_KEY=ABSK-EXAMPLE-NOT-A-REAL-KEY
+check "misplaced ABSK key: recognized and persisted as a Bedrock API key" \
+    grep -qx 'AWS_BEARER_TOKEN_BEDROCK=ABSK-EXAMPLE-NOT-A-REAL-KEY' "$WORK/h10/.headlong/.env"
+check "misplaced ABSK key: model follows Bedrock" \
+    grep -qx 'SHELLM_MODEL=us.anthropic.claude-sonnet-4-6' "$WORK/h10/.headlong/.env"
+
+run_init "$WORK/h11" OPENAI_API_KEY=bedrock-api-key-EXAMPLE-NOT-A-REAL-KEY
+check "misplaced short-term Bedrock token: recognized as Bedrock" \
+    grep -qx 'AWS_BEARER_TOKEN_BEDROCK=bedrock-api-key-EXAMPLE-NOT-A-REAL-KEY' "$WORK/h11/.headlong/.env"
+
 # --- a stale SHELLM_MODEL pinned from the misfiled variable heals ------------
 # An earlier init derived gpt-5.5 from the key sitting in OPENAI_API_KEY;
 # reconciling the key must re-pin the model, or every later run keeps routing
@@ -128,6 +173,8 @@ export PAYLOAD_OUT="$WORK/payload.json"
 cd "$WORK" || exit 1
 env -u SHELLM_MODEL -u HEADLONG_HOME -u LLM_PROVIDER -u LLM_API_URL -u LLM_MODEL \
     -u OPENAI_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY -u OPENCODE_API_KEY \
+    -u AWS_BEARER_TOKEN_BEDROCK -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY \
+    -u AWS_PROFILE -u AWS_CONFIG_FILE -u AWS_SHARED_CREDENTIALS_FILE \
     PATH="$CURL_STUB:$PATH" LLM_RETRIES=0 \
     HOME="$WORK/h6" ANTHROPIC_API_KEY=sk-ant-test LLM_MAX_TOKENS=4242 \
     bash "$REPO/bin/llm" -m claude-sonnet-4-5-20250929 hi >/dev/null 2>&1
@@ -140,6 +187,8 @@ check "bin/llm: LLM_MAX_TOKENS from the environment reaches the request" \
 printf 'echo POLLUTION\nLLM_MAX_TOKENS=1234\n' > "$WORK/.env"
 env -u SHELLM_MODEL -u HEADLONG_HOME -u LLM_PROVIDER -u LLM_API_URL -u LLM_MODEL \
     -u OPENAI_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY -u OPENCODE_API_KEY \
+    -u AWS_BEARER_TOKEN_BEDROCK -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY \
+    -u AWS_PROFILE -u AWS_CONFIG_FILE -u AWS_SHARED_CREDENTIALS_FILE \
     -u LLM_MAX_TOKENS \
     PATH="$CURL_STUB:$PATH" LLM_RETRIES=0 \
     HOME="$WORK/h6" ANTHROPIC_API_KEY=sk-ant-test \

--- a/tests/test_llm_bedrock.sh
+++ b/tests/test_llm_bedrock.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# test_llm_bedrock.sh - Amazon Bedrock routing, payloads, auth, and Responses SSE
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ - $2}"; }
+check() { local label="$1"; shift; if "$@" >/dev/null 2>&1; then ok "$label"; else bad "$label"; fi; }
+check_not() { local label="$1"; shift; if "$@" >/dev/null 2>&1; then bad "$label"; else ok "$label"; fi; }
+
+mkdir -p "$WORK/bin" "$WORK/home"
+cat > "$WORK/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CURL_ARGS"
+
+out_file=""
+body=""
+url=""
+config=""
+prev=""
+for arg in "$@"; do
+    case "$prev" in
+        -o) out_file="$arg" ;;
+        -d) body="$arg" ;;
+        --config) config="$arg" ;;
+    esac
+    [[ "$arg" == http* ]] && url="$arg"
+    prev="$arg"
+done
+case "$body" in
+    @*) cp "${body#@}" "$PAYLOAD_OUT" ;;
+esac
+[[ -z "$config" ]] || cp "$config" "$SIGV4_OUT"
+
+if [[ -n "$out_file" ]]; then
+    if [[ "$url" == */model/*/invoke ]]; then
+        printf '%s' '{"content":[{"type":"thinking","thinking":"considering"},{"type":"text","text":"claude ok"}],"stop_reason":"end_turn","usage":{"input_tokens":12,"output_tokens":3}}' > "$out_file"
+    else
+        printf '%s' '{"status":"completed","output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"reasoned"}]},{"type":"message","content":[{"type":"output_text","text":"mantle "}]},{"type":"message","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":20,"output_tokens":5,"output_tokens_details":{"reasoning_tokens":2}}}' > "$out_file"
+    fi
+    printf '200'
+else
+    printf 'event: response.reasoning_summary_text.delta\n'
+    printf 'data: {"type":"response.reasoning_summary_text.delta","delta":"reasoned"}\n\n'
+    printf 'event: response.output_text.delta\n'
+    printf 'data: {"type":"response.output_text.delta","delta":"mantle "}\n\n'
+    printf 'event: response.output_text.delta\n'
+    printf 'data: {"type":"response.output_text.delta","delta":"ok"}\n\n'
+    printf 'event: response.completed\n'
+    printf 'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":20,"output_tokens":5,"output_tokens_details":{"reasoning_tokens":2}}}}\n\n'
+fi
+EOF
+chmod +x "$WORK/bin/curl"
+cat > "$WORK/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "configure get region --profile test-profile" ]]; then
+    printf 'ap-southeast-2\n'
+    exit 0
+fi
+if [[ "$*" == "configure export-credentials --profile test-profile --format process" ]]; then
+    n=$(( $(cat "$AWS_EXPORT_COUNT" 2>/dev/null || echo 0) + 1 ))
+    printf '%s' "$n" > "$AWS_EXPORT_COUNT"
+    printf '{"Version":1,"AccessKeyId":"PROFILEKEY%s","SecretAccessKey":"profile-secret-%s","SessionToken":"profile-session-%s"}\n' "$n" "$n" "$n"
+    exit 0
+fi
+printf 'unexpected aws invocation: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$WORK/bin/aws"
+
+export PATH="$WORK/bin:$PATH"
+export HEADLONG_HOME="$WORK/home"
+export CURL_ARGS="$WORK/curl.args"
+export PAYLOAD_OUT="$WORK/payload.json"
+export SIGV4_OUT="$WORK/sigv4.conf"
+export AWS_EXPORT_COUNT="$WORK/aws-export-count"
+export LLM_RETRIES=0 LLM_USAGE_LEDGER=/dev/null
+unset ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY OPENCODE_API_KEY
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE AWS_CONFIG_FILE AWS_SHARED_CREDENTIALS_FILE
+unset AWS_DEFAULT_REGION HEADLONG_AWS_PROFILE_CREDENTIALS LLM_PROVIDER LLM_API_URL LLM_MODEL SHELLM_MODEL
+export AWS_BEARER_TOKEN_BEDROCK="bedrock-test-token"
+
+LLM="$REPO/bin/llm"
+run_llm() { (cd "$WORK" && "$LLM" "$@"); }
+reset() { : > "$CURL_ARGS"; : > "$PAYLOAD_OUT"; : > "$SIGV4_OUT"; }
+
+# Claude uses InvokeModel and automatically takes the non-streaming path.
+reset
+out=$(AWS_REGION=eu-west-1 run_llm --stream -m 'bedrock/us.anthropic.claude-sonnet-4-6-v1:0' \
+    --thinking --effort high 'say ok' 2>"$WORK/stderr")
+check "Claude response extracted" test "$out" = "claude ok"
+check "Claude model routes to Bedrock Runtime" grep -q 'bedrock-runtime.eu-west-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6-v1%3A0/invoke' "$CURL_ARGS"
+check "Bedrock routing prefix is stripped" jq -e '.model == null' "$PAYLOAD_OUT"
+check "Claude payload uses Bedrock Messages version" jq -e '.anthropic_version == "bedrock-2023-05-31"' "$PAYLOAD_OUT"
+check "Claude payload omits stream" jq -e 'has("stream") | not' "$PAYLOAD_OUT"
+check "Claude payload retains thinking and effort" jq -e '.thinking.type == "adaptive" and .output_config.effort == "high"' "$PAYLOAD_OUT"
+check "Claude non-streaming cap stays within InvokeModel limit" jq -e '.max_tokens == 21333' "$PAYLOAD_OUT"
+check "explicit Claude streaming explains fallback" grep -q 'binary event frames' "$WORK/stderr"
+check "Claude non-streaming thinking is emitted on stderr" grep -q 'considering' "$WORK/stderr"
+check "Bedrock API key is bearer auth" grep -q 'Authorization: Bearer bedrock-test-token' "$CURL_ARGS"
+
+# Claude 4.5 predates adaptive thinking; translate effort to a fixed budget.
+reset
+out=$(run_llm --no-stream -m 'us.anthropic.claude-sonnet-4-5-20250929-v1:0' \
+    --thinking --effort high -t 10000 'say ok' 2>"$WORK/stderr")
+check "older Claude response extracted" test "$out" = "claude ok"
+check "older Claude uses fixed-budget thinking" jq -e '.thinking.type == "enabled" and .thinking.budget_tokens == 8192' "$PAYLOAD_OUT"
+check "older Claude drops unsupported output effort" jq -e 'has("output_config") | not' "$PAYLOAD_OUT"
+
+# gpt-oss uses Mantle's default /v1 Responses route and streams typed SSE.
+reset
+out=$(run_llm -m openai.gpt-oss-120b -t 321 'say ok' 2>"$WORK/stderr")
+check "Mantle gpt-oss stream extracted" test "$out" = "mantle ok"
+check "Mantle reasoning summary streams on stderr" grep -q 'reasoned' "$WORK/stderr"
+check "gpt-oss uses Mantle default Responses route" grep -q 'bedrock-mantle.us-east-1.api.aws/v1/responses' "$CURL_ARGS"
+check_not "gpt-oss avoids first-party OpenAI route" grep -q '/openai/v1/responses' "$CURL_ARGS"
+check "Responses payload uses input messages" jq -e '.model == "openai.gpt-oss-120b" and .input[0].content == "say ok"' "$PAYLOAD_OUT"
+check "Responses payload streams without retention" jq -e '.stream == true and .store == false and .max_output_tokens == 321' "$PAYLOAD_OUT"
+
+# First-party GPT models use Mantle's special /openai/v1 route.
+reset
+out=$(run_llm -m openai.gpt-5.6-sol --thinking high --system-prompt 'be terse' 'say ok' 2>"$WORK/stderr")
+check "Mantle GPT-5.6 stream extracted" test "$out" = "mantle ok"
+check "GPT-5.6 uses Mantle OpenAI Responses route" grep -q 'bedrock-mantle.us-east-1.api.aws/openai/v1/responses' "$CURL_ARGS"
+check "Responses payload carries instructions and reasoning" jq -e '.instructions == "be terse" and .reasoning.effort == "high"' "$PAYLOAD_OUT"
+
+# Non-streaming extraction scans all output items rather than assuming index 0.
+reset
+out=$(LLM_USAGE_FILE="$WORK/usage.json" run_llm --no-stream -m openai.gpt-5.6-sol 'say ok' 2>"$WORK/stderr")
+check "non-streaming Responses output is joined" test "$out" = "mantle ok"
+check "non-streaming Responses reasoning is on stderr" grep -q 'reasoned' "$WORK/stderr"
+check "Responses usage is recorded" jq -e '.in_tok == 20 and .out_tok == 5 and .think_tok == 2' "$WORK/usage.json"
+
+# Geographic/global OpenAI IDs are valid on Bedrock Runtime's Responses API.
+reset
+out=$(run_llm -m global.openai.gpt-5.6-sol 'say ok' 2>"$WORK/stderr")
+check "runtime OpenAI stream extracted" test "$out" = "mantle ok"
+check "global OpenAI ID uses Runtime Responses route" grep -q 'bedrock-runtime.us-east-1.amazonaws.com/openai/v1/responses' "$CURL_ARGS"
+
+# Standard AWS credentials are the fallback and the secret stays off argv.
+reset
+unset AWS_BEARER_TOKEN_BEDROCK
+export AWS_ACCESS_KEY_ID=AKIATEST AWS_SECRET_ACCESS_KEY='secret/test+value' AWS_SESSION_TOKEN='session/test+value'
+out=$(run_llm --no-stream -m openai.gpt-oss-120b 'say ok' 2>"$WORK/stderr")
+check "SigV4 fallback succeeds" test "$out" = "mantle ok"
+check "Mantle SigV4 service is configured" grep -q 'aws:amz:us-east-1:bedrock-mantle' "$SIGV4_OUT"
+check "SigV4 config contains the AWS credentials" grep -q 'AKIATEST:secret/test+value' "$SIGV4_OUT"
+check "SigV4 config includes the session token" grep -q 'x-amz-security-token: session/test+value' "$SIGV4_OUT"
+check_not "AWS secret is absent from curl argv" grep -q 'secret/test+value' "$CURL_ARGS"
+
+# AWS_PROFILE resolves credential_process credentials for every llm invocation
+# and supplies the profile's region when no region environment variable exists.
+reset
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_REGION AWS_DEFAULT_REGION
+export AWS_PROFILE=test-profile
+out=$(run_llm --no-stream -t 256 'say ok' 2>"$WORK/stderr")
+check "AWS profile alone selects the Bedrock Claude default" test "$out" = "claude ok"
+check "AWS profile region selects the Bedrock endpoint" grep -q 'bedrock-runtime.ap-southeast-2.amazonaws.com' "$CURL_ARGS"
+check "AWS profile credentials feed curl SigV4" grep -q 'PROFILEKEY1:profile-secret-1' "$SIGV4_OUT"
+check_not "profile secret is absent from curl argv" grep -q 'profile-secret-1' "$CURL_ARGS"
+
+reset
+out=$(run_llm --no-stream -m openai.gpt-oss-120b 'say ok' 2>"$WORK/stderr")
+check "AWS profile works with Mantle" test "$out" = "mantle ok"
+check "AWS profile is resolved again for the next call" grep -q 'PROFILEKEY2:profile-secret-2' "$SIGV4_OUT"
+check "credential_process export ran once per call" test "$(cat "$AWS_EXPORT_COUNT")" = 2
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_sandbox_gate.sh
+++ b/tests/test_sandbox_gate.sh
@@ -52,6 +52,8 @@ run_init() {
     local home="$1"; shift
     mkdir -p "$home"
     env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY \
+        -u OPENCODE_API_KEY -u AWS_BEARER_TOKEN_BEDROCK -u AWS_ACCESS_KEY_ID \
+        -u AWS_SECRET_ACCESS_KEY -u AWS_PROFILE \
         -u HEADLONG_UNSANDBOXED -u HEADLONG_FAKE_DOCKER -u SHELLM_DOCKER_IMAGE -u SHELLM_MODEL \
         HOME="$home" HEADLONG_HOME="$home/.headlong" HEADLONG_APP_DIR="$APP" \
         HEADLONG_NO_TTY=1 PATH="$STUB:$PATH" "$@" \
@@ -95,6 +97,8 @@ check "fake ok: sandbox promised despite a down daemon"  grep -qx "SHELLM_REQUIR
 # --- --dry-run: walks the gate, writes nothing, exits 0 ----------------------
 mkdir -p "$WORK/h6"
 env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY \
+    -u OPENCODE_API_KEY -u AWS_BEARER_TOKEN_BEDROCK -u AWS_ACCESS_KEY_ID \
+    -u AWS_SECRET_ACCESS_KEY -u AWS_PROFILE \
     -u HEADLONG_UNSANDBOXED -u SHELLM_DOCKER_IMAGE -u SHELLM_MODEL \
     HOME="$WORK/h6" HEADLONG_HOME="$WORK/h6/.headlong" HEADLONG_APP_DIR="$APP" \
     HEADLONG_NO_TTY=1 HEADLONG_FAKE_DOCKER=ok PATH="$STUB:$PATH" \

--- a/tests/test_thinker_env_fallback.sh
+++ b/tests/test_thinker_env_fallback.sh
@@ -112,7 +112,7 @@ out=$(
     unset OPENROUTER_API_KEY HEADLONG_HOME SHELLM_HOME
     mkdir -p "$H/id/memories" "$H/id/skills" "$H/id/kernel" "$H/id/trajectories" "$H/.headlong" "$H/wd"
     printf 'name=probe\n' > "$H/id/info.txt"
-    printf 'OPENROUTER_API_KEY=from-headlong\n' > "$H/.headlong/.env"
+    printf 'OPENROUTER_API_KEY=from-headlong\nAWS_BEARER_TOKEN_BEDROCK=bedrock-from-headlong\nAWS_PROFILE=test-profile\nAWS_CONFIG_FILE=/tmp/test-aws-config\nAWS_REGION=us-west-2\n' > "$H/.headlong/.env"
     export IDENTITY_DIR="$H/id" TRAJ_DIR="$H/id/trajectories" TRAJ_ID=t1 MEM_DIR="$H/id/memories"
     cd "$H/wd" || exit 1
     # shellcheck disable=SC1090  # the library under test
@@ -123,6 +123,14 @@ out=$(
 case "$out" in
     *"--var OPENROUTER_API_KEY "*) ok "the key is forwarded to the nested shellm" ;;
     *) bad "the key is forwarded to the nested shellm" "no bare --var for it" ;;
+esac
+case "$out" in
+    *"--var AWS_BEARER_TOKEN_BEDROCK "*"--var AWS_REGION "*) ok "Bedrock key and region are forwarded to the nested shellm" ;;
+    *) bad "Bedrock key and region are forwarded to the nested shellm" "missing bare --var entries" ;;
+esac
+case "$out" in
+    *"--var AWS_PROFILE "*"--var AWS_CONFIG_FILE "*) ok "AWS profile configuration is forwarded to the nested shellm" ;;
+    *) bad "AWS profile configuration is forwarded to the nested shellm" "missing bare --var entries" ;;
 esac
 
 echo

--- a/tests/test_var_secrets.sh
+++ b/tests/test_var_secrets.sh
@@ -42,6 +42,15 @@ printf '%s' "$n" > "$LLM_COUNT"
 if [[ -f "$LLM_SCRIPT/$n" ]]; then cat "$LLM_SCRIPT/$n"; else cat "$LLM_SCRIPT/last"; fi
 STUB
 chmod +x "$WORK/toolbin/llm"
+cat > "$WORK/toolbin/aws" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == "configure export-credentials --profile sandbox-profile --format process" ]]; then
+    printf '{"Version":1,"AccessKeyId":"PROFILEACCESS","SecretAccessKey":"profile-secret-value","SessionToken":"profile-session-value"}\n'
+    exit 0
+fi
+exit 1
+STUB
+chmod +x "$WORK/toolbin/aws"
 
 export PATH="$WORK/toolbin:$PATH"
 export LLM_COUNT="$WORK/count"
@@ -130,6 +139,25 @@ if [[ "$hits" -eq 0 ]]; then
     ok "forwarded secret is nowhere under the state home"
 else
     bad "forwarded secret is nowhere under the state home" "$(grep -rlF "$SECRET" "$HEADLONG_HOME" | head -3)"
+fi
+
+# --- 4. AWS profile credentials are resolved on the host for generated code --
+unset ANTHROPIC_API_KEY AWS_BEARER_TOKEN_BEDROCK AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+export AWS_PROFILE=sandbox-profile AWS_REGION=us-east-1
+export SHELLM_MODEL=openai.gpt-5.6-sol
+fence "printf '%s %s %s' \"\$AWS_ACCESS_KEY_ID\" \"\$AWS_SECRET_ACCESS_KEY\" \"\$AWS_SESSION_TOKEN\" > '$WORK/aws-profile.txt'
+ps -axo args= > '$WORK/aws-profile-ps.txt' 2>/dev/null || ps -eo args= > '$WORK/aws-profile-ps.txt'" > "$WORK/script/1"
+fence 'FINAL=done' > "$WORK/script/last"
+run_shellm "profile task"
+if grep -qx 'PROFILEACCESS profile-secret-value profile-session-value' "$WORK/aws-profile.txt" 2>/dev/null; then
+    ok "AWS profile credentials reach generated code"
+else
+    bad "AWS profile credentials reach generated code" "$(cat "$WORK/aws-profile.txt" 2>/dev/null)"
+fi
+if ! grep -qF 'profile-secret-value' "$WORK/aws-profile-ps.txt" 2>/dev/null; then
+    ok "resolved AWS profile secret stays off process argv"
+else
+    bad "resolved AWS profile secret stays off process argv" "secret found in ps snapshot"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -339,13 +339,18 @@ _build_shellm_flags() {
     printf '%s\n' "--var" "TRAJ_DIR=$abs_traj_dir"
     printf '%s\n' "--var" "TRAJ_ID=$TRAJ_ID"
 
-    # Propagate model + API keys to nested shellm calls. Inside Docker, .env
+    # Propagate model + provider credentials to nested shellm calls. Inside
+    # Docker, .env
     # isn't mounted, so without these the nested call hits the final else in
     # bin/shellm's model fallback and fails with "ANTHROPIC_API_KEY is not set".
-    # Keys go by NAME (bare `--var NAME`): shellm reads the value from its
-    # environment, so it never shows up in `ps` or the recorded command line.
+    # Credentials and region go by NAME (bare `--var NAME`): shellm reads the
+    # value from its environment, so it never shows up in `ps` or the recorded
+    # command line.
     [[ -n "${SHELLM_MODEL:-}" ]] && printf '%s\n' "--var" "SHELLM_MODEL=$SHELLM_MODEL"
-    for _ak in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY; do
+    for _ak in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
+               AWS_BEARER_TOKEN_BEDROCK AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
+               AWS_SESSION_TOKEN AWS_PROFILE AWS_CONFIG_FILE \
+               AWS_SHARED_CREDENTIALS_FILE AWS_REGION AWS_DEFAULT_REGION; do
         if [[ -n "${!_ak:-}" ]]; then
             export "${_ak?}"
             printf '%s\n' "--var" "$_ak"

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -290,7 +290,8 @@ EOF
 # ---------------------------------------------------------------------------
 
 _have_key() {
-    [[ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GEMINI_API_KEY:-}${OPENROUTER_API_KEY:-}${OPENCODE_API_KEY:-}" ]]
+    [[ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GEMINI_API_KEY:-}${OPENROUTER_API_KEY:-}${OPENCODE_API_KEY:-}${AWS_BEARER_TOKEN_BEDROCK:-}${AWS_PROFILE:-}" \
+       || ( -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ) ]]
 }
 
 _key_var_for() {  # guess the provider env var from the key's prefix
@@ -298,6 +299,7 @@ _key_var_for() {  # guess the provider env var from the key's prefix
         sk-ant-*) echo ANTHROPIC_API_KEY ;;
         sk-or-*)  echo OPENROUTER_API_KEY ;;
         AIza*)    echo GEMINI_API_KEY ;;
+        ABSK*|bedrock-api-key-*) echo AWS_BEARER_TOKEN_BEDROCK ;;
         sk-*)     echo OPENAI_API_KEY ;;
         *)        echo "" ;;
     esac
@@ -310,17 +312,20 @@ _default_model_for() {
         GEMINI_API_KEY)     echo "gemini-3.5-flash" ;;
         OPENROUTER_API_KEY) echo "anthropic/claude-sonnet-4.5" ;;
         OPENCODE_API_KEY)   echo "opencode-go/deepseek-v4-flash" ;;
+        AWS_BEARER_TOKEN_BEDROCK|AWS_ACCESS_KEY_ID|AWS_PROFILE) echo "us.anthropic.claude-sonnet-4-6" ;;
     esac
 }
 
 _key_var_unambiguous() {  # the ONLY provider var a key's prefix can belong to
     # Deliberately stricter than _key_var_for: a bare sk- key is OpenAI *or*
     # OpenCode (see _prompt_key, which has to ask), so it is not evidence of
-    # anything and must never move a key. Only these three prefixes settle it.
+    # anything and must never move a key. Only these provider-specific
+    # prefixes settle it.
     case "$1" in
         sk-ant-*) echo ANTHROPIC_API_KEY ;;
         sk-or-*)  echo OPENROUTER_API_KEY ;;
         AIza*)    echo GEMINI_API_KEY ;;
+        ABSK*|bedrock-api-key-*) echo AWS_BEARER_TOKEN_BEDROCK ;;
         *)        echo "" ;;
     esac
 }
@@ -372,6 +377,12 @@ _first_key_var() {  # the provider var to use (llm's priority order)
         want=$(_key_var_unambiguous "${!var}")
         [[ -z "$want" || "$want" == "$var" ]] && { echo "$var"; return 0; }
     done
+    [[ -n "${AWS_BEARER_TOKEN_BEDROCK:-}" ]] && { echo AWS_BEARER_TOKEN_BEDROCK; return 0; }
+    if [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+        echo AWS_ACCESS_KEY_ID
+        return 0
+    fi
+    [[ -n "${AWS_PROFILE:-}" ]] && { echo AWS_PROFILE; return 0; }
     # Every key present contradicts its variable and _reconcile_key_vars could
     # not place one (it never runs inside $(...)); fall back to the old
     # first-set-wins so behavior is unchanged rather than absent.
@@ -390,6 +401,40 @@ _llm_ok() {
     # Generous cap: reasoning models spend thinking tokens against -t, and
     # a too-small budget makes the reply come back empty.
     llm -t 256 "Reply with the single word: ok" >/dev/null 2>>"$INIT_LOG"
+}
+
+_model_uses_bedrock() {
+    case "${SHELLM_MODEL:-}" in
+        bedrock/*|openai.gpt-*|*.openai.gpt-*|anthropic.claude*|*.anthropic.claude*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+_persist_bedrock_environment() {
+    _model_uses_bedrock || return 0
+
+    # Persist whichever authentication path the runtime will actually prefer.
+    # The state env is mode 600, matching all other provider key storage.
+    if [[ -n "${AWS_BEARER_TOKEN_BEDROCK:-}" ]]; then
+        _env_set "$HEADLONG_HOME/.env" AWS_BEARER_TOKEN_BEDROCK "$AWS_BEARER_TOKEN_BEDROCK"
+    elif [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+        _env_set "$HEADLONG_HOME/.env" AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID"
+        _env_set "$HEADLONG_HOME/.env" AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
+        [[ -z "${AWS_SESSION_TOKEN:-}" ]] \
+            || _env_set "$HEADLONG_HOME/.env" AWS_SESSION_TOKEN "$AWS_SESSION_TOKEN"
+    elif [[ -n "${AWS_PROFILE:-}" ]]; then
+        _env_set "$HEADLONG_HOME/.env" AWS_PROFILE "$AWS_PROFILE"
+        [[ -z "${AWS_CONFIG_FILE:-}" ]] \
+            || _env_set "$HEADLONG_HOME/.env" AWS_CONFIG_FILE "$AWS_CONFIG_FILE"
+        [[ -z "${AWS_SHARED_CREDENTIALS_FILE:-}" ]] \
+            || _env_set "$HEADLONG_HOME/.env" AWS_SHARED_CREDENTIALS_FILE "$AWS_SHARED_CREDENTIALS_FILE"
+    fi
+
+    local region="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+    if [[ -z "$region" && -n "${AWS_PROFILE:-}" ]] && command -v aws >/dev/null 2>&1; then
+        region=$(aws configure get region --profile "$AWS_PROFILE" 2>/dev/null || true)
+    fi
+    _env_set "$HEADLONG_HOME/.env" AWS_REGION "${region:-us-east-1}"
 }
 
 _prompt_key() {
@@ -424,12 +469,13 @@ _prompt_key() {
         esac
     elif [[ -z "$var" ]]; then
         local which
-        which=$(ask "Which provider is that key for? (1) Anthropic (2) OpenAI (3) Gemini (4) OpenRouter (5) OpenCode" "1")
+        which=$(ask "Which provider is that key for? (1) Anthropic (2) OpenAI (3) Gemini (4) OpenRouter (5) OpenCode (6) Amazon Bedrock" "1")
         case "$which" in
             2) var=OPENAI_API_KEY ;;
             3) var=GEMINI_API_KEY ;;
             4) var=OPENROUTER_API_KEY ;;
             5) var=OPENCODE_API_KEY ;;
+            6) var=AWS_BEARER_TOKEN_BEDROCK ;;
             *) var=ANTHROPIC_API_KEY ;;
         esac
     fi
@@ -442,12 +488,12 @@ _prompt_key() {
 _ensure_api_key() {
     _reconcile_key_vars
     if ! _have_key && [[ "$HAS_TTY" -eq 0 ]]; then
-        die "no API key found. Set ANTHROPIC_API_KEY (or OPENAI/GEMINI/OPENROUTER/OPENCODE_API_KEY), or put it in $HEADLONG_HOME/.env"
+        die "no API key found. Set ANTHROPIC_API_KEY (or OPENAI/GEMINI/OPENROUTER/OPENCODE_API_KEY/AWS_BEARER_TOKEN_BEDROCK/AWS_PROFILE), or put it in $HEADLONG_HOME/.env"
     fi
     if ! _have_key; then
         cat >/dev/tty <<'EOF'
 
-Headlong needs an LLM API key (Anthropic, OpenAI, Gemini, OpenRouter, or OpenCode).
+Headlong needs an LLM API key (Anthropic, OpenAI, Gemini, OpenRouter, OpenCode, or Amazon Bedrock).
 Paste just the key itself; headlong-init figures out the provider from it.
 
   * Use a DEDICATED, SPEND-CAPPED key. The agent you're about to create
@@ -468,6 +514,7 @@ EOF
     if [[ -z "${SHELLM_MODEL:-}" ]]; then
         _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$(_default_model_for "$(_first_key_var)")"
     fi
+    _persist_bedrock_environment
 
     # A default identity means an earlier init already validated a key.
     # Unattended re-runs (a restarted container: tty allocated, nobody


### PR DESCRIPTION
## Summary

Adds Amazon Bedrock as an inference provider for Headlong.

- Claude models use Bedrock Runtime's `InvokeModel` API.
- OpenAI `openai.gpt-*` models use the Bedrock Mantle Responses API, including streaming.
- Authentication supports Bedrock API keys, standard AWS credentials, and refreshable `AWS_PROFILE` / `credential_process` credentials.
- The installer detects Bedrock credentials, persists the selected Region and authentication configuration, and propagates credentials safely through shellm and its Docker sandbox.
- Documentation and provider-specific regression tests are included.

## Verification

- Live Claude and Mantle calls passed with both bearer-token and SigV4 authentication.
- Live profile-only calls passed using refreshed credentials from AWS CLI.
- All 32 shell test suites pass.
