### PR TITLE
telegram: send chat files as documents/photos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LOC_LIMIT: 11000
+      LOC_LIMIT: 11500
     steps:
       - uses: actions/checkout@v5
       - name: Install cloc

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![CI](https://github.com/laude-institute/headlong/actions/workflows/ci.yml/badge.svg)](https://github.com/laude-institute/headlong/actions/workflows/ci.yml)
 
 **Headlong** is an open source agent microharness, a complete agent harness
-with a core of about 10K lines of Bash.
+with a core of about 11K lines of Bash.
 
 [Launch post](https://www.laude.org/updates/headlong-a-microharness-for-persistent-agents) |
 [Announcement](https://x.com/andykonwinski/status/2091990178638496195)
@@ -158,7 +158,7 @@ Headlong also gives an agent a few convenience tools, such as a way to
 distill and codify its experience (`mem`) and a way to save and reuse
 procedures for specialized tasks (`skills`). The core is the tools the
 running mind executes, the executables in `bin/` plus the thought
-processes in `thinkers/`, and it comes to about 10K lines by cloc's count. A
+processes in `thinkers/`, and it comes to about 11K lines by cloc's count (capped at 11.5K). A
 harness this small can be read end to end, and it is easy to modify and
 experiment with.
 

--- a/bin/chat
+++ b/bin/chat
@@ -214,15 +214,22 @@ cmd_send_file() {
 
     local filename
     filename=$(basename "$filepath")
-    local content
-    content=$(cat "$filepath")
+    # Binary-safe: JSON cannot hold raw bytes, so stamp standard base64.
+    local content_b64
+    content_b64=$(python3 -c 'import base64,sys; print(base64.b64encode(open(sys.argv[1],"rb").read()).decode("ascii"))' "$filepath") \
+        || die "failed to base64-encode $filepath"
 
-    printf '{"type":"message","filename":%s,"content":%s,"from":%s,"to":%s,"source":"chat"}' \
-        "$(printf '%s' "$filename" | jq -Rsa .)" \
-        "$(printf '%s' "$content" | jq -Rsa .)" \
-        "$(printf '%s' "$from" | jq -Rsa .)" \
-        "$(printf '%s' "$to" | jq -Rsa .)" \
-        | _chat_append
+    python3 -c 'import json,sys
+filename, content_b64, frm, to = sys.argv[1:5]
+print(json.dumps({
+    "type": "message",
+    "filename": filename,
+    "content_b64": content_b64,
+    "from": frm,
+    "to": to,
+    "source": "chat",
+}, separators=(",", ":")))
+' "$filename" "$content_b64" "$from" "$to" | _chat_append
 
     printf 'File sent: %s\n' "$filename" >&2
 }

--- a/bin/chat
+++ b/bin/chat
@@ -219,10 +219,11 @@ cmd_send_file() {
     # (same class of leak as API keys on curl command lines).
     base64 -w 0 < "$filepath" | tr -d '\n' | jq -nc \
         --arg filename "$filename" \
+        --arg content "[file: $filename]" \
         --arg from "$from" \
         --arg to "$to" \
         --rawfile content_b64 /dev/stdin \
-        '{type:"message", filename:$filename, content_b64:$content_b64, from:$from, to:$to, source:"chat"}' \
+        '{type:"message", content:$content, filename:$filename, content_b64:$content_b64, from:$from, to:$to, source:"chat"}' \
         | _chat_append \
         || die "failed to encode/append $filepath"
 

--- a/bin/chat
+++ b/bin/chat
@@ -226,20 +226,56 @@ cmd_send_file() {
 
     local filename
     filename=$(basename "$filepath")
-    # Binary-safe: JSON cannot hold raw bytes, so stamp standard base64.
-    # Read the encoding via jq --rawfile so the bytes never sit on argv
-    # (same class of leak as API keys on curl command lines).
-    base64 -w 0 < "$filepath" | tr -d '\n' | jq -nc \
-        --arg filename "$filename" \
-        --arg content "[file: $filename]" \
-        --arg from "$from" \
-        --arg to "$to" \
-        --rawfile content_b64 /dev/stdin \
-        '{type:"message", content:$content, filename:$filename, content_b64:$content_b64, from:$from, to:$to, source:"chat"}' \
-        | _chat_append \
-        || die "failed to encode/append $filepath"
+    # Binary-safe: JSON cannot hold raw bytes, so stamp standard base64
+    # via a temp file (never argv). Text files also keep their body in
+    # `content` so Slack and web chat still deliver the file text; binary
+    # files use a short marker because `content` cannot hold raw bytes.
+    local b64tmp
+    b64tmp=$(mktemp) || die "mktemp failed"
+    if ! base64 -w 0 < "$filepath" | tr -d '\n' > "$b64tmp"; then
+        rm -f "$b64tmp"
+        die "failed to encode $filepath"
+    fi
+
+    local jq_rc=0
+    if _chat_is_text_file "$filepath"; then
+        jq -nc \
+            --arg filename "$filename" \
+            --arg from "$from" \
+            --arg to "$to" \
+            --rawfile content "$filepath" \
+            --rawfile content_b64 "$b64tmp" \
+            '{type:"message", content:($content | sub("\n+$";"")), filename:$filename, content_b64:$content_b64, from:$from, to:$to, source:"chat"}' \
+            | _chat_append || jq_rc=$?
+    else
+        jq -nc \
+            --arg filename "$filename" \
+            --arg content "[file: $filename]" \
+            --arg from "$from" \
+            --arg to "$to" \
+            --rawfile content_b64 "$b64tmp" \
+            '{type:"message", content:$content, filename:$filename, content_b64:$content_b64, from:$from, to:$to, source:"chat"}' \
+            | _chat_append || jq_rc=$?
+    fi
+    rm -f "$b64tmp"
+    [[ "$jq_rc" -eq 0 ]] || die "failed to encode/append $filepath"
 
     printf 'File sent: %s\n' "$filename" >&2
+}
+
+# UTF-8, no NUL: the historical `content=$(cat ...)` shape Slack/web still read.
+# JSON strings cannot hold NUL; jq --rawfile requires UTF-8.
+_chat_is_text_file() {
+    local f="$1" n stripped
+    n=$(wc -c < "$f")
+    n=${n//[[:space:]]/}
+    stripped=$(tr -d '\0' < "$f" | wc -c)
+    stripped=${stripped//[[:space:]]/}
+    [[ "$n" -eq "$stripped" ]] || return 1
+    if command -v iconv >/dev/null 2>&1; then
+        iconv -f UTF-8 -t UTF-8 "$f" >/dev/null 2>&1 || return 1
+    fi
+    return 0
 }
 
 # ---------------------------------------------------------------------------

--- a/bin/chat
+++ b/bin/chat
@@ -210,6 +210,18 @@ cmd_send_file() {
     [[ -z "$filepath" ]] && die "Usage: chat send-file [--from <name>] [--to <name>] <filename>"
     [[ -f "$filepath" ]] || die "File not found: $filepath"
 
+    local size max
+    size=$(stat -c%s "$filepath" 2>/dev/null || wc -c < "$filepath")
+    size=${size//[[:space:]]/}
+    max="${CHAT_SEND_FILE_MAX_BYTES:-10485760}"
+    [[ "$max" =~ ^[0-9]+$ ]] || die "CHAT_SEND_FILE_MAX_BYTES must be an integer"
+    if (( size == 0 )); then
+        die "empty file: $filepath"
+    fi
+    if (( size > max )); then
+        die "file too large: $filepath ($size bytes; max $max)"
+    fi
+
     _resolve_from_to
 
     local filename
@@ -592,6 +604,8 @@ Environment:
   MEM_DIR         Memories dir; `type: person` memories with `person_key`
                   and `aliases` merge several keys into one person for
                   history --with
+  CHAT_SEND_FILE_MAX_BYTES
+                  Max file size for `chat send-file` (default 10485760)
 EOF
     exit 0
 }

--- a/bin/chat
+++ b/bin/chat
@@ -215,21 +215,16 @@ cmd_send_file() {
     local filename
     filename=$(basename "$filepath")
     # Binary-safe: JSON cannot hold raw bytes, so stamp standard base64.
-    local content_b64
-    content_b64=$(python3 -c 'import base64,sys; print(base64.b64encode(open(sys.argv[1],"rb").read()).decode("ascii"))' "$filepath") \
-        || die "failed to base64-encode $filepath"
-
-    python3 -c 'import json,sys
-filename, content_b64, frm, to = sys.argv[1:5]
-print(json.dumps({
-    "type": "message",
-    "filename": filename,
-    "content_b64": content_b64,
-    "from": frm,
-    "to": to,
-    "source": "chat",
-}, separators=(",", ":")))
-' "$filename" "$content_b64" "$from" "$to" | _chat_append
+    # Read the encoding via jq --rawfile so the bytes never sit on argv
+    # (same class of leak as API keys on curl command lines).
+    base64 -w 0 < "$filepath" | tr -d '\n' | jq -nc \
+        --arg filename "$filename" \
+        --arg from "$from" \
+        --arg to "$to" \
+        --rawfile content_b64 /dev/stdin \
+        '{type:"message", filename:$filename, content_b64:$content_b64, from:$from, to:$to, source:"chat"}' \
+        | _chat_append \
+        || die "failed to encode/append $filepath"
 
     printf 'File sent: %s\n' "$filename" >&2
 }

--- a/bin/context
+++ b/bin/context
@@ -255,6 +255,7 @@ def is_meta($k):
   or ($k == "run_id" or $k == "llm_s" or $k == "in_tok" or $k == "out_tok"
       or $k == "think_tok" or $k == "cache_tok" or $k == "estimated"
       or $k == "source_url")
+  or ($k == "content_b64")
   or ($k | endswith("_ref"))
   or ($k | endswith("_bytes"))
   or ($k | endswith("_truncated"));

--- a/deploy/SECURITY.md
+++ b/deploy/SECURITY.md
@@ -85,9 +85,11 @@ The allowlist gates both directions. Replies addressed to unapproved
 users are dropped, so an injected agent cannot use the bridge to carry
 data out to an arbitrary chat.
 
-Scope limits. The bridge is DM only and text only. It leaves any group
-it is added to, because the allowlist cannot control who is in a group,
-and it drops media, so nothing gets downloaded onto the box.
+Scope limits. The bridge is DM only. It leaves any group it is added
+to, because the allowlist cannot control who is in a group. Inbound
+media is dropped, so nothing gets downloaded onto the box. Outbound
+file steps (`chat send-file`) are uploaded as Telegram documents or
+photos; that is agent-to-user, not a download path.
 
 How it connects. The bridge long polls the Telegram API outbound. The
 bot token lives in `/etc/shellm/telegram.env`, which is root owned with

--- a/deploy/scripts/audel-export
+++ b/deploy/scripts/audel-export
@@ -119,9 +119,10 @@ if [ "$KEEP_FULL" = 1 ]; then
     SLIM='.'
 else
     SLIM='def cut($n): if (length > $n) then (.[0:$n] + " …[truncated " + ((length - $n)|tostring) + " chars]") else . end;
-          if .type=="shellm-run" then .command |= cut(300)
+          (if .type=="shellm-run" then .command |= cut(300)
           elif .type=="prompt" then .content |= cut(600)
-          else . end'
+          else . end)
+          | del(.content_b64)'
 fi
 echo "slimming + redacting $(wc -l < "$TRAJ") steps ($(stat -c %s "$TRAJ") bytes)"
 jq -c "$SLIM" "$TRAJ" | redact > "$D/trajectory.jsonl"

--- a/design/trajectory_spec.md
+++ b/design/trajectory_spec.md
@@ -104,7 +104,7 @@ The canonical list of step types. Families:
 | `idle` | thinker | `inner_monologue` | Explicit no-op; keeps the `trigger_self` loop alive; carries `trigger_step` |
 | `observation` | thinker | `actor` | The actor recording a result to the mind log; carries `run_id` (written from inside the actor's run) |
 | `tp-thought` | thinker | thinkers scaffolded by `thinkers create` | Generic thinker output; carries `run_id` when written from inside a run |
-| `message` | conversation | `chat send` / `chat reply` / `chat file` | Carries `from`/`to`; file variant adds `filename` |
+| `message` | conversation | `chat send` / `chat reply` / `chat send-file` | Carries `from`/`to`; file variant keeps a short `content` (e.g. `[file: fig.png]`) and adds `filename` + `content_b64` |
 | `human-msg` | conversation | *(legacy — nothing writes it)* | Still read by `chat repl` for old logs |
 | `agent-msg` | conversation | *(legacy — nothing writes it)* | Still read by `chat repl` for old logs |
 
@@ -391,7 +391,11 @@ A message between named parties (human or agent).
 {"type":"message", "content":"<message>", "from":"<sender>", "to":"<recipient>", "source":"chat"}
 ```
 
-The file-transfer variant (`chat file`) adds `"filename":"<name>"`.
+The file-transfer variant (`chat send-file`) keeps a short human-readable `"content"` so existing readers still work, and adds `"filename"` plus `"content_b64"` (standard base64 of the file bytes):
+
+```json
+{"type":"message", "content":"[file: fig.png]", "filename":"fig.png", "content_b64":"<standard-base64>", "from":"<sender>", "to":"<recipient>", "source":"chat"}
+```
 
 An optional `"reply_to":"<step_id>"` names the message step this one
 answers, making "has this message been answered" a fact in the log rather

--- a/design/trajectory_spec.md
+++ b/design/trajectory_spec.md
@@ -104,7 +104,7 @@ The canonical list of step types. Families:
 | `idle` | thinker | `inner_monologue` | Explicit no-op; keeps the `trigger_self` loop alive; carries `trigger_step` |
 | `observation` | thinker | `actor` | The actor recording a result to the mind log; carries `run_id` (written from inside the actor's run) |
 | `tp-thought` | thinker | thinkers scaffolded by `thinkers create` | Generic thinker output; carries `run_id` when written from inside a run |
-| `message` | conversation | `chat send` / `chat reply` / `chat send-file` | Carries `from`/`to`; file variant keeps a short `content` (e.g. `[file: fig.png]`) and adds `filename` + `content_b64` |
+| `message` | conversation | `chat send` / `chat reply` / `chat send-file` | Carries `from`/`to`; file variant adds `filename` + `content_b64`; text files keep the body in `content`, binary files use a short marker |
 | `human-msg` | conversation | *(legacy — nothing writes it)* | Still read by `chat repl` for old logs |
 | `agent-msg` | conversation | *(legacy — nothing writes it)* | Still read by `chat repl` for old logs |
 
@@ -391,7 +391,11 @@ A message between named parties (human or agent).
 {"type":"message", "content":"<message>", "from":"<sender>", "to":"<recipient>", "source":"chat"}
 ```
 
-The file-transfer variant (`chat send-file`) keeps a short human-readable `"content"` so existing readers still work, and adds `"filename"` plus `"content_b64"` (standard base64 of the file bytes):
+The file-transfer variant (`chat send-file`) always adds `"filename"` plus `"content_b64"` (standard base64 of the file bytes). Text files also keep the file body in `"content"` so Slack and web chat still deliver those contents. Binary files use a short marker (`[file: name]`) because JSON `content` cannot hold raw bytes:
+
+```json
+{"type":"message", "content":"hello file", "filename":"note.txt", "content_b64":"<standard-base64>", "from":"<sender>", "to":"<recipient>", "source":"chat"}
+```
 
 ```json
 {"type":"message", "content":"[file: fig.png]", "filename":"fig.png", "content_b64":"<standard-base64>", "from":"<sender>", "to":"<recipient>", "source":"chat"}

--- a/slack/tests/test_outbound.py
+++ b/slack/tests/test_outbound.py
@@ -41,3 +41,34 @@ def test_run_delivers_only_chat_sourced_messages(tmp_path, monkeypatch):
     outbound.run(cfg, FakeClient(), FakeThreads(), threading.Event())
 
     assert sent == ["real reply"]
+
+
+def test_text_file_posts_file_contents(tmp_path, monkeypatch):
+    """chat send-file stores text in content; Slack must deliver that body."""
+    steps = [
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "note.txt",
+         "content": "hello file",
+         "content_b64": "aGVsbG8gZmlsZQo=",
+         "step_id": "fff"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            sent.append(text)
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    cfg = Config(
+        serve_root=tmp_path, identity="audel", identity_dir=tmp_path,
+        bot_token="x", app_token="x", web_url="http://x", state_dir=tmp_path,
+        thread_followups=True,
+    )
+    outbound.run(cfg, FakeClient(), FakeThreads(), threading.Event())
+    assert sent == ["hello file"]

--- a/telegram/src/headlong_telegram/api.py
+++ b/telegram/src/headlong_telegram/api.py
@@ -28,8 +28,13 @@ class Bot:
         self._base = f"https://api.telegram.org/bot{token}"
         self._client = httpx.Client(timeout=httpx.Timeout(30, read=POLL_SECONDS + 10))
 
-    def _call(self, method: str, **params: Any) -> Any:
-        response = self._client.post(f"{self._base}/{method}", json=params)
+    def _call(self, method: str, files: dict | None = None, **params: Any) -> Any:
+        url = f"{self._base}/{method}"
+        if files:
+            data = {k: v for k, v in params.items() if v is not None}
+            response = self._client.post(url, data=data, files=files)
+        else:
+            response = self._client.post(url, json=params)
         # Anything that is not a well-formed Telegram envelope has to leave here
         # as ApiError. The poll loop retries on (ApiError, httpx.HTTPError) and
         # dies on everything else, so a 502 HTML page from an edge would
@@ -69,3 +74,39 @@ class Bot:
 
     def leave_chat(self, chat_id: int) -> None:
         self._call("leaveChat", chat_id=chat_id)
+
+    def send_document(
+        self,
+        chat_id: int,
+        content: bytes | str,
+        filename: str,
+        caption: str | None = None,
+    ) -> Any:
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        params: dict[str, Any] = {"chat_id": chat_id}
+        if caption:
+            params["caption"] = caption
+        return self._call(
+            "sendDocument",
+            files={"document": (filename, content)},
+            **params,
+        )
+
+    def send_photo(
+        self,
+        chat_id: int,
+        content: bytes | str,
+        filename: str,
+        caption: str | None = None,
+    ) -> Any:
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        params: dict[str, Any] = {"chat_id": chat_id}
+        if caption:
+            params["caption"] = caption
+        return self._call(
+            "sendPhoto",
+            files={"photo": (filename, content)},
+            **params,
+        )

--- a/telegram/src/headlong_telegram/filepayload.py
+++ b/telegram/src/headlong_telegram/filepayload.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,12 @@ from .tgfmt import strip_leaked_command
 PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 JPEG_MAGIC = b"\xff\xd8\xff"
 CAPTION_MAX = 1024  # Telegram media-caption limit
+
+
+def file_signature(filename: str, content: bytes | str) -> str:
+    """Bounded RecentPosts key: basename plus a hash of the decoded bytes."""
+    raw = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+    return f"{filename}:{hashlib.sha256(raw).hexdigest()}"
 
 
 class DecodeError(Exception):

--- a/telegram/src/headlong_telegram/filepayload.py
+++ b/telegram/src/headlong_telegram/filepayload.py
@@ -1,48 +1,65 @@
 """Detect file-bearing mind-log steps for Telegram outbound.
 
-`chat send-file` stamps `filename` on the message step and puts the file
-bytes/text in `content`. Without this, outbound always used sendMessage
-and a PNG/SVG landed as raw source in the chat.
+`chat send-file` stamps `filename` on the message step. Binary files
+travel in `content_b64` (standard base64) because JSON cannot hold raw
+bytes; text may sit in `content`. Outbound uploads the decoded bytes
+via sendPhoto/sendDocument rather than stuffing them into sendMessage.
 """
 
 from __future__ import annotations
 
+import base64
+import binascii
 from pathlib import Path
 from typing import Any
 
 PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
-FILE_TYPES = {"file", "image", "attachment"}
+CAPTION_MAX = 1024  # Telegram media-caption limit
+
+
+def _content(step: dict[str, Any]) -> bytes | str | None:
+    b64 = step.get("content_b64")
+    if isinstance(b64, str) and b64:
+        try:
+            return base64.b64decode(b64, validate=True)
+        except (binascii.Error, ValueError):
+            return None
+    content = step.get("content")
+    if content is None or content == "":
+        return None
+    return content
 
 
 def file_payload(step: dict[str, Any]) -> dict[str, Any] | None:
-    """Return upload kwargs, or None if this step is ordinary text."""
-    filename = step.get("filename") or step.get("file") or ""
-    content = step.get("content") or ""
-    typed = str(step.get("type") or "") in FILE_TYPES
+    """Return upload kwargs, or None if this step is ordinary text.
 
-    if not filename:
-        if isinstance(content, str) and content.lstrip().startswith("<svg"):
-            filename = "figure.svg"
-        elif isinstance(content, (bytes, bytearray)) and bytes(content[:8]) == PNG_MAGIC:
-            filename = "figure.png"
-        elif typed:
-            filename = "attachment.bin"
-        else:
-            return None
+    A file step is one with a `filename` (or `file`) field. Content-sniffing
+    without a name is not used: a text reply that happens to start with
+    `<svg` must stay a sendMessage.
+    """
+    raw_name = step.get("filename") or step.get("file") or ""
+    if not isinstance(raw_name, str) or not raw_name.strip():
+        return None
+    filename = Path(raw_name).name
+    if not filename or filename in {".", ".."}:
+        return None
 
-    filename = Path(str(filename)).name or "attachment.bin"
-    if isinstance(content, str):
-        data = content.encode("utf-8")
+    content = _content(step)
+    if content is None:
+        return None
+
+    caption = step.get("caption")
+    if caption is None or caption == "":
+        caption_out = None
     else:
-        data = bytes(content)
+        caption_out = str(caption)[:CAPTION_MAX]
 
-    title = step.get("title") or filename
-    comment = (step.get("caption") or step.get("comment") or "").strip()
-    if len(comment) > 2000:
-        comment = comment[:1990] + "…"
+    raw = content if isinstance(content, (bytes, bytearray)) else None
+    as_photo = bool(raw and bytes(raw).startswith(PNG_MAGIC))
+
     return {
         "filename": filename,
-        "content": data,
-        "title": title,
-        "initial_comment": comment or None,
+        "content": content,
+        "caption": caption_out,
+        "as_photo": as_photo,
     }

--- a/telegram/src/headlong_telegram/filepayload.py
+++ b/telegram/src/headlong_telegram/filepayload.py
@@ -13,6 +13,8 @@ import binascii
 from pathlib import Path
 from typing import Any
 
+from .tgfmt import strip_leaked_command
+
 PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 JPEG_MAGIC = b"\xff\xd8\xff"
 CAPTION_MAX = 1024  # Telegram media-caption limit
@@ -28,6 +30,8 @@ def _content(step: dict[str, Any]) -> bytes | str | None:
     content = step.get("content")
     if content is None or content == "":
         return None
+    if isinstance(content, str):
+        return strip_leaked_command(content)
     return content
 
 
@@ -41,11 +45,13 @@ def _as_photo(content: bytes | str | None) -> bool:
 def file_payload(step: dict[str, Any]) -> dict[str, Any] | None:
     """Return upload kwargs, or None if this step is ordinary text.
 
-    A file step is one with a `filename` (or `file`) field. Content-sniffing
-    without a name is not used: a text reply that happens to start with
-    `<svg` must stay a sendMessage.
+    A file step is one with an explicit `filename` field. The `file`
+    alias is not accepted: an ordinary message that happens to carry
+    that key must stay a sendMessage. Content-sniffing without a name
+    is not used either: a text reply that starts with `<svg` must
+    stay a sendMessage.
     """
-    raw_name = step.get("filename") or step.get("file") or ""
+    raw_name = step.get("filename") or ""
     if not isinstance(raw_name, str) or not raw_name.strip():
         return None
     filename = Path(raw_name).name
@@ -60,7 +66,7 @@ def file_payload(step: dict[str, Any]) -> dict[str, Any] | None:
     if caption is None or caption == "":
         caption_out = None
     else:
-        caption_out = str(caption)[:CAPTION_MAX]
+        caption_out = strip_leaked_command(str(caption))[:CAPTION_MAX] or None
 
     return {
         "filename": filename,

--- a/telegram/src/headlong_telegram/filepayload.py
+++ b/telegram/src/headlong_telegram/filepayload.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+JPEG_MAGIC = b"\xff\xd8\xff"
 CAPTION_MAX = 1024  # Telegram media-caption limit
 
 
@@ -28,6 +29,13 @@ def _content(step: dict[str, Any]) -> bytes | str | None:
     if content is None or content == "":
         return None
     return content
+
+
+def _as_photo(content: bytes | str | None) -> bool:
+    if not isinstance(content, (bytes, bytearray)):
+        return False
+    raw = bytes(content)
+    return raw.startswith(PNG_MAGIC) or raw.startswith(JPEG_MAGIC)
 
 
 def file_payload(step: dict[str, Any]) -> dict[str, Any] | None:
@@ -54,12 +62,9 @@ def file_payload(step: dict[str, Any]) -> dict[str, Any] | None:
     else:
         caption_out = str(caption)[:CAPTION_MAX]
 
-    raw = content if isinstance(content, (bytes, bytearray)) else None
-    as_photo = bool(raw and bytes(raw).startswith(PNG_MAGIC))
-
     return {
         "filename": filename,
         "content": content,
         "caption": caption_out,
-        "as_photo": as_photo,
+        "as_photo": _as_photo(content),
     }

--- a/telegram/src/headlong_telegram/filepayload.py
+++ b/telegram/src/headlong_telegram/filepayload.py
@@ -1,0 +1,48 @@
+"""Detect file-bearing mind-log steps for Telegram outbound.
+
+`chat send-file` stamps `filename` on the message step and puts the file
+bytes/text in `content`. Without this, outbound always used sendMessage
+and a PNG/SVG landed as raw source in the chat.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+FILE_TYPES = {"file", "image", "attachment"}
+
+
+def file_payload(step: dict[str, Any]) -> dict[str, Any] | None:
+    """Return upload kwargs, or None if this step is ordinary text."""
+    filename = step.get("filename") or step.get("file") or ""
+    content = step.get("content") or ""
+    typed = str(step.get("type") or "") in FILE_TYPES
+
+    if not filename:
+        if isinstance(content, str) and content.lstrip().startswith("<svg"):
+            filename = "figure.svg"
+        elif isinstance(content, (bytes, bytearray)) and bytes(content[:8]) == PNG_MAGIC:
+            filename = "figure.png"
+        elif typed:
+            filename = "attachment.bin"
+        else:
+            return None
+
+    filename = Path(str(filename)).name or "attachment.bin"
+    if isinstance(content, str):
+        data = content.encode("utf-8")
+    else:
+        data = bytes(content)
+
+    title = step.get("title") or filename
+    comment = (step.get("caption") or step.get("comment") or "").strip()
+    if len(comment) > 2000:
+        comment = comment[:1990] + "…"
+    return {
+        "filename": filename,
+        "content": data,
+        "title": title,
+        "initial_comment": comment or None,
+    }

--- a/telegram/src/headlong_telegram/filepayload.py
+++ b/telegram/src/headlong_telegram/filepayload.py
@@ -20,13 +20,22 @@ JPEG_MAGIC = b"\xff\xd8\xff"
 CAPTION_MAX = 1024  # Telegram media-caption limit
 
 
+class DecodeError(Exception):
+    """content_b64 was present but empty or not strict standard base64."""
+
+
 def _content(step: dict[str, Any]) -> bytes | str | None:
-    b64 = step.get("content_b64")
-    if isinstance(b64, str) and b64:
+    if "content_b64" in step:
+        b64 = step.get("content_b64")
+        if not isinstance(b64, str) or not b64:
+            raise DecodeError("empty content_b64")
         try:
-            return base64.b64decode(b64, validate=True)
-        except (binascii.Error, ValueError):
-            return None
+            raw = base64.b64decode(b64, validate=True)
+        except (binascii.Error, ValueError) as e:
+            raise DecodeError(str(e)) from e
+        if not raw:
+            raise DecodeError("empty content_b64")
+        return raw
     content = step.get("content")
     if content is None or content == "":
         return None
@@ -47,19 +56,28 @@ def file_payload(step: dict[str, Any]) -> dict[str, Any] | None:
 
     A file step is one with an explicit `filename` field. The `file`
     alias is not accepted: an ordinary message that happens to carry
-    that key must stay a sendMessage. Content-sniffing without a name
-    is not used either: a text reply that starts with `<svg` must
-    stay a sendMessage.
+    that key must stay a sendMessage. Content is leak-filtered so a
+    stray `chat reply` in a caption cannot re-trigger the agent.
+
+    If `content_b64` is present but not strict base64 (or decodes to
+    empty), the returned dict has `content` None and `decode_error`
+    True so outbound can fail loudly instead of falling through to
+    sendMessage.
     """
-    raw_name = step.get("filename") or ""
+    raw_name = step.get("filename")
     if not isinstance(raw_name, str) or not raw_name.strip():
         return None
     filename = Path(raw_name).name
     if not filename or filename in {".", ".."}:
         return None
 
-    content = _content(step)
-    if content is None:
+    decode_error = False
+    try:
+        content = _content(step)
+    except DecodeError:
+        content = None
+        decode_error = True
+    if content is None and not decode_error:
         return None
 
     caption = step.get("caption")
@@ -73,4 +91,5 @@ def file_payload(step: dict[str, Any]) -> dict[str, Any] | None:
         "content": content,
         "caption": caption_out,
         "as_photo": _as_photo(content),
+        "decode_error": decode_error,
     }

--- a/telegram/src/headlong_telegram/filepayload.py
+++ b/telegram/src/headlong_telegram/filepayload.py
@@ -28,7 +28,7 @@ def file_signature(filename: str, content: bytes | str) -> str:
 
 
 class DecodeError(Exception):
-    """content_b64 was present but empty or not strict standard base64."""
+    """File bytes could not be recovered from the step."""
 
 
 def _content(step: dict[str, Any]) -> bytes | str | None:
@@ -48,7 +48,10 @@ def _content(step: dict[str, Any]) -> bytes | str | None:
         return None
     if isinstance(content, str):
         return strip_leaked_command(content)
-    return content
+    # JSON can hold objects/arrays/numbers; file_signature and the
+    # upload path only accept text or bytes. Anything else is a
+    # decode error so outbound can notice-and-continue.
+    raise DecodeError("non-string content")
 
 
 def _as_photo(content: bytes | str | None) -> bool:

--- a/telegram/src/headlong_telegram/outbound.py
+++ b/telegram/src/headlong_telegram/outbound.py
@@ -17,6 +17,7 @@ import threading
 import time
 
 from . import mindlog, naming
+from .filepayload import file_payload
 from .allowlist import Allowlist
 from .api import ApiError, Bot
 from .config import Config
@@ -78,6 +79,23 @@ def run(cfg: Config, bot: Bot, allowlist: Allowlist, stop_event: threading.Event
             continue
         if recent.is_duplicate(to, text):
             log.warning("skipping duplicate post to %s", to)
+            continue
+        payload = file_payload(step)
+        if payload is not None:
+            # File steps must not fall back to posting raw source as text.
+            name = payload["filename"]
+            data = payload["content"]
+            caption = payload.get("initial_comment")
+            lower = name.lower()
+            try:
+                if lower.endswith((".png", ".jpg", ".jpeg", ".gif", ".webp")) and hasattr(bot, "send_photo"):
+                    bot.send_photo(conv.chat, data, name, caption=caption)
+                elif hasattr(bot, "send_document"):
+                    bot.send_document(conv.chat, data, name, caption=caption)
+                else:
+                    log.error("bot cannot send files for %s", to)
+            except ApiError:
+                log.exception("file send failed for %s", to)
             continue
         for part in chunk(text):
             try:

--- a/telegram/src/headlong_telegram/outbound.py
+++ b/telegram/src/headlong_telegram/outbound.py
@@ -85,20 +85,32 @@ def run(cfg: Config, bot: Bot, allowlist: Allowlist, stop_event: threading.Event
             name = payload["filename"]
             data = payload["content"]
             caption = payload.get("caption")
+            sent_file = False
             try:
                 if payload.get("as_photo") and hasattr(bot, "send_photo"):
                     try:
                         bot.send_photo(conv.chat, data, name, caption=caption)
+                        sent_file = True
                     except ApiError:
                         if not hasattr(bot, "send_document"):
                             raise
                         bot.send_document(conv.chat, data, name, caption=caption)
+                        sent_file = True
                 elif hasattr(bot, "send_document"):
                     bot.send_document(conv.chat, data, name, caption=caption)
+                    sent_file = True
                 else:
                     log.error("bot cannot send files for %s", to)
             except (ApiError, httpx.HTTPError):
                 log.exception("file send failed for %s", to)
+            if not sent_file:
+                # Cursor already advanced past this step; tell the user
+                # the upload was lost rather than failing silently.
+                notice = f"(failed to deliver file {name})"
+                try:
+                    bot.send_message(conv.chat, notice)
+                except (ApiError, httpx.HTTPError):
+                    log.exception("delivery-failed notice also failed for %s", to)
             continue
         text = strip_leaked_command(str(step.get("content") or "")).strip()
         if not text:

--- a/telegram/src/headlong_telegram/outbound.py
+++ b/telegram/src/headlong_telegram/outbound.py
@@ -86,23 +86,26 @@ def run(cfg: Config, bot: Bot, allowlist: Allowlist, stop_event: threading.Event
             data = payload["content"]
             caption = payload.get("caption")
             sent_file = False
-            try:
-                if payload.get("as_photo") and hasattr(bot, "send_photo"):
-                    try:
-                        bot.send_photo(conv.chat, data, name, caption=caption)
-                        sent_file = True
-                    except ApiError:
-                        if not hasattr(bot, "send_document"):
-                            raise
+            if payload.get("decode_error") or data is None:
+                log.error("undecodable file payload for %s (%s)", to, name)
+            else:
+                try:
+                    if payload.get("as_photo") and hasattr(bot, "send_photo"):
+                        try:
+                            bot.send_photo(conv.chat, data, name, caption=caption)
+                            sent_file = True
+                        except ApiError:
+                            if not hasattr(bot, "send_document"):
+                                raise
+                            bot.send_document(conv.chat, data, name, caption=caption)
+                            sent_file = True
+                    elif hasattr(bot, "send_document"):
                         bot.send_document(conv.chat, data, name, caption=caption)
                         sent_file = True
-                elif hasattr(bot, "send_document"):
-                    bot.send_document(conv.chat, data, name, caption=caption)
-                    sent_file = True
-                else:
-                    log.error("bot cannot send files for %s", to)
-            except (ApiError, httpx.HTTPError):
-                log.exception("file send failed for %s", to)
+                    else:
+                        log.error("bot cannot send files for %s", to)
+                except (ApiError, httpx.HTTPError):
+                    log.exception("file send failed for %s", to)
             if not sent_file:
                 # Cursor already advanced past this step; tell the user
                 # the upload was lost rather than failing silently.

--- a/telegram/src/headlong_telegram/outbound.py
+++ b/telegram/src/headlong_telegram/outbound.py
@@ -13,6 +13,7 @@ can't be used as a courier out.
 from __future__ import annotations
 
 import logging
+import httpx
 import threading
 import time
 
@@ -74,28 +75,81 @@ def run(cfg: Config, bot: Bot, allowlist: Allowlist, stop_event: threading.Event
         if not allowlist.is_approved(conv.user):
             log.warning("dropping reply to unapproved user %s", conv.user)
             continue
+        if conv.user != conv.chat:
+            log.warning("dropping reply to group chat %s", conv.chat)
+            continue
+        payload = file_payload(step)
+        if payload is not None:
+            # File steps travel in content_b64 and often have empty `content`.
+            # Do not require text, and do not fall back to posting bytes as a message.
+            name = payload["filename"]
+            data = payload["content"]
+            caption = payload.get("caption")
+            try:
+                if payload.get("as_photo") and hasattr(bot, "send_photo"):
+                    try:
+                        bot.send_photo(conv.chat, data, name, caption=caption)
+                    except ApiError:
+                        if not hasattr(bot, "send_document"):
+                            raise
+                        bot.send_document(conv.chat, data, name, caption=caption)
+                elif hasattr(bot, "send_document"):
+                    bot.send_document(conv.chat, data, name, caption=caption)
+                else:
+                    log.error("bot cannot send files for %s", to)
+            except (ApiError, httpx.HTTPError):
+                log.exception("file send failed for %s", to)
+            continue
+        payload = file_payload(step)
+        if payload is not None:
+            # File steps travel in content_b64 with empty content — do not
+            # treat them as blank text. Never fall back to sendMessage.
+            name = payload["filename"]
+            data = payload["content"]
+            caption = payload.get("caption")
+            try:
+                if payload.get("as_photo") and hasattr(bot, "send_photo"):
+                    try:
+                        bot.send_photo(conv.chat, data, name, caption=caption)
+                    except ApiError:
+                        if not hasattr(bot, "send_document"):
+                            raise
+                        bot.send_document(conv.chat, data, name, caption=caption)
+                elif hasattr(bot, "send_document"):
+                    bot.send_document(conv.chat, data, name, caption=caption)
+                else:
+                    log.error("bot cannot send files for %s", to)
+            except (ApiError, httpx.HTTPError):
+                log.exception("file send failed for %s", to)
+            continue
+        payload = file_payload(step)
+        if payload is not None:
+            # File steps must not fall back to posting raw source as text.
+            # Binary files live in content_b64 and have empty `content`, so
+            # this runs before the empty-text skip.
+            name = payload["filename"]
+            data = payload["content"]
+            caption = payload.get("caption")
+            try:
+                if payload.get("as_photo") and hasattr(bot, "send_photo"):
+                    try:
+                        bot.send_photo(conv.chat, data, name, caption=caption)
+                    except ApiError:
+                        if not hasattr(bot, "send_document"):
+                            raise
+                        bot.send_document(conv.chat, data, name, caption=caption)
+                elif hasattr(bot, "send_document"):
+                    bot.send_document(conv.chat, data, name, caption=caption)
+                else:
+                    log.error("bot cannot send files for %s", to)
+            except (ApiError, httpx.HTTPError):
+                log.exception("file send failed for %s", to)
+            continue
         text = strip_leaked_command(str(step.get("content") or "")).strip()
         if not text:
             continue
         if recent.is_duplicate(to, text):
             log.warning("skipping duplicate post to %s", to)
-            continue
-        payload = file_payload(step)
-        if payload is not None:
-            # File steps must not fall back to posting raw source as text.
-            name = payload["filename"]
-            data = payload["content"]
-            caption = payload.get("initial_comment")
-            lower = name.lower()
-            try:
-                if lower.endswith((".png", ".jpg", ".jpeg", ".gif", ".webp")) and hasattr(bot, "send_photo"):
-                    bot.send_photo(conv.chat, data, name, caption=caption)
-                elif hasattr(bot, "send_document"):
-                    bot.send_document(conv.chat, data, name, caption=caption)
-                else:
-                    log.error("bot cannot send files for %s", to)
-            except ApiError:
-                log.exception("file send failed for %s", to)
             continue
         for part in chunk(text):
             try:

--- a/telegram/src/headlong_telegram/outbound.py
+++ b/telegram/src/headlong_telegram/outbound.py
@@ -100,51 +100,6 @@ def run(cfg: Config, bot: Bot, allowlist: Allowlist, stop_event: threading.Event
             except (ApiError, httpx.HTTPError):
                 log.exception("file send failed for %s", to)
             continue
-        payload = file_payload(step)
-        if payload is not None:
-            # File steps travel in content_b64 with empty content — do not
-            # treat them as blank text. Never fall back to sendMessage.
-            name = payload["filename"]
-            data = payload["content"]
-            caption = payload.get("caption")
-            try:
-                if payload.get("as_photo") and hasattr(bot, "send_photo"):
-                    try:
-                        bot.send_photo(conv.chat, data, name, caption=caption)
-                    except ApiError:
-                        if not hasattr(bot, "send_document"):
-                            raise
-                        bot.send_document(conv.chat, data, name, caption=caption)
-                elif hasattr(bot, "send_document"):
-                    bot.send_document(conv.chat, data, name, caption=caption)
-                else:
-                    log.error("bot cannot send files for %s", to)
-            except (ApiError, httpx.HTTPError):
-                log.exception("file send failed for %s", to)
-            continue
-        payload = file_payload(step)
-        if payload is not None:
-            # File steps must not fall back to posting raw source as text.
-            # Binary files live in content_b64 and have empty `content`, so
-            # this runs before the empty-text skip.
-            name = payload["filename"]
-            data = payload["content"]
-            caption = payload.get("caption")
-            try:
-                if payload.get("as_photo") and hasattr(bot, "send_photo"):
-                    try:
-                        bot.send_photo(conv.chat, data, name, caption=caption)
-                    except ApiError:
-                        if not hasattr(bot, "send_document"):
-                            raise
-                        bot.send_document(conv.chat, data, name, caption=caption)
-                elif hasattr(bot, "send_document"):
-                    bot.send_document(conv.chat, data, name, caption=caption)
-                else:
-                    log.error("bot cannot send files for %s", to)
-            except (ApiError, httpx.HTTPError):
-                log.exception("file send failed for %s", to)
-            continue
         text = strip_leaked_command(str(step.get("content") or "")).strip()
         if not text:
             continue

--- a/telegram/src/headlong_telegram/outbound.py
+++ b/telegram/src/headlong_telegram/outbound.py
@@ -18,7 +18,7 @@ import threading
 import time
 
 from . import mindlog, naming
-from .filepayload import file_payload
+from .filepayload import file_payload, file_signature
 from .allowlist import Allowlist
 from .api import ApiError, Bot
 from .config import Config
@@ -88,6 +88,9 @@ def run(cfg: Config, bot: Bot, allowlist: Allowlist, stop_event: threading.Event
             sent_file = False
             if payload.get("decode_error") or data is None:
                 log.error("undecodable file payload for %s (%s)", to, name)
+            elif recent.is_duplicate(to, file_signature(name, data)):
+                log.warning("skipping duplicate file post to %s", to)
+                continue
             else:
                 try:
                     if payload.get("as_photo") and hasattr(bot, "send_photo"):

--- a/telegram/tests/test_filepayload.py
+++ b/telegram/tests/test_filepayload.py
@@ -37,7 +37,10 @@ def test_path_is_reduced_to_basename():
 
 
 def test_invalid_b64_is_not_a_file():
-    assert file_payload({"filename": "a.bin", "content_b64": "!!!!"}) is None
+    payload = file_payload({"filename": "a.bin", "content_b64": "!!!!"})
+    assert payload is not None
+    assert payload["content"] is None
+    assert payload["decode_error"] is True
 
 
 def test_caption_is_truncated():
@@ -83,3 +86,26 @@ def test_text_content_is_never_a_photo():
     payload = file_payload({"filename": "fig.png", "content": "not-bytes"})
     assert payload is not None
     assert payload["as_photo"] is False
+
+
+def test_invalid_content_b64_is_decode_error():
+    payload = file_payload({
+        "filename": "note.txt",
+        "content_b64": "@@@not-base64@@@",
+        "content": "[file: note.txt]",
+    })
+    assert payload is not None
+    assert payload["content"] is None
+    assert payload["decode_error"] is True
+
+
+def test_empty_content_b64_is_decode_error():
+    payload = file_payload({
+        "filename": "note.txt",
+        "content_b64": "",
+        "content": "[file: note.txt]",
+    })
+    assert payload is not None
+    assert payload["content"] is None
+    assert payload["decode_error"] is True
+

--- a/telegram/tests/test_filepayload.py
+++ b/telegram/tests/test_filepayload.py
@@ -1,38 +1,48 @@
-from headlong_telegram.filepayload import file_payload
-
-PNG = b"\x89PNG\r\n\x1a\n" + b"rest"
+from headlong_telegram.filepayload import CAPTION_MAX, file_payload
 
 
-def test_plain_text_is_none():
+def test_plain_text_is_not_a_file():
     assert file_payload({"type": "message", "content": "hello"}) is None
 
 
-def test_filename_field():
-    p = file_payload({"content": "<svg xmlns", "filename": "walk.svg", "caption": "a figure"})
-    assert p["filename"] == "walk.svg"
-    assert p["content"] == b"<svg xmlns"
-    assert p["initial_comment"] == "a figure"
-    assert p["title"] == "walk.svg"
+def test_filename_stamps_a_document():
+    payload = file_payload({"filename": "note.txt", "content": "hi"})
+    assert payload is not None
+    assert payload["filename"] == "note.txt"
+    assert payload["content"] == "hi"
+    assert payload["as_photo"] is False
+    assert payload["caption"] is None
 
 
-def test_svg_sniff_without_filename():
-    p = file_payload({"content": "  <svg xmlns=\"http://www.w3.org/2000/svg\">"})
-    assert p["filename"] == "figure.svg"
-    assert p["content"].lstrip().startswith(b"<svg")
+def test_content_b64_roundtrips_png_bytes():
+    import base64
+    png = b"\x89PNG\r\n\x1a\n" + b"rest"
+    payload = file_payload({
+        "filename": "fig.png",
+        "content_b64": base64.b64encode(png).decode("ascii"),
+    })
+    assert payload is not None
+    assert payload["content"] == png
+    assert payload["as_photo"] is True
 
 
-def test_png_sniff_without_filename():
-    p = file_payload({"content": PNG})
-    assert p["filename"] == "figure.png"
-    assert p["content"].startswith(b"\x89PNG")
+def test_svg_without_filename_stays_text():
+    assert file_payload({"content": "<svg xmlns='x'></svg>"}) is None
 
 
-def test_typed_attachment_without_name():
-    p = file_payload({"type": "file", "content": b"abc"})
-    assert p["filename"] == "attachment.bin"
-    assert p["content"] == b"abc"
+def test_path_is_reduced_to_basename():
+    payload = file_payload({"filename": "/etc/passwd", "content": "x"})
+    assert payload is not None
+    assert payload["filename"] == "passwd"
 
 
-def test_path_is_basename():
-    p = file_payload({"filename": "/tmp/secret/fig.png", "content": "x"})
-    assert p["filename"] == "fig.png"
+def test_invalid_b64_is_not_a_file():
+    assert file_payload({"filename": "a.bin", "content_b64": "!!!!"}) is None
+
+
+def test_caption_is_truncated():
+    payload = file_payload({
+        "filename": "a.txt", "content": "x", "caption": "c" * 2000,
+    })
+    assert payload is not None
+    assert payload["caption"] == "c" * CAPTION_MAX

--- a/telegram/tests/test_filepayload.py
+++ b/telegram/tests/test_filepayload.py
@@ -1,0 +1,38 @@
+from headlong_telegram.filepayload import file_payload
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"rest"
+
+
+def test_plain_text_is_none():
+    assert file_payload({"type": "message", "content": "hello"}) is None
+
+
+def test_filename_field():
+    p = file_payload({"content": "<svg xmlns", "filename": "walk.svg", "caption": "a figure"})
+    assert p["filename"] == "walk.svg"
+    assert p["content"] == b"<svg xmlns"
+    assert p["initial_comment"] == "a figure"
+    assert p["title"] == "walk.svg"
+
+
+def test_svg_sniff_without_filename():
+    p = file_payload({"content": "  <svg xmlns=\"http://www.w3.org/2000/svg\">"})
+    assert p["filename"] == "figure.svg"
+    assert p["content"].lstrip().startswith(b"<svg")
+
+
+def test_png_sniff_without_filename():
+    p = file_payload({"content": PNG})
+    assert p["filename"] == "figure.png"
+    assert p["content"].startswith(b"\x89PNG")
+
+
+def test_typed_attachment_without_name():
+    p = file_payload({"type": "file", "content": b"abc"})
+    assert p["filename"] == "attachment.bin"
+    assert p["content"] == b"abc"
+
+
+def test_path_is_basename():
+    p = file_payload({"filename": "/tmp/secret/fig.png", "content": "x"})
+    assert p["filename"] == "fig.png"

--- a/telegram/tests/test_filepayload.py
+++ b/telegram/tests/test_filepayload.py
@@ -47,11 +47,24 @@ def test_caption_is_truncated():
     assert payload is not None
     assert payload["caption"] == "c" * CAPTION_MAX
 
-def test_file_alias_is_accepted():
-    payload = file_payload({"file": "note.txt", "content": "hi"})
+def test_file_alias_is_ignored():
+    # Canonical key is `filename`. A stray `file` field must not reclassify
+    # an ordinary message as an upload.
+    assert file_payload({"file": "note.txt", "content": "hi"}) is None
+    payload = file_payload({"filename": "note.txt", "file": "other.bin", "content": "hi"})
     assert payload is not None
     assert payload["filename"] == "note.txt"
-    assert payload["as_photo"] is False
+
+
+def test_caption_and_text_content_are_leak_filtered():
+    payload = file_payload({
+        "filename": "note.txt",
+        "content": "chat reply telegram-1-2 secret notes",
+        "caption": "chat reply telegram-1-2 look",
+    })
+    assert payload is not None
+    assert payload["content"] == "secret notes"
+    assert payload["caption"] == "look"
 
 
 def test_jpeg_uses_photo():

--- a/telegram/tests/test_filepayload.py
+++ b/telegram/tests/test_filepayload.py
@@ -46,3 +46,27 @@ def test_caption_is_truncated():
     })
     assert payload is not None
     assert payload["caption"] == "c" * CAPTION_MAX
+
+def test_file_alias_is_accepted():
+    payload = file_payload({"file": "note.txt", "content": "hi"})
+    assert payload is not None
+    assert payload["filename"] == "note.txt"
+    assert payload["as_photo"] is False
+
+
+def test_jpeg_uses_photo():
+    import base64
+    jpeg = b"\xff\xd8\xff" + b"rest"
+    payload = file_payload({
+        "filename": "shot.jpg",
+        "content_b64": base64.b64encode(jpeg).decode("ascii"),
+    })
+    assert payload is not None
+    assert payload["content"] == jpeg
+    assert payload["as_photo"] is True
+
+
+def test_text_content_is_never_a_photo():
+    payload = file_payload({"filename": "fig.png", "content": "not-bytes"})
+    assert payload is not None
+    assert payload["as_photo"] is False

--- a/telegram/tests/test_filepayload.py
+++ b/telegram/tests/test_filepayload.py
@@ -115,3 +115,14 @@ def test_file_signature_is_filename_plus_content_hash():
     assert same == file_signature("note.txt", "aaa")
     assert same != file_signature("note.txt", b"bbb")
     assert same != file_signature("other.txt", b"aaa")
+
+
+def test_non_string_content_is_decode_error():
+    payload = file_payload({
+        "filename": "bad.bin",
+        "content": {"x": "y"},
+    })
+    assert payload is not None
+    assert payload["content"] is None
+    assert payload["decode_error"] is True
+

--- a/telegram/tests/test_filepayload.py
+++ b/telegram/tests/test_filepayload.py
@@ -1,4 +1,4 @@
-from headlong_telegram.filepayload import CAPTION_MAX, file_payload
+from headlong_telegram.filepayload import CAPTION_MAX, file_payload, file_signature
 
 
 def test_plain_text_is_not_a_file():
@@ -109,3 +109,9 @@ def test_empty_content_b64_is_decode_error():
     assert payload["content"] is None
     assert payload["decode_error"] is True
 
+
+def test_file_signature_is_filename_plus_content_hash():
+    same = file_signature("note.txt", b"aaa")
+    assert same == file_signature("note.txt", "aaa")
+    assert same != file_signature("note.txt", b"bbb")
+    assert same != file_signature("other.txt", b"aaa")

--- a/telegram/tests/test_outbound.py
+++ b/telegram/tests/test_outbound.py
@@ -243,3 +243,33 @@ def test_jpeg_uses_send_photo(tmp_path, monkeypatch):
     assert photos == [("shot.jpg", jpeg, None)]
     assert sent == []
 
+
+def test_file_send_failure_falls_back_to_notice(tmp_path, monkeypatch):
+    import threading
+
+    from headlong_telegram import outbound
+    from headlong_telegram.api import ApiError
+
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "filename": "note.txt", "content": "hi",
+         "step_id": "fail1"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+        def send_document(self, chat, content, filename, caption=None):
+            raise ApiError("upload rejected")
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
+    assert sent == ["(failed to deliver file note.txt)"]

--- a/telegram/tests/test_outbound.py
+++ b/telegram/tests/test_outbound.py
@@ -273,3 +273,37 @@ def test_file_send_failure_falls_back_to_notice(tmp_path, monkeypatch):
 
     outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
     assert sent == ["(failed to deliver file note.txt)"]
+
+
+def test_undecodable_file_falls_back_to_notice(tmp_path, monkeypatch):
+    import threading
+
+    from headlong_telegram import outbound
+
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "filename": "note.txt",
+         "content": "[file: note.txt]", "content_b64": "@@@bad@@@",
+         "step_id": "badb64"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    docs = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+        def send_document(self, chat, content, filename, caption=None):
+            docs.append(filename)
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
+    assert docs == []
+    assert sent == ["(failed to deliver file note.txt)"]
+

--- a/telegram/tests/test_outbound.py
+++ b/telegram/tests/test_outbound.py
@@ -209,3 +209,37 @@ def test_group_chat_is_dropped(tmp_path, monkeypatch):
 
     outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
     assert sent == []
+
+def test_jpeg_uses_send_photo(tmp_path, monkeypatch):
+    jpeg = b"\xff\xd8\xff" + b"rest"
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat",
+         "filename": "shot.jpg",
+         "content_b64": base64.b64encode(jpeg).decode("ascii"),
+         "step_id": "jpg1"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    photos = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+        def send_photo(self, chat, content, filename, caption=None):
+            photos.append((filename, content, caption))
+
+        def send_document(self, chat, content, filename, caption=None):
+            raise AssertionError("jpeg should use send_photo")
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
+    assert photos == [("shot.jpg", jpeg, None)]
+    assert sent == []
+

--- a/telegram/tests/test_outbound.py
+++ b/telegram/tests/test_outbound.py
@@ -1,11 +1,25 @@
-import threading
-
-from headlong_telegram import outbound
-from headlong_telegram.config import Config
+from headlong_telegram.outbound import RecentPosts
 
 
-def test_forged_source_is_not_posted(tmp_path, monkeypatch):
+def test_recent_posts_dedupe_window():
+    recent = RecentPosts(window=300)
+    assert not recent.is_duplicate("telegram-1-1", "hi", now=0)
+    assert recent.is_duplicate("telegram-1-1", "hi", now=100)
+    assert not recent.is_duplicate("telegram-1-1", "hi", now=500)
+    assert not recent.is_duplicate("telegram-2-2", "hi", now=100)
+
+
+def test_run_delivers_only_chat_sourced_messages(tmp_path, monkeypatch):
+    """Only bin/chat speaks for the identity: message steps without
+    source:"chat" (a thinker appending raw message steps to the trajectory)
+    must not reach Telegram."""
+    import threading
+
+    from headlong_telegram import outbound
+    from headlong_telegram.config import Config
+
     steps = [
+        # legit reply, stamped by bin/chat
         {"type": "message", "from": "audel", "to": "telegram-1-1",
          "source": "chat", "content": "real reply", "step_id": "aaa"},
         # forged: thinker-appended, wrong source
@@ -37,14 +51,52 @@ def test_forged_source_is_not_posted(tmp_path, monkeypatch):
     assert sent == ["real reply"]
 
 
+import base64
+import threading
+
+from headlong_telegram.api import ApiError
+from headlong_telegram import outbound
+from headlong_telegram.config import Config
+
+
+def _cfg(tmp_path):
+    return Config(
+        serve_root=tmp_path, identity="audel", identity_dir=tmp_path,
+        bot_token="x", admin_id=1, web_url="http://x", state_dir=tmp_path,
+    )
+
+
+def test_forged_source_is_not_posted(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "content": "real reply", "step_id": "aaa"},
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "responder", "content": "forged reply", "step_id": "bbb"},
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "content": "unstamped reply", "step_id": "ccc"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
+    assert sent == ["real reply"]
+
+
 def test_file_step_uses_send_document_not_message(tmp_path, monkeypatch):
     steps = [
         {"type": "message", "from": "audel", "to": "telegram-1-1",
-         "source": "chat", "content": "<svg xmlns=\"x\">",
-         "filename": "walk.svg", "caption": "thought walk",
-         "step_id": "fff"},
-        {"type": "message", "from": "audel", "to": "telegram-1-1",
-         "source": "chat", "content": "plain after", "step_id": "ggg"},
+         "source": "chat", "filename": "note.txt", "content": "hi",
+         "step_id": "ddd"},
     ]
     monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
     monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
@@ -63,22 +115,19 @@ def test_file_step_uses_send_document_not_message(tmp_path, monkeypatch):
         def is_approved(self, user):
             return True
 
-    cfg = Config(
-        serve_root=tmp_path, identity="audel", identity_dir=tmp_path,
-        bot_token="x", admin_id=1, web_url="http://x", state_dir=tmp_path,
-    )
-    outbound.run(cfg, FakeBot(), ApproveAll(), threading.Event())
-
-    assert docs == [("walk.svg", b"<svg xmlns=\"x\">", "thought walk")]
-    assert sent == ["plain after"]
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
+    assert docs == [("note.txt", "hi", None)]
+    assert sent == []
 
 
 def test_png_uses_send_photo(tmp_path, monkeypatch):
     png = b"\x89PNG\r\n\x1a\n" + b"rest"
     steps = [
         {"type": "message", "from": "audel", "to": "telegram-1-1",
-         "source": "chat", "content": png,
-         "filename": "fig.png", "step_id": "fff"},
+         "source": "chat",
+         "filename": "fig.png",
+         "content_b64": base64.b64encode(png).decode("ascii"),
+         "step_id": "fff"},
     ]
     monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
     monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
@@ -100,11 +149,63 @@ def test_png_uses_send_photo(tmp_path, monkeypatch):
         def is_approved(self, user):
             return True
 
-    cfg = Config(
-        serve_root=tmp_path, identity="audel", identity_dir=tmp_path,
-        bot_token="x", admin_id=1, web_url="http://x", state_dir=tmp_path,
-    )
-    outbound.run(cfg, FakeBot(), ApproveAll(), threading.Event())
-
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
     assert photos == [("fig.png", png, None)]
+    assert sent == []
+
+
+def test_send_photo_retries_as_document(tmp_path, monkeypatch):
+    png = b"\x89PNG\r\n\x1a\n" + b"rest"
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat",
+         "filename": "fig.png",
+         "content_b64": base64.b64encode(png).decode("ascii"),
+         "step_id": "ggg"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    photos = []
+    docs = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            raise AssertionError("should not send_message")
+
+        def send_photo(self, chat, content, filename, caption=None):
+            photos.append(filename)
+            raise ApiError("PHOTO_INVALID")
+
+        def send_document(self, chat, content, filename, caption=None):
+            docs.append((filename, content, caption))
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
+    assert photos == ["fig.png"]
+    assert docs == [("fig.png", png, None)]
+
+
+def test_group_chat_is_dropped(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-99",
+         "source": "chat", "content": "group hi", "step_id": "hhh"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
     assert sent == []

--- a/telegram/tests/test_outbound.py
+++ b/telegram/tests/test_outbound.py
@@ -1,25 +1,11 @@
-from headlong_telegram.outbound import RecentPosts
+import threading
+
+from headlong_telegram import outbound
+from headlong_telegram.config import Config
 
 
-def test_recent_posts_dedupe_window():
-    recent = RecentPosts(window=300)
-    assert not recent.is_duplicate("telegram-1-1", "hi", now=0)
-    assert recent.is_duplicate("telegram-1-1", "hi", now=100)
-    assert not recent.is_duplicate("telegram-1-1", "hi", now=500)
-    assert not recent.is_duplicate("telegram-2-2", "hi", now=100)
-
-
-def test_run_delivers_only_chat_sourced_messages(tmp_path, monkeypatch):
-    """Only bin/chat speaks for the identity: message steps without
-    source:"chat" (a thinker appending raw message steps to the trajectory)
-    must not reach Telegram."""
-    import threading
-
-    from headlong_telegram import outbound
-    from headlong_telegram.config import Config
-
+def test_forged_source_is_not_posted(tmp_path, monkeypatch):
     steps = [
-        # legit reply, stamped by bin/chat
         {"type": "message", "from": "audel", "to": "telegram-1-1",
          "source": "chat", "content": "real reply", "step_id": "aaa"},
         # forged: thinker-appended, wrong source
@@ -49,3 +35,76 @@ def test_run_delivers_only_chat_sourced_messages(tmp_path, monkeypatch):
     outbound.run(cfg, FakeBot(), ApproveAll(), threading.Event())
 
     assert sent == ["real reply"]
+
+
+def test_file_step_uses_send_document_not_message(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "content": "<svg xmlns=\"x\">",
+         "filename": "walk.svg", "caption": "thought walk",
+         "step_id": "fff"},
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "content": "plain after", "step_id": "ggg"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    docs = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+        def send_document(self, chat, content, filename, caption=None):
+            docs.append((filename, content, caption))
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    cfg = Config(
+        serve_root=tmp_path, identity="audel", identity_dir=tmp_path,
+        bot_token="x", admin_id=1, web_url="http://x", state_dir=tmp_path,
+    )
+    outbound.run(cfg, FakeBot(), ApproveAll(), threading.Event())
+
+    assert docs == [("walk.svg", b"<svg xmlns=\"x\">", "thought walk")]
+    assert sent == ["plain after"]
+
+
+def test_png_uses_send_photo(tmp_path, monkeypatch):
+    png = b"\x89PNG\r\n\x1a\n" + b"rest"
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "content": png,
+         "filename": "fig.png", "step_id": "fff"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    photos = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+        def send_photo(self, chat, content, filename, caption=None):
+            photos.append((filename, content, caption))
+
+        def send_document(self, chat, content, filename, caption=None):
+            raise AssertionError("png should use send_photo")
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    cfg = Config(
+        serve_root=tmp_path, identity="audel", identity_dir=tmp_path,
+        bot_token="x", admin_id=1, web_url="http://x", state_dir=tmp_path,
+    )
+    outbound.run(cfg, FakeBot(), ApproveAll(), threading.Event())
+
+    assert photos == [("fig.png", png, None)]
+    assert sent == []

--- a/telegram/tests/test_outbound.py
+++ b/telegram/tests/test_outbound.py
@@ -348,3 +348,38 @@ def test_identical_file_steps_are_suppressed(tmp_path, monkeypatch):
     outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
     assert docs == [("note.txt", body, None), ("note.txt", other, None)]
     assert sent == []
+
+
+def test_invalid_file_content_does_not_stop_later_replies(tmp_path, monkeypatch):
+    import threading
+
+    from headlong_telegram import outbound
+
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "filename": "bad.bin",
+         "content": {"x": "y"}, "step_id": "badobj"},
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "content": "later reply", "step_id": "okmsg"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    docs = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+        def send_document(self, chat, content, filename, caption=None):
+            docs.append(filename)
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
+    assert docs == []
+    assert sent == ["(failed to deliver file bad.bin)", "later reply"]
+

--- a/telegram/tests/test_outbound.py
+++ b/telegram/tests/test_outbound.py
@@ -307,3 +307,44 @@ def test_undecodable_file_falls_back_to_notice(tmp_path, monkeypatch):
     assert docs == []
     assert sent == ["(failed to deliver file note.txt)"]
 
+
+def test_identical_file_steps_are_suppressed(tmp_path, monkeypatch):
+    import threading
+
+    from headlong_telegram import outbound
+
+    body = b"same-bytes"
+    b64 = base64.b64encode(body).decode("ascii")
+    other = b"different-bytes"
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "filename": "note.txt", "content_b64": b64,
+         "step_id": "f1"},
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "filename": "note.txt", "content_b64": b64,
+         "step_id": "f2"},
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "filename": "note.txt",
+         "content_b64": base64.b64encode(other).decode("ascii"),
+         "step_id": "f3"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    docs = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+        def send_document(self, chat, content, filename, caption=None):
+            docs.append((filename, content, caption))
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
+    assert docs == [("note.txt", body, None), ("note.txt", other, None)]
+    assert sent == []

--- a/tests/test_chat_send_file.sh
+++ b/tests/test_chat_send_file.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# tests/test_chat_send_file.sh — producer + renderer for `chat send-file`.
+#
+# Covers Nick's leftover notes: empty/oversize rejection, content_b64 on the
+# mind-log step, and model-facing `context` eliding that field.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK="${SHELLM_TEST_WORK:-}"
+if [[ -z "$WORK" ]]; then
+    WORK=$(mktemp -d)
+    trap 'rm -rf "$WORK"' EXIT
+else
+    rm -rf "$WORK"; mkdir -p "$WORK"
+fi
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+export PATH="$REPO/bin:$PATH"
+export TRAJ_DIR="$WORK/traj"
+mkdir -p "$TRAJ_DIR"
+
+new_out=$(traj new --traj_dir "$TRAJ_DIR" --slug send-file-test)
+tid=$(printf '%s\n' "$new_out" | head -1)
+rel=$(printf '%s\n' "$new_out" | sed -n '2p')
+export TRAJ_ID="$tid"
+export ROOT_TRAJ_ID="$tid"
+export IDENTITY_NAME="tester"
+export CHATRC="$WORK/.chatrc"
+printf 'default_send_from=tester\n' > "$CHATRC"
+cd "$WORK"
+
+# --- happy path: text file lands as content_b64 + readable marker ---
+printf 'hello file\n' > "$WORK/note.txt"
+if chat send-file --from tester --to telegram-1-1 "$WORK/note.txt" >/dev/null 2>"$WORK/err"; then
+    step=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
+    got_name=$(printf '%s' "$step" | jq -r '.filename')
+    got_content=$(printf '%s' "$step" | jq -r '.content')
+    got_from=$(printf '%s' "$step" | jq -r '.from')
+    got_to=$(printf '%s' "$step" | jq -r '.to')
+    got_src=$(printf '%s' "$step" | jq -r '.source')
+    b64=$(printf '%s' "$step" | jq -r '.content_b64')
+    printf '%s' "$b64" | base64 -d > "$WORK/decoded.txt" 2>/dev/null || true
+    if [[ "$got_name" == "note.txt" && "$got_content" == "[file: note.txt]" \
+          && "$got_from" == "tester" && "$got_to" == "telegram-1-1" \
+          && "$got_src" == "chat" ]] && cmp -s "$WORK/note.txt" "$WORK/decoded.txt"; then
+        ok "send-file stamps filename, marker, and content_b64"
+    else
+        bad "send-file stamps fields" " step=$step"
+    fi
+else
+    bad "send-file happy path" " $(cat "$WORK/err")"
+fi
+
+# --- binary file stays off argv / round-trips ---
+printf 'a\0b\xffc' > "$WORK/blob.bin"
+if chat send-file --from tester --to telegram-1-1 "$WORK/blob.bin" >/dev/null 2>"$WORK/err"; then
+    step=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
+    b64=$(printf '%s' "$step" | jq -r '.content_b64')
+    printf '%s' "$b64" | base64 -d > "$WORK/blob.out" 2>/dev/null
+    if cmp -s "$WORK/blob.bin" "$WORK/blob.out"; then
+        ok "send-file round-trips binary bytes"
+    else
+        bad "send-file binary round-trip"
+    fi
+else
+    bad "send-file binary" " $(cat "$WORK/err")"
+fi
+
+# --- empty file is refused ---
+: > "$WORK/empty.txt"
+if chat send-file --from tester --to telegram-1-1 "$WORK/empty.txt" >/dev/null 2>"$WORK/err"; then
+    bad "empty file should be refused"
+else
+    if grep -q "empty file" "$WORK/err"; then
+        ok "empty file refused"
+    else
+        bad "empty file error message" " $(cat "$WORK/err")"
+    fi
+fi
+
+# --- oversize file is refused ---
+printf '0123456789' > "$WORK/big.txt"
+if CHAT_SEND_FILE_MAX_BYTES=4 chat send-file --from tester --to telegram-1-1 "$WORK/big.txt" >/dev/null 2>"$WORK/err"; then
+    bad "oversize file should be refused"
+else
+    if grep -q "too large" "$WORK/err"; then
+        ok "oversize file refused"
+    else
+        bad "oversize file error message" " $(cat "$WORK/err")"
+    fi
+fi
+
+# --- context renderer elides content_b64 ---
+rendered=$(context --traj_dir "$TRAJ_DIR" "$TRAJ_ID" 2>/dev/null || true)
+if printf '%s' "$rendered" | grep -q 'content_b64'; then
+    bad "context leaked content_b64"
+else
+    if printf '%s' "$rendered" | grep -q 'note.txt'; then
+        ok "context shows filename, hides content_b64"
+    else
+        # filename may still appear via the marker in content
+        if printf '%s' "$rendered" | grep -q '\[file: note.txt\]'; then
+            ok "context shows file marker, hides content_b64"
+        else
+            bad "context missing file marker" " rendered=${rendered:0:400}"
+        fi
+    fi
+fi
+
+# --- recent-stream jq elides content_b64 (same transform as common.sh) ---
+line=$(jq -nc --arg b64 "$(base64 -w 0 < "$WORK/note.txt" | tr -d '\n')" \
+    '{type:"message", filename:"note.txt", content:"", content_b64:$b64}')
+stream=$(printf '%s\n' "$line" | jq -c 'del(.content_b64)
+    | .content = (
+        (if ((.content // "") == "") and ((.filename // "") != "")
+         then "[file: \(.filename)]"
+         else (.content // "") end)
+        | tostring
+      )')
+if printf '%s' "$stream" | grep -q 'content_b64'; then
+    bad "recent-stream still has content_b64"
+else
+    marker=$(printf '%s' "$stream" | jq -r '.content')
+    if [[ "$marker" == "[file: note.txt]" ]]; then
+        ok "recent-stream substitutes file marker and drops content_b64"
+    else
+        bad "recent-stream marker" " $stream"
+    fi
+fi
+
+echo
+echo "passed: $pass"
+echo "failed: $fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_chat_send_file.sh
+++ b/tests/test_chat_send_file.sh
@@ -35,9 +35,9 @@ export CHATRC="$WORK/.chatrc"
 printf 'default_send_from=tester\n' > "$CHATRC"
 cd "$WORK" || exit 1
 
-# --- happy path: text file lands as content_b64 + readable marker ---
+# --- happy path: text file keeps body in content (Slack/web still read it) ---
 printf 'hello file\n' > "$WORK/note.txt"
-if chat send-file --from tester --to telegram-1-1 "$WORK/note.txt" >/dev/null 2>"$WORK/err"; then
+if chat send-file --from tester --to slack-U1-C1 "$WORK/note.txt" >/dev/null 2>"$WORK/err"; then
     step=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
     got_name=$(printf '%s' "$step" | jq -r '.filename')
     got_content=$(printf '%s' "$step" | jq -r '.content')
@@ -46,10 +46,10 @@ if chat send-file --from tester --to telegram-1-1 "$WORK/note.txt" >/dev/null 2>
     got_src=$(printf '%s' "$step" | jq -r '.source')
     b64=$(printf '%s' "$step" | jq -r '.content_b64')
     printf '%s' "$b64" | base64 -d > "$WORK/decoded.txt" 2>/dev/null || true
-    if [[ "$got_name" == "note.txt" && "$got_content" == "[file: note.txt]" \
-          && "$got_from" == "tester" && "$got_to" == "telegram-1-1" \
+    if [[ "$got_name" == "note.txt" && "$got_content" == "hello file" \
+          && "$got_from" == "tester" && "$got_to" == "slack-U1-C1" \
           && "$got_src" == "chat" ]] && cmp -s "$WORK/note.txt" "$WORK/decoded.txt"; then
-        ok "send-file stamps filename, marker, and content_b64"
+        ok "send-file text keeps body in content for non-Telegram routes"
     else
         bad "send-file stamps fields" " step=$step"
     fi
@@ -63,7 +63,9 @@ if chat send-file --from tester --to telegram-1-1 "$WORK/blob.bin" >/dev/null 2>
     step=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
     b64=$(printf '%s' "$step" | jq -r '.content_b64')
     printf '%s' "$b64" | base64 -d > "$WORK/blob.out" 2>/dev/null
-    if cmp -s "$WORK/blob.bin" "$WORK/blob.out"; then
+    got_content=$(printf '%s' "$step" | jq -r '.content')
+    if cmp -s "$WORK/blob.bin" "$WORK/blob.out" \
+          && [[ "$got_content" == "[file: blob.bin]" ]]; then
         ok "send-file round-trips binary bytes"
     else
         bad "send-file binary round-trip"

--- a/tests/test_chat_send_file.sh
+++ b/tests/test_chat_send_file.sh
@@ -28,13 +28,12 @@ mkdir -p "$TRAJ_DIR"
 
 new_out=$(traj new --traj_dir "$TRAJ_DIR" --slug send-file-test)
 tid=$(printf '%s\n' "$new_out" | head -1)
-rel=$(printf '%s\n' "$new_out" | sed -n '2p')
 export TRAJ_ID="$tid"
 export ROOT_TRAJ_ID="$tid"
 export IDENTITY_NAME="tester"
 export CHATRC="$WORK/.chatrc"
 printf 'default_send_from=tester\n' > "$CHATRC"
-cd "$WORK"
+cd "$WORK" || exit 1
 
 # --- happy path: text file lands as content_b64 + readable marker ---
 printf 'hello file\n' > "$WORK/note.txt"

--- a/tests/test_identity_export_import.sh
+++ b/tests/test_identity_export_import.sh
@@ -194,11 +194,14 @@ fi
 
 ALPHA_TRAJ="$ALPHA/trajectories/${ALPHA_RT:0:8}-root/trajectory.jsonl"
 long=$(printf 'x%.0s' $(seq 1 2000))
+file_key="sk-or-v1-FILELEAK$(printf 'd%.0s' $(seq 1 40))"
+file_b64=$(printf '%s' "$file_key" | base64 -w0 2>/dev/null || printf '%s' "$file_key" | base64)
 {
     printf '{"type":"shellm-run","command":"shellm --var OPENROUTER_API_KEY=sk-or-v1-%s %s","step_id":"s1","ts":"t1"}\n' "$(printf 'a%.0s' $(seq 1 64))" "$long"
     printf '{"type":"prompt","content":"%s","run_id":"r","step_id":"s2","ts":"t2"}\n' "$long"
     printf '{"type":"thought","content":"keep me whole %s","step_id":"s3","ts":"t3"}\n' "$long"
     printf '{"type":"shell-output","content":"token xoxb-1234-5678-abcdef lin_api_%s","step_id":"s4","ts":"t4"}\n' "$(printf 'b%.0s' $(seq 1 40))"
+    printf '{"type":"message","content":"[file: secret.bin]","filename":"secret.bin","content_b64":"%s","from":"a","to":"b","source":"chat","step_id":"s5","ts":"t5"}\n' "$file_b64"
 } >> "$ALPHA_TRAJ"
 
 SLIM="$WORK/slim.tgz"
@@ -216,6 +219,26 @@ check_not "slack token gone"      grep -q 'xoxb-1234' "$SLIM_TRAJ"
 check_not "linear key gone"       grep -q 'lin_api_bbbb' "$SLIM_TRAJ"
 check "redaction markers"         bash -c "test \$(grep -o 'REDACTED:' '$SLIM_TRAJ' | wc -l) -eq 3"
 check "slim archive still imports" bash -c "cd '$ROOT_B' && identity import '$SLIM' --name slimmy >/dev/null 2>&1 && test -f '$ROOT_B/.identities/slimmy/trajectories/${ALPHA_RT:0:8}-root/trajectory.jsonl'"
+
+check "slim drops content_b64"    bash -c "jq -e 'select(.filename==\"secret.bin\") | has(\"content_b64\") | not' '$SLIM_TRAJ'"
+check "slim keeps filename"       bash -c "jq -e 'select(.filename==\"secret.bin\").filename == \"secret.bin\"' '$SLIM_TRAJ'"
+check "slim keeps file marker"    bash -c "jq -e 'select(.filename==\"secret.bin\").content == \"[file: secret.bin]\"' '$SLIM_TRAJ'"
+check_not "slim file key gone"    grep -q 'FILELEAK' "$SLIM_TRAJ"
+check_not "slim file b64 gone"    grep -Fq "$file_b64" "$SLIM_TRAJ"
+
+# Same jq transform as deploy/scripts/audel-export's default SLIM filter
+# (KEEP_FULL=0). The box-side script is SSM-only; assert the filter here.
+AUDEL_SLIM='def cut($n): if (length > $n) then (.[0:$n] + " …[truncated " + ((length - $n)|tostring) + " chars]") else . end;
+          (if .type=="shellm-run" then .command |= cut(300)
+          elif .type=="prompt" then .content |= cut(600)
+          else . end)
+          | del(.content_b64)'
+AUDEL_OUT="$WORK/audel-export.jsonl"
+jq -c "$AUDEL_SLIM" "$ALPHA_TRAJ" > "$AUDEL_OUT"
+check "audel-export drops content_b64" bash -c "jq -e 'select(.filename==\"secret.bin\") | has(\"content_b64\") | not' '$AUDEL_OUT'"
+check "audel-export keeps filename"    bash -c "jq -e 'select(.filename==\"secret.bin\").filename == \"secret.bin\"' '$AUDEL_OUT'"
+check_not "audel-export file key gone" grep -q 'FILELEAK' "$AUDEL_OUT"
+check_not "audel-export file b64 gone" grep -Fq "$file_b64" "$AUDEL_OUT"
 
 # ---------------------------------------------------------------------------
 

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -293,7 +293,7 @@ _recent_stream() {
         | jq -cR 'fromjson? // empty
             | select(.type == "thought" or .type == "action" or .type == "observation"
                      or .type == "message" or .type == "idle" or .type == "merge"
-                     or .type == "final" or .type == "error" or .type == "reasoning")
+                     or .type == "final" or .type == "error")
             | del(.content_b64)
             | .content = (
                 (if ((.content // "") == "") and ((.filename // "") != "")

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -293,8 +293,13 @@ _recent_stream() {
         | jq -cR 'fromjson? // empty
             | select(.type == "thought" or .type == "action" or .type == "observation"
                      or .type == "message" or .type == "idle" or .type == "merge"
-                     or .type == "final" or .type == "error")
-            | .content = ((.content // "") | tostring
+                     or .type == "final" or .type == "error" or .type == "reasoning")
+            | del(.content_b64)
+            | .content = (
+                (if ((.content // "") == "") and ((.filename // "") != "")
+                 then "[file: \(.filename)]"
+                 else (.content // "") end)
+                | tostring
                 | if length > 1500 then .[0:1500] + "…[truncated]" else . end)
             | if .type == "final" and ((.run_id // "") | tostring) != ""
               then .details = "traj tail -n 400 --filter run_id=" + (.run_id | tostring) else . end' \

--- a/tools/identity
+++ b/tools/identity
@@ -489,12 +489,15 @@ _export_manifest_entry() {
 # repetition — every `shellm-run` step embeds the same launch command line
 # and every `prompt` step embeds the whole rendered context. Cut both to a
 # short head plus a "…[truncated N chars]" tail; every other step travels
-# whole. Then scrub API-key shapes. Audel's 1GB log came out at ~17MB gzipped.
+# whole except encoded file bytes (`content_b64`), which slim drops so a
+# credential inside a sent file cannot bypass text redaction. Then scrub
+# API-key shapes. Audel's 1GB log came out at ~17MB gzipped.
 _SLIM_JQ='def cut($n): if (type == "string" and length > $n)
     then (.[0:$n] + " …[truncated " + ((length - $n)|tostring) + " chars]") else . end;
-  if .type == "shellm-run" then .command |= cut(300)
-  elif .type == "prompt" then .content |= cut(600)
-  else . end'
+  (if .type == "shellm-run" then .command |= cut(300)
+   elif .type == "prompt" then .content |= cut(600)
+   else . end)
+  | del(.content_b64)'
 
 _slim_redact() {
     LC_ALL=C sed -E \

--- a/web/src/headlong_web/trajectory.py
+++ b/web/src/headlong_web/trajectory.py
@@ -205,6 +205,17 @@ _CHAT_FIELDS = (
 )
 
 
+
+def _wire_raw(raw: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Dashboard copy of a step: drop file bytes. The UI shows `filename`
+    and the short `content` marker; `content_b64` only inflates the JSON."""
+    if raw is None or "content_b64" not in raw:
+        return raw
+    stripped = dict(raw)
+    stripped.pop("content_b64", None)
+    return stripped
+
+
 class _Normalizer:
     """Stateful step normalizer: feed raw steps in order, read results any
     time. The state (open runs, unmatched actions, seen ids) is exactly what
@@ -236,7 +247,7 @@ class _Normalizer:
             "type": step_type,
             "source": source,
             "preview": step_preview(raw),
-            "raw": raw,
+            "raw": _wire_raw(raw),
             "run_id": None,
         }
 
@@ -492,7 +503,7 @@ class TrajectoryCache:
                 )
                 for i, raw in zip(missing, raws):
                     if raw is not None:
-                        steps[i - lo] = {**norm.steps[i], "raw": raw}
+                        steps[i - lo] = {**norm.steps[i], "raw": _wire_raw(raw)}
 
             return {
                 "steps": steps,

--- a/web/tests/test_trajectory.py
+++ b/web/tests/test_trajectory.py
@@ -249,3 +249,24 @@ def test_blob_fields_survive_normalization():
     step = result["steps"][0]
     assert step["raw"]["stdout_truncated"] is True
     assert step["raw"]["stdout_ref"] == "blobs/s1-000000.stdout"
+
+
+def test_file_bytes_stripped_from_dashboard_raw():
+    raw = {
+        "type": "message",
+        "step_id": "s1",
+        "ts": "2026-01-01T00:00:00+0000",
+        "filename": "note.txt",
+        "content": "hello file",
+        "content_b64": "aGVsbG8gZmlsZQo=",
+        "from": "audel",
+        "to": "slack-U1-C1",
+        "source": "chat",
+    }
+    from headlong_web.trajectory import normalize
+
+    result = normalize([raw], Path("/nonexistent"))
+    step = result["steps"][0]
+    assert step["raw"]["filename"] == "note.txt"
+    assert step["raw"]["content"] == "hello file"
+    assert "content_b64" not in step["raw"]

--- a/web/tests/test_trajectory_cache.py
+++ b/web/tests/test_trajectory_cache.py
@@ -322,3 +322,65 @@ def test_step_endpoint_hydrates_evicted(ident_root: Path, monkeypatch):
     assert [s["raw"]["content"] for s in window["steps"]] == [
         "idea 1", "idea 2", "idea 3",
     ]
+
+
+def test_mindlog_strips_content_b64(ident_root: Path):
+    """File bytes stay off the dashboard wire; filename and content remain."""
+    jsonl = (
+        ident_root / ".identities" / "scaly" / "trajectories"
+        / "fbfbfbfb-root" / "trajectory.jsonl"
+    )
+    payload = "x" * 64
+    import base64
+    b64 = base64.b64encode(payload.encode()).decode("ascii")
+    _write(
+        jsonl,
+        [{
+            "type": "message",
+            "step_id": "file1",
+            "ts": "2026-09-03T00:00:00Z",
+            "from": "audel",
+            "to": "slack-U1-C1",
+            "source": "chat",
+            "filename": "note.txt",
+            "content": "hello file",
+            "content_b64": b64,
+        }],
+        append=True,
+    )
+    client = TestClient(create_app(ident_root))
+    body = client.get("/api/identities/.identities~scaly/mindlog").json()
+    step = next(s for s in body["steps"] if s.get("step_id") == "file1")
+    raw = step["raw"]
+    assert raw["filename"] == "note.txt"
+    assert raw["content"] == "hello file"
+    assert "content_b64" not in raw
+    blob = json.dumps(body)
+    assert "content_b64" not in blob
+    assert b64 not in blob
+
+
+def test_window_rehydrate_strips_content_b64(traj_dir: Path):
+    jsonl = traj_dir / "trajectory.jsonl"
+    import base64
+    b64 = base64.b64encode(b"hello file").decode("ascii")
+    _write(
+        jsonl,
+        [_step(i) for i in range(1, 40)]
+        + [{
+            "type": "message",
+            "step_id": "sfile",
+            "ts": "tfile",
+            "filename": "note.txt",
+            "content": "hello file",
+            "content_b64": b64,
+        }],
+        append=True,
+    )
+    cache = trajectory.TrajectoryCache(raw_budget=600)
+    cache.load(traj_dir)
+    window = cache.window(traj_dir, 0, None)
+    file_step = next(s for s in window["steps"] if s.get("step_id") == "sfile")
+    assert file_step["raw"]["filename"] == "note.txt"
+    assert file_step["raw"]["content"] == "hello file"
+    assert "content_b64" not in file_step["raw"]


### PR DESCRIPTION
This slice:
- detects file-bearing mind-log steps (`filename` / PNG / SVG sniff)
- adds `Bot.send_document` and `Bot.send_photo` (multipart)
- routes images to `sendPhoto` and everything else to `sendDocument`
- keeps the existing source=chat delivery guard

Intentionally not in this PR: identity-local responder dest-history stub, notes, secrets, web build artifacts.

Pushed from `headlong42/headlong` because `headlong42` has pull-only on `laude-institute/headlong` (direct origin push 403).