### PR TITLE
keep API keys out of curl arguments

### DIFF
--- a/bin/llm
+++ b/bin/llm
@@ -622,39 +622,62 @@ build_payload_opencode() {
 # URL and headers per provider
 # ---------------------------------------------------------------------------
 
+# Secret headers reach curl through a 0600 config file (`-K file`), never argv:
+# argv is readable by every same-host process (`ps`, /proc/*/cmdline) for the
+# life of the request (issue #80). Unlike `-H @file`, which needs curl 7.55,
+# config files work with the older curl shipped by macOS Mojave. Non-secret
+# headers stay on argv. One file is reused across retries and removed by
+# _llm_cleanup.
+_llm_auth_file=""
+add_auth_header() {
+    local _header="$1"
+    # Curl config values are double quoted. Escape every character that curl
+    # treats specially inside those quotes so an unusual key cannot add a
+    # second config option.
+    _header="${_header//\\/\\\\}"
+    _header="${_header//\"/\\\"}"
+    _header="${_header//$'\t'/\\t}"
+    _header="${_header//$'\n'/\\n}"
+    _header="${_header//$'\r'/\\r}"
+    _header="${_header//$'\v'/\\v}"
+    _llm_auth_file=$(mktemp "${TMPDIR:-/tmp}/llm-auth.XXXXXX")
+    printf 'header = "%s"\n' "$_header" > "$_llm_auth_file"
+    headers+=(-K "$_llm_auth_file")
+}
+
 get_url_headers() {
     case "$LLM_PROVIDER" in
         anthropic)
             [[ -z "${ANTHROPIC_API_KEY:-}" ]] && die "ANTHROPIC_API_KEY is not set"
             url="${LLM_API_URL:-https://api.anthropic.com/v1/messages}"
             headers=(-H "content-type: application/json"
-                     -H "x-api-key: $ANTHROPIC_API_KEY"
                      -H "anthropic-version: 2023-06-01")
+            add_auth_header "x-api-key: $ANTHROPIC_API_KEY"
             ;;
         openai)
             [[ -z "${OPENAI_API_KEY:-}" ]] && die "OPENAI_API_KEY is not set"
             url="${LLM_API_URL:-https://api.openai.com/v1/chat/completions}"
-            headers=(-H "Content-Type: application/json"
-                     -H "Authorization: Bearer $OPENAI_API_KEY")
+            headers=(-H "Content-Type: application/json")
+            add_auth_header "Authorization: Bearer $OPENAI_API_KEY"
             ;;
         openrouter)
             [[ -z "${OPENROUTER_API_KEY:-}" ]] && die "OPENROUTER_API_KEY is not set"
             url="${LLM_API_URL:-https://openrouter.ai/api/v1/chat/completions}"
-            headers=(-H "Content-Type: application/json"
-                     -H "Authorization: Bearer $OPENROUTER_API_KEY")
+            headers=(-H "Content-Type: application/json")
+            add_auth_header "Authorization: Bearer $OPENROUTER_API_KEY"
             ;;
         opencode)
             [[ -z "${OPENCODE_API_KEY:-}" ]] && die "OPENCODE_API_KEY is not set"
             url="${LLM_API_URL:-https://opencode.ai/zen/v1/messages}"
             headers=(-H "content-type: application/json"
-                     -H "x-api-key: $OPENCODE_API_KEY"
                      -H "anthropic-version: 2023-06-01")
+            add_auth_header "x-api-key: $OPENCODE_API_KEY"
             ;;
         opencode-go)
             [[ -z "${OPENCODE_API_KEY:-}" ]] && die "OPENCODE_API_KEY is not set"
             url="${LLM_API_URL:-https://opencode.ai/zen/go/v1/chat/completions}"
