### PR TITLE
shellm: thinking on stderr is not an llm failure

### DIFF
--- a/bin/shellm
+++ b/bin/shellm
@@ -1398,13 +1398,13 @@ call_llm() {
         die "llm failed (exit $llm_exit): $_llm_err"
     fi
 
-    # If llm produced no output, surface any error from stderr
-    if [[ ! -s "$text_file" && -s "$stderr_file" ]]; then
-        local _llm_err
-        _llm_err=$(cat "$stderr_file")
-        rm -f "$text_file" "$stderr_file"
-        die "llm failed: $_llm_err"
-    fi
+    # No visible text is not a failure. `llm --thinking` streams reasoning to
+    # stderr, and a run that spends its whole token budget there returns 200,
+    # exits 0 and emits nothing on stdout, which is exactly what run_loop's
+    # empty-response retry feeds back as assistant context. Dying on a
+    # non-empty stderr here made that retry unreachable and printed the
+    # model's reasoning as an error. Real failures exit non-zero and are
+    # caught above.
 
     cat "$text_file"
     rm -f "$text_file" "$stderr_file"

--- a/tests/test_shellm_empty_response_retry.sh
+++ b/tests/test_shellm_empty_response_retry.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# tests/test_shellm_empty_response_retry.sh — call_llm only fails the call
+# when llm actually failed.
+#
+# Usage: tests/test_shellm_empty_response_retry.sh
+#
+# `llm --thinking` streams the model's reasoning to stderr and, when the
+# token budget runs out during that reasoning, returns 200 with no visible
+# text and exits 0. run_loop's empty-response retry exists for exactly that
+# case (feed the captured thinking back as assistant context and continue),
+# so call_llm must hand it back an empty response instead of dying on the
+# thinking text. A real failure — llm exiting non-zero — must still die.
+#
+# call_llm is extracted from bin/shellm and exercised directly (sourcing the
+# whole script would run it) against a stub `llm` on PATH.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/llm" <<'STUB'
+#!/usr/bin/env bash
+# Stub llm: LLM_STUB_MODE picks which provider outcome to imitate.
+case "$LLM_STUB_MODE" in
+    thinking_only)   printf 'Thinking: the budget ran out here\n' >&2; exit 0 ;;
+    thinking_blank)  printf 'Thinking: the budget ran out here\n' >&2; printf '\n'; exit 0 ;;
+    thinking_text)   printf 'Thinking: done\n' >&2; printf 'visible answer\n'; exit 0 ;;
+    silent)          exit 0 ;;
+    failed)          printf 'llm: error: API error (HTTP 500)\n' >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$tmp/bin/llm"
+
+# Run call_llm the way run_loop does: inside a command substitution, in a
+# shell with bin/shellm's own `set -euo pipefail`. The nesting is not
+# cosmetic: bash does not carry errexit into the QUIET=0 branch's pipeline
+# subshell from there, which is what lets that branch record llm's exit code
+# at all. Writes the captured thinking to $tmp/think and stderr to $tmp/err.
+run_call_llm() {
+    local mode="$1" quiet="$2"
+    : > "$tmp/think"
+    LLM_STUB_MODE="$mode" QUIET="$quiet" PATH="$tmp/bin:$PATH" \
+    SHELLM_MODEL=stub-model SHELLM_EFFORT=medium SHELLM_MAX_TOKENS='' \
+    THINK_FILE="$tmp/think" REPO="$REPO" \
+        bash -c '
+            set -euo pipefail
+            die() { echo "shellm: error: $*" >&2; exit 1; }
+            eval "$(sed -n "/^call_llm()/,/^}/p" "$REPO/bin/shellm")"
+            _response=$(call_llm "system prompt" "[]" "$THINK_FILE")
+            printf "%s" "$_response"
+        ' 2>"$tmp/err"
+}
+
+check() {
+    local label="$1" mode="$2" quiet="$3" want_rc="$4" want_out="$5"
+    local out rc
+    out=$(run_call_llm "$mode" "$quiet"); rc=$?
+    if [[ "$rc" -eq "$want_rc" && "$out" == "$want_out" ]]; then
+        ok "$label (QUIET=$quiet)"
+    else
+        bad "$label (QUIET=$quiet)" "rc=$rc want=$want_rc out=$(printf '%q' "$out") stderr=$(printf '%q' "$(cat "$tmp/err")")"
+    fi
+}
+
+for quiet in 0 1; do
+    # The reported bug: thinking on stderr with no visible text is not an
+    # error, and dying on it makes run_loop's retry unreachable.
+    check "thinking on stderr, no visible text returns empty" thinking_only "$quiet" 0 ""
+
+    # The thinking has to survive the call, or the retry has nothing to feed
+    # back and falls through to the sleep-and-repeat branch.
+    run_call_llm thinking_only "$quiet" >/dev/null
+    if [[ -s "$tmp/think" ]] && grep -q 'budget ran out' "$tmp/think"; then
+        ok "thinking is captured for the retry (QUIET=$quiet)"
+    else
+        bad "thinking is captured for the retry (QUIET=$quiet)" "$(cat "$tmp/think")"
+    fi
+
+    # Whitespace-only output is the same empty response after $( ) strips it.
+    check "blank line with thinking returns empty" thinking_blank "$quiet" 0 ""
+
+    # A normal answer is unaffected by any of this.
+    check "visible text is returned" thinking_text "$quiet" 0 "visible answer"
+
+    # No output and nothing on stderr: still an empty response, still no die.
+    check "silent success returns empty" silent "$quiet" 0 ""
+
+    # Must-not: a failed llm call still dies rather than reaching the retry.
+    check "a non-zero llm exit still fails the call" failed "$quiet" 1 ""
+    if grep -q 'llm failed (exit 1)' "$tmp/err"; then
+        ok "the failure message names llm's exit code (QUIET=$quiet)"
+    else
+        bad "the failure message names llm's exit code (QUIET=$quiet)" "$(cat "$tmp/err")"
+    fi
+done
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Fixes #86.

