### PR TITLE
shellm: a sibling directory is not a mounted one

### DIFF
--- a/bin/shellm
+++ b/bin/shellm
@@ -758,6 +758,48 @@ env_metadata_mismatch_message() {
         "$env_name" "$stored_access" "$SHELLM_DOCKER_ACCESS"
 }
 
+# Collapse an absolute path lexically: drop empty and `.` segments, pop one
+# level per `..`, and emit no trailing slash. Purely textual, and deliberately
+# not realpath: these paths are compared as CONTAINER paths, and docker
+# normalizes `..` the same way in both -w and a mount destination (`-w /a/../b`
+# lands on /a/b). Resolving symlinks here would judge the host source instead,
+# so a workdir symlinked into the runs dir but mounted at its own link path
+# would read as covered by a mount that does not contain it.
+#
+# No forks and no word splitting: bin/shellm also runs on macOS bash 3.2, and
+# splitting on IFS=/ would glob a segment containing `*`.
+_norm_path() {
+    local rest="$1" out="" seg
+    while [[ -n "$rest" ]]; do
+        seg="${rest%%/*}"
+        if [[ "$seg" == "$rest" ]]; then rest=""; else rest="${rest#*/}"; fi
+        case "$seg" in
+            ""|.) ;;
+            ..)   out="${out%/*}" ;;
+            *)    out="$out/$seg" ;;
+        esac
+    done
+    printf '%s\n' "${out:-/}"
+}
+
+# True when `path` is already covered by an existing bind mount rooted at
+# `root`. Both are container-side paths: these decide whether docker_setup
+# still needs a -v for a directory, and inside the container a path is
+# reachable only if it sits under a mount destination.
+#
+# Normalize before comparing, and require a path boundary. A bare prefix test
+# reads a sibling as a child (`/x/workdirs` "covering" `/x/workdirs-scratch`),
+# which cost the sibling its -v while docker still made the -w directory, so
+# the run continued against an empty directory with no error anywhere.
+_path_covered() {
+    local path root
+    path=$(_norm_path "$1")
+    root=$(_norm_path "$2")
+    # ${root%/} so a root of "/" yields the pattern /* rather than //*, which
+    # matches nothing and would leave every path uncovered by the filesystem root.
+    [[ "$path" == "$root" || "$path" == "${root%/}"/* ]]
+}
+
 docker_setup_die() {
     local message="$1"
     if [[ -n "${_SHELLM_CONTAINER:-}" ]]; then
@@ -824,7 +866,7 @@ docker_setup() {
     done
 
     # Make custom workdirs visible when they live outside the state home.
-    if [[ "$workspace" != "$runs_mount"* ]]; then
+    if ! _path_covered "$workspace" "$runs_mount"; then
         extra_mounts+=(-v "$workspace:$workspace")
         seen_dirs+=("$workspace")
     fi
@@ -835,7 +877,7 @@ docker_setup() {
         _id_abs=$(cd "$IDENTITY_DIR" && pwd)
         local _id_covered=0
         for d in "${seen_dirs[@]}"; do
-            [[ "$_id_abs" == "$d" || "$_id_abs" == "$d"/* ]] && { _id_covered=1; break; }
+            _path_covered "$_id_abs" "$d" && { _id_covered=1; break; }
         done
         if [[ "$_id_covered" -eq 0 ]]; then
             extra_mounts+=(-v "$_id_abs:$_id_abs")
@@ -849,10 +891,10 @@ docker_setup() {
         abs_path=$(realpath "$f")
         abs_dir=$(dirname "$abs_path")
         # Skip if under workspace or an already mounted parent.
-        [[ "$abs_dir" == "$workspace"* ]] && continue
+        _path_covered "$abs_dir" "$workspace" && continue
         local already=0
         for d in "${seen_dirs[@]+"${seen_dirs[@]}"}"; do
-            [[ "$abs_dir" == "$d"* ]] && { already=1; break; }
+            _path_covered "$abs_dir" "$d" && { already=1; break; }
         done
         [[ "$already" -eq 1 ]] && continue
         seen_dirs+=("$abs_dir")
@@ -867,7 +909,7 @@ docker_setup() {
         abs_dir=$(cd "$_val" && pwd) || continue
         local already=0
         for d in "${seen_dirs[@]+"${seen_dirs[@]}"}"; do
-            [[ "$abs_dir" == "$d"* ]] && { already=1; break; }
+            _path_covered "$abs_dir" "$d" && { already=1; break; }
         done
         [[ "$already" -eq 1 ]] && continue
         seen_dirs+=("$abs_dir")
@@ -897,7 +939,7 @@ docker_setup() {
             # Skip if already under a mounted dir
             local _covered=0
             for _sd in "${seen_dirs[@]}"; do
-                [[ "$_tdir" == "$_sd" || "$_tdir" == "$_sd"/* ]] && { _covered=1; break; }
+                _path_covered "$_tdir" "$_sd" && { _covered=1; break; }
             done
             [[ "$_covered" -eq 1 ]] && continue
             # Skip if already collected
@@ -1128,7 +1170,7 @@ docker_container_can_reach_path() {
     local cid="$1" path="$2" dest
     while IFS= read -r dest; do
         [[ -n "$dest" ]] || continue
-        [[ "$path" == "$dest" || "$path" == "$dest"/* ]] && return 0
+        _path_covered "$path" "$dest" && return 0
     done < <(docker inspect -f '{{range .Mounts}}{{.Destination}}{{"\n"}}{{end}}' "$cid" 2>/dev/null)
     return 1
 }

--- a/tests/test_shellm_mount_coverage.sh
+++ b/tests/test_shellm_mount_coverage.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# tests/test_shellm_mount_coverage.sh — which directories docker_setup believes
+# an existing bind mount already covers.
+#
+# Usage: tests/test_shellm_mount_coverage.sh
+#
+# Why: the coverage test used to be a bare prefix match, so `/x/workdirs` read
+# as covering the sibling `/x/workdirs-scratch`. The sibling then got no -v,
+# docker created an empty directory at the -w path, and the run continued with
+# the operator's files invisible and the agent's writes discarded — silently.
+# It also decided container reuse, so a workdir it could never mount produced a
+# fresh container on every run.
+#
+# These are container-side paths: a path inside the container is reachable only
+# if it sits under a mount destination, and docker normalizes `..` in both -w
+# and destinations (`-w /a/../b` lands on /a/b). So the predicate normalizes
+# lexically and must NOT resolve symlinks — resolving would judge the host
+# source instead, and a workdir symlinked into the runs dir but mounted at its
+# link path would read as covered by a mount that does not contain it.
+#
+# The function is exercised directly; no docker daemon and no network.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+SHELLM="$REPO/bin/shellm"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+# Pull just the functions under test out of shellm, which otherwise runs main.
+eval "$(awk '/^_norm_path\(\)/,/^}/' "$SHELLM")"
+eval "$(awk '/^_path_covered\(\)/,/^}/' "$SHELLM")"
+
+type _path_covered >/dev/null 2>&1 || { echo "FAIL _path_covered not extractable from bin/shellm"; exit 1; }
+
+# covered PATH ROOT -> expect "yes" or "no"
+covered() { if _path_covered "$1" "$2"; then echo yes; else echo no; fi; }
+
+t() {
+    local want="$1" path="$2" root="$3" label="$4" got
+    got=$(covered "$path" "$root")
+    if [[ "$got" == "$want" ]]; then ok "$label"
+    else bad "$label" "covered('$path','$root') = $got, want $want"; fi
+}
+
+# --- existing semantics: these held before the fix and must keep holding ---
+t yes /x/workdirs          /x/workdirs   "a path is covered by itself"
+t yes /x/workdirs/run1     /x/workdirs   "a genuine child is covered"
+t yes /x/workdirs/a/b/c    /x/workdirs   "a deep child is covered"
+t no  /x/other             /x/workdirs   "an unrelated path is not covered"
+t no  /x                   /x/workdirs   "a parent is not covered by its child"
+t yes /anything/at/all     /             "the root covers everything"
+
+# --- the defect: a sibling that merely shares the root's text ---
+t no  /x/workdirs-scratch  /x/workdirs   "a sibling sharing the prefix is NOT covered"
+t no  /x/workdirsX         /x/workdirs   "a sibling with one extra char is NOT covered"
+t no  /x/workdirs.bak/f    /x/workdirs   "a file under a prefix-sharing sibling is NOT covered"
+
+# --- the defect: unnormalized paths, which docker normalizes before acting ---
+t no  /x/workdirs/../scratch    /x/workdirs  "a .. escape out of the root is NOT covered"
+t yes /x/workdirs/run/../run2   /x/workdirs  "a .. that stays inside is still covered"
+t yes /x/workdirs/./run1        /x/workdirs  "a . segment does not defeat coverage"
+t yes /x//workdirs//run1        /x/workdirs  "duplicate slashes do not defeat coverage"
+t yes /x/workdirs/run1/         /x/workdirs  "a trailing slash does not defeat coverage"
+t yes /x/workdirs/run1          /x/workdirs/ "a trailing slash on the root still covers"
+t no  /x/workdirs/../../etc     /x/workdirs  "a .. climb above the root is NOT covered"
+
+# --- segments that must survive verbatim: no globbing, no word splitting ---
+t yes '/x/workdirs/a*b'        /x/workdirs      "a glob char in a segment is data, not a pattern"
+t no  '/x/workdirs*/evil'      /x/workdirs      "a glob char does not widen the root"
+t yes '/x/work dirs/run1'      '/x/work dirs'   "a space in a segment is preserved"
+t yes '/x/workdirs/[a]'        /x/workdirs      "bracket chars in a segment are data"
+
+# --- degenerate inputs: must not crash, and must not widen coverage ---
+n() { local got; got=$(_norm_path "$1"); if [[ "$got" == "$2" ]]; then ok "$3"; else bad "$3" "_norm_path('$1') = '$got', want '$2'"; fi; }
+n ''          /  "an empty path normalizes to the root"
+n /           /  "the root normalizes to itself"
+n ///         /  "repeated slashes collapse to the root"
+n /..         /  "a .. at the root cannot climb past it"
+n /a/../..    /  "a .. climb past the root stops at the root"
+n /a/b/../c   /a/c "a .. pops exactly one level"
+t no  ''      /x   "an empty path is not covered by a real root"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ $((pass + fail)) -ge 27 ]] || { printf 'FAIL only %d assertions ran; expected at least 27\n' "$((pass + fail))"; exit 1; }
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Fixes #81.

`docker_setup` decided whether a directory was already covered by an existing bind mount with a bare prefix test, `[[ "$abs_dir" == "$d"* ]]`. A path is a textual prefix of its siblings, so `/x/workdirs` read as covering `/x/workdirs-scratch` and the sibling got no `-v`. Docker still received `-w` on that path and created an empty directory there, so the run continued with the operator's files invisible and the agent's writes discarded at teardown, with no error on any surface.

It also decided container reuse. `docker_container_can_reach_path` compares against real mount destinations, so it correctly reported that the container could not reach the workdir and forced a new one, which `docker_setup` then built with the same missing mount. Three runs with the same `--workdir` produced three containers where an ordinary workdir produced one and reused it twice.

## Why a path boundary is not the whole fix

The obvious patch is `== "$d" || == "$d"/*`, which is what lines 838 and 900 already did. It closes the sibling case and leaves the class open: the predicate also never normalized, and `--workdir "$SHELLM_WORKDIRS_DIR/../scratch"` genuinely is `"$runs_mount"/*` as a string, so it stays unmounted. I ran that against a boundary-only build to be sure rather than assuming it.

The comparison also wants normalization rather than resolution, which is the opposite of the call made for the compose gate in #47. These are container paths, not host paths: inside the container a path is reachable only if it sits under a mount destination, and docker normalizes `..` in both `-w` and destinations (`-w /a/../b` lands on `/a/b`, and a destination containing `..` is stored normalized). Resolving symlinks would judge the host source instead, so a workdir symlinked into the workdirs dir but mounted at its own link path would begin reading as covered by a mount that does not contain it.

So both halves now go through one `_path_covered` that normalizes lexically and requires a boundary, used at all seven sites: the four that were wrong, the two that already had the boundary right, and the reuse check that had drifted from them.

## Verification

Test-first, with the seam extracted carrying the old behavior first so the red run was a real failure rather than `command not found`: 10 passed and 6 failed with the wrong values printed, then 27 passed after the change.

Against a real daemon (docker 29.1.3), asserting on the mount list `docker_setup` produced:

| case | expected | before | after |
| --- | --- | --- | --- |
| workdir is a prefix-sharing sibling | mounted | missing | mounted |
| workdir reached through `..` | mounted | missing | mounted |
| `-f` file's dir is a prefix-sharing sibling | mounted | missing | mounted |
| `--var` dir is a prefix-sharing sibling | mounted | missing | mounted |
| workdir inside the workdirs dir | reachable | ok | ok |
| workdir plainly outside it | mounted | ok | ok |
| identity dir is a prefix-sharing sibling | mounted | ok | ok |
| symlink target dir is a prefix-sharing sibling | mounted | ok | ok |
| identity dir, `-f` dir, `--var` dir, symlink target already inside the workdir | no second mount | ok | ok |

Three runs with the same `--workdir` now create one container and reuse it, for both the sibling and the `..` spelling.

`tests/run-all.sh` passes, the shellcheck gate is clean, and the new test passes under bash 3.2.57 as well as bash 5. I have not run the macOS job itself; the change shells out to nothing, so it is pure bash 3.2 syntax, but that job is the real gate.

The unit test covers the predicate directly, including the degenerate inputs (empty, `/`, repeated slashes, `..` climbing past the root) and segments containing glob and bracket characters, since the helper avoids word splitting on purpose.