-            headers=(-H "Content-Type: application/json"
-                     -H "Authorization: Bearer $OPENCODE_API_KEY")
+            headers=(-H "Content-Type: application/json")
+            add_auth_header "Authorization: Bearer $OPENCODE_API_KEY"
             ;;
         openai-compatible)
             # SHELLM_API_URL fallback, like SHELLM_MODEL above: shellm clears
@@ -666,7 +689,7 @@ get_url_headers() {
             [[ -z "$url" ]] && die "LLM_API_URL is not set (openai-compatible has no default endpoint; e.g. http://localhost:11434/v1/chat/completions for Ollama)"
             headers=(-H "Content-Type: application/json")
             if [[ -n "${LLM_API_KEY:-}" ]]; then
-                headers+=(-H "Authorization: Bearer $LLM_API_KEY")
+                add_auth_header "Authorization: Bearer $LLM_API_KEY"
             fi
             ;;
         gemini)
@@ -674,8 +697,8 @@ get_url_headers() {
             local action="generateContent"
             [[ "$LLM_STREAM" -eq 1 ]] && action="streamGenerateContent?alt=sse"
             url="${LLM_API_URL:-https://generativelanguage.googleapis.com/v1beta/models/${LLM_MODEL}:${action}}"
-            headers=(-H "Content-Type: application/json"
-                     -H "x-goog-api-key: $GEMINI_API_KEY")
+            headers=(-H "Content-Type: application/json")
+            add_auth_header "x-goog-api-key: $GEMINI_API_KEY"
             ;;
         *)
             die "Unknown provider: $LLM_PROVIDER"