`llm --thinking` puts the model's reasoning on stderr, and a call that spends its whole token budget there returns 200 with nothing on stdout and exits 0. `call_llm` treated "no stdout, something on stderr" as a failure and died, printing the reasoning as the error.

That is what `run_loop`'s empty-response retry exists for. The retry needs an empty response together with non-empty captured thinking, and the thinking is the stderr the guard died on, so the feed-back branch was unreachable: the only way past the guard was a provider emitting whitespace-only stdout, which `$( )` then strips back to empty.

The guard predates the exit-code check above it (c3ef334, before `call_llm` looked at llm's exit code at all; 58cc447 added the check two months later). Every error path in `bin/llm` goes through its `die()` and exits 1, so exit 0 with content on stderr is thinking, a truncation warning or a transient-retry notice, and the check above already covers the failures. Removing the guard leaves the empty-response policy where it was written, in `run_loop`.

## Verification

`tests/test_shellm_empty_response_retry.sh` extracts `call_llm` and drives it against a stub `llm`, in both quiet modes: thinking with no visible text returns empty and keeps the thinking for the retry, whitespace-only and silent responses return empty, a normal answer is unaffected, and a non-zero llm exit still fails the call naming the exit code. 14 assertions, RED before the change. Restoring the guard turns the two thinking-only assertions red; deleting the exit-code check turns the four failure assertions red.

The test runs `call_llm` inside a command substitution the way `run_loop` does. That nesting is not cosmetic: bash does not carry `errexit` into the non-quiet branch's pipeline subshell from there, which is what lets that branch record llm's exit code.

End to end through the real stack, with `SHELLM_API_URL` pointed at a local endpoint returning a thinking-only Anthropic stream that ends in `"stop_reason": "max_tokens"`:

| | exit | provider calls | result |
|---|---|---|---|
| before | 1 | 2 | `shellm: error: llm failed: <the reasoning>` |
| after | 0 | 3 | retry fires, second call answers, run completes |

Eight branches were run end to end through `bin/shellm` before and after, on bash 5.2 and on bash 3.2.57: thinking-only then answer, silent-empty then answer, always-thinking-only against a retry cap, always-silent against a cap, a non-zero llm exit, a normal answer, quiet mode, and whitespace-only stdout. Only the three cases that reach the guard change; the terminal "after N retries" deaths and the exit-code death are unchanged.

Also run locally: `tests/run-all.sh` 36/36 on bash 5.2 and on bash 3.2.57 (built from source for this), `bash -n` and the bash-4 construct lint over all 71 product scripts under 3.2, `shellcheck -S warning` over the tree, pytest for web, slack and telegram, `tests/smoke_install.sh` in a bare `ubuntu:24.04` container, and the cargo and viewer checks.