@@ -1006,6 +1029,7 @@ if [[ -z "$LLM_USAGE_FILE" ]]; then
 fi
 _llm_cleanup() {
     rm -f "$payload_file"
+    if [[ -n "${_llm_auth_file:-}" ]]; then rm -f "$_llm_auth_file"; fi
     if [[ -n "${_adapter_dir:-}" ]]; then rm -rf "$_adapter_dir"; fi
     if [[ "$_llm_usage_own" -eq 1 ]]; then rm -f "$LLM_USAGE_FILE"; fi
     return 0

--- a/bin/shellm
+++ b/bin/shellm
@@ -262,6 +262,13 @@ redact_sensitive() {
         output="${output//${LLM_API_KEY}/<redacted-api-key>}"
     fi
 
+    local _key_var
+    for _key_var in OPENAI_API_KEY OPENROUTER_API_KEY GEMINI_API_KEY OPENCODE_API_KEY; do
+        if [[ -n "${!_key_var:-}" ]]; then
+            output="${output//${!_key_var}/<redacted-api-key>}"
+        fi
+    done
+
     printf '%s' "$output" | LC_ALL=C sed -E 's/sk-ant-[A-Za-z0-9._-]+/<redacted-anthropic-key>/g'
 }
 

--- a/tests/test_llm_openai_compatible.sh
+++ b/tests/test_llm_openai_compatible.sh
@@ -10,7 +10,8 @@
 #   - the provider works with NO API key of any kind set (the point of it:
 #     Ollama and friends need no key, and no dummy key masquerade either)
 #   - no Authorization header is sent when LLM_API_KEY is unset
-#   - LLM_API_KEY, when set, is sent as a Bearer token
+#   - LLM_API_KEY, when set, is sent as a Bearer token through a curl config
+#     file with mode 0600, never on curl's argv (issue #80)
 #   - LLM_API_URL is required: without it the call dies loudly
 #   - SHELLM_API_URL works as the fallback URL (direct llm callers in a
 #     shellm deployment: thinkers, mem, recap)
@@ -41,9 +42,10 @@ bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
 
 # --- curl stub ---------------------------------------------------------------
 # Records every argument in $CURL_ARGS and copies the -d @file payload to
-# $CURL_PAYLOAD (the real payload tempfile is gone by the time the test can
-# look), then answers with one SSE chunk plus [DONE], or a JSON body on the
-# non-streaming (-o) path.
+# $CURL_PAYLOAD and any -K config files to $CURL_HEADERS (the real tempfiles are
+# gone by the time the test can look; the config file's mode lands in
+# $CURL_HEADERS_MODE), then answers with one SSE chunk plus [DONE], or a JSON
+# body on the non-streaming (-o) path.
 mkdir -p "$WORK/bin"
 cat > "$WORK/bin/curl" <<'EOF'
 #!/usr/bin/env bash
@@ -53,6 +55,10 @@ prev=""
 for a in "$@"; do
     [[ "$prev" == "-o" ]] && out_file="$a"
     [[ "$prev" == "-d" && "$a" == @* ]] && cat "${a#@}" > "$CURL_PAYLOAD"
+    if [[ "$prev" == "-K" ]]; then
+        cat "$a" >> "$CURL_HEADERS"
+        { stat -c %a "$a" 2>/dev/null || stat -f %Lp "$a"; } >> "$CURL_HEADERS_MODE"
+    fi
     prev="$a"
 done
 if [[ -n "$out_file" ]]; then
@@ -70,6 +76,8 @@ export HEADLONG_HOME="$WORK/home"   # bin/llm writes run/llm_health.json here
 mkdir -p "$HEADLONG_HOME"
 export CURL_ARGS="$WORK/curl_args"
 export CURL_PAYLOAD="$WORK/curl_payload"
+export CURL_HEADERS="$WORK/curl_headers"
+export CURL_HEADERS_MODE="$WORK/curl_headers_mode"
 export LLM_RETRIES=0
 # Keyless operation is the point of this provider: every key must be absent,
 # along with any .env-sourced overrides the suite's shell may carry. cd to
@@ -82,7 +90,7 @@ cd "$WORK" || exit 1
 LLM="$REPO/bin/llm"
 URL="http://127.0.0.1:9/v1/chat/completions"
 
-reset() { : > "$CURL_ARGS"; : > "$CURL_PAYLOAD"; }
+reset() { : > "$CURL_ARGS"; : > "$CURL_PAYLOAD"; : > "$CURL_HEADERS"; : > "$CURL_HEADERS_MODE"; }
 
 # ---------------------------------------------------------------------------
 # Works with no API key of any kind
@@ -102,8 +110,8 @@ if grep -q '127.0.0.1:9' "$CURL_ARGS"; then
 else
     bad "request went to LLM_API_URL"
 fi
-if grep -qi 'authorization' "$CURL_ARGS"; then
-    bad "no Authorization header without LLM_API_KEY" "$(grep -im1 authorization "$CURL_ARGS")"
+if grep -qi 'authorization' "$CURL_ARGS" "$CURL_HEADERS"; then
+    bad "no Authorization header without LLM_API_KEY" "$(grep -ihm1 authorization "$CURL_ARGS" "$CURL_HEADERS")"
 else
     ok "no Authorization header without LLM_API_KEY"
 fi
@@ -120,10 +128,40 @@ fi
 reset
 LLM_PROVIDER=openai-compatible LLM_API_URL="$URL" LLM_API_KEY="sekrit" \
     "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
-if grep -q 'Authorization: Bearer sekrit' "$CURL_ARGS"; then
+if grep -q 'Authorization: Bearer sekrit' "$CURL_HEADERS"; then
     ok "LLM_API_KEY is sent as Authorization: Bearer"
 else
     bad "LLM_API_KEY is sent as Authorization: Bearer" "$(head -1 "$WORK/stderr")"
+fi
+# The whole point of the config file: the key must never ride curl's argv,
+# where any same-host process can read it via ps (issue #80).
+if grep -q 'sekrit' "$CURL_ARGS"; then
+    bad "LLM_API_KEY stays off curl's argv" "$(grep -m1 sekrit "$CURL_ARGS")"
+else
+    ok "LLM_API_KEY stays off curl's argv"
+fi
+if grep -qx '600' "$CURL_HEADERS_MODE"; then
+    ok "auth config file is mode 600"
+else
+    bad "auth config file is mode 600" "mode: $(cat "$CURL_HEADERS_MODE")"
+fi
+
+# Quotes, backslashes, and newlines have meaning in a curl config file. They
+# must stay inside the header value instead of becoming another config option.
+reset
+odd_key=$'sek"rit\\part\nurl = "https://wrong.example"'
+LLM_PROVIDER=openai-compatible LLM_API_URL="$URL" LLM_API_KEY="$odd_key" \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+if [[ "$(wc -l < "$CURL_HEADERS" | tr -d ' ')" -eq 1 ]] \
+   && grep -Fq 'header = "Authorization: Bearer sek\"rit\\part\nurl = \"https://wrong.example\""' "$CURL_HEADERS"; then
+    ok "auth config escapes quoted values"
+else
+    bad "auth config escapes quoted values" "$(head -1 "$CURL_HEADERS")"
+fi
+if grep -Fq "$odd_key" "$CURL_ARGS"; then
+    bad "escaped LLM_API_KEY stays off curl's argv" "key found in argv"
+else
+    ok "escaped LLM_API_KEY stays off curl's argv"
 fi
 
 # ---------------------------------------------------------------------------
@@ -231,6 +269,12 @@ if grep -q 'LLM_API_URL overrides the default openai endpoint (requests go to 12
     ok "LLM_API_URL on a keyed provider warns on stderr"
 else
     bad "LLM_API_URL on a keyed provider warns on stderr" "$(head -1 "$WORK/stderr")"
+fi
+# Keyed vendor providers use the same config file as openai-compatible.
+if grep -q 'Authorization: Bearer sekrit' "$CURL_HEADERS" && ! grep -q 'sekrit' "$CURL_ARGS"; then
+    ok "keyed provider (openai) sends its key via the config file, not argv"
+else
+    bad "keyed provider (openai) sends its key via the config file, not argv" "$(grep -m1 sekrit "$CURL_ARGS")"
 fi
 
 # The warning names the host only: credentials a URL can carry (userinfo,

--- a/tests/test_redact_sensitive.sh
+++ b/tests/test_redact_sensitive.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# tests/test_redact_sensitive.sh — redact_sensitive masks every provider key.
+#
+# Usage: tests/test_redact_sensitive.sh
+#
+# The function is extracted from bin/shellm and exercised directly (sourcing
+# the whole script would run it). Every provider key env var's value must
+# come back masked, and the sk-ant- pattern is masked even with no env var
+# carrying the value.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+eval "$(sed -n '/^redact_sensitive()/,/^}/p' "$REPO/bin/shellm")"
+if ! declare -f redact_sensitive >/dev/null; then
+    bad "redact_sensitive extracted from bin/shellm"
+    printf '\n%d passed, %d failed\n' "$pass" "$fail"
+    exit 1
+fi
+
+for var in ANTHROPIC_API_KEY LLM_API_KEY OPENAI_API_KEY OPENROUTER_API_KEY \
+           GEMINI_API_KEY OPENCODE_API_KEY; do
+    secret="key-$$-$RANDOM$RANDOM"
+    export "$var=$secret"
+    out=$(redact_sensitive "before $secret after")
+    if [[ "$out" != *"$secret"* && "$out" == *redacted* ]]; then
+        ok "$var value is masked"
+    else
+        bad "$var value is masked" "$out"
+    fi
+    unset "$var"
+done
+
+out=$(redact_sensitive "token sk-ant-abc123XYZ here")
+if [[ "$out" == *'<redacted-anthropic-key>'* && "$out" != *sk-ant-abc123XYZ* ]]; then
+    ok "sk-ant- pattern is masked without the env var"
+else
+    bad "sk-ant- pattern is masked without the env var" "$out"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
fixes #80 

Pass authentication headers through private curl config files instead of process arguments. Redact every supported provider key from shellm output and add tests for both protections.