### PR TITLE
dash timeline: deeplink to steps and runs

### DIFF
--- a/web/viewer/app/app.css
+++ b/web/viewer/app/app.css
@@ -287,6 +287,18 @@ html.dark {
   transform-origin: left center;
 }
 
+/* Timeline: a deeplinked (or search-jumped) element pulses so the eye
+   finds it on the crowded canvas */
+@keyframes tl-flash {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(103, 232, 249, 0); }
+  30%, 70% { box-shadow: 0 0 0 3px rgba(103, 232, 249, 0.9), 0 0 20px rgba(34, 211, 238, 0.8); }
+}
+
+.tl-flash {
+  animation: tl-flash 1.1s ease-in-out 3;
+  border-radius: 4px;
+}
+
 /* Mind log v2: always-dark presentation canvas with the hype-video edge
    glow (pink upper left, teal lower right), independent of the dash theme. */
 .ml2-canvas {

--- a/web/viewer/app/components/mindlog-search.tsx
+++ b/web/viewer/app/components/mindlog-search.tsx
@@ -49,9 +49,10 @@ function Snippet({ text, q }: { text: string; q: string }) {
   );
 }
 
-/** Modal for a hit older than the loaded window: fetch and show the one
- * step without dragging thousands of intermediate steps into the page. */
-function StepModal({
+/** Modal for a step older than the loaded window (a search hit or a
+ * deeplink): fetch and show the one step without dragging thousands of
+ * intermediate steps into the page. */
+export function StepModal({
   identityId,
   stepId,
   stepCount,
@@ -59,7 +60,7 @@ function StepModal({
 }: {
   identityId: string;
   stepId: string;
-  stepCount: number;
+  stepCount?: number;
   onClose: () => void;
 }) {
   const { data, isError } = useQuery({
@@ -101,8 +102,9 @@ function StepModal({
         ) : (
           <>
             <div className="mb-2 pr-8 font-mono text-[10px] text-muted-foreground">
-              step {data.index + 1} of {stepCount} — older than the loaded
-              window
+              step {data.index + 1}
+              {stepCount !== undefined && <> of {stepCount}</>} — older than
+              the loaded window
             </div>
             <StepCard step={data.step} expandAll />
           </>

--- a/web/viewer/app/components/timeline-detail.tsx
+++ b/web/viewer/app/components/timeline-detail.tsx
@@ -6,7 +6,15 @@
 // never reflows.
 
 import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, ChevronRight, CornerDownRight, Play, X } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  CornerDownRight,
+  Link,
+  Play,
+  X,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { ExpandableText } from "~/components/expandable-text";
@@ -40,7 +48,33 @@ export type TimelineSelection =
   | { kind: "step"; step: NormalizedStep }
   | { kind: "run"; block: TimelineBlock };
 
-function Modal({
+/** While the modal is open the URL carries ?step=/?run= for the selected
+ * item, so the copy just lifts the address bar. */
+function CopyLinkButton() {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      aria-label="Copy link"
+      title="Copy link to this item"
+      className="absolute right-10 top-3 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+      onClick={() => {
+        void navigator.clipboard?.writeText(window.location.href).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        });
+      }}
+    >
+      {copied ? (
+        <Check className="h-4 w-4 text-green-500" />
+      ) : (
+        <Link className="h-4 w-4" />
+      )}
+    </button>
+  );
+}
+
+export function Modal({
   onClose,
   children,
 }: {
@@ -64,6 +98,7 @@ function Modal({
         className="relative max-h-[85vh] w-full max-w-2xl overflow-y-auto rounded-lg border bg-background p-4 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
+        <CopyLinkButton />
         <button
           type="button"
           onClick={onClose}
@@ -186,7 +221,7 @@ export function TimelineDetailModal({
     const hasContext = trigger || runBlock || triggeredRuns.length > 0;
     return (
       <Modal onClose={onClose}>
-        <div className="pr-8">
+        <div className="pr-14">
           <StepCard step={step} expandAll />
           {hasContext && (
             <div className="mt-3 space-y-0.5 border-t pt-2">
@@ -243,7 +278,7 @@ function RunModal({
   const result = typeof final?.raw.content === "string" ? final.raw.content : null;
   return (
     <Modal onClose={onClose}>
-      <div className="pr-8">
+      <div className="pr-14">
         <div className="mb-1 flex flex-wrap items-center gap-2">
           <Badge variant="outline" className="text-[10px]">
             run

--- a/web/viewer/app/components/timeline-view.tsx
+++ b/web/viewer/app/components/timeline-view.tsx
@@ -26,9 +26,15 @@ import {
   Pause,
 } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { TimelineDetailModal, type TimelineSelection } from "~/components/timeline-detail";
+import { StepModal } from "~/components/mindlog-search";
+import {
+  Modal,
+  TimelineDetailModal,
+  type TimelineSelection,
+} from "~/components/timeline-detail";
+import { useTrajContext } from "~/lib/traj-context";
 import { timelineColor } from "~/lib/step-colors";
 import {
   GUTTER_W,
@@ -153,12 +159,37 @@ export function TimelineView({
    * wrapper object per request so repeat clicks reopen the modal. */
   openStep?: { step: NormalizedStep } | null;
 }) {
+  const traj = useTrajContext();
   const [hovered, setHovered] = useState<string | null>(null);
   const [selected, setSelected] = useState<TimelineSelection | null>(null);
 
+  // Deeplinks: ?step= / ?run= mirror the open detail modal, so the address
+  // bar is always a shareable link to what's on screen. The params present
+  // at mount are resolved once the layout is up (below).
+  const [stepParam, setStepParam] = useQueryState("step", parseAsString);
+  const [runParam, setRunParam] = useQueryState("run", parseAsString);
+  const [flashId, setFlashId] = useState<string | null>(null);
+  const [missing, setMissing] = useState<{
+    kind: "step" | "run";
+    id: string;
+  } | null>(null);
+  const pendingDeeplink = useRef<{
+    step: string | null;
+    run: string | null;
+  } | null>({ step: stepParam, run: runParam });
+
+  const applySelection = useCallback(
+    (sel: TimelineSelection | null) => {
+      setSelected(sel);
+      void setStepParam(sel?.kind === "step" ? sel.step.step_id : null);
+      void setRunParam(sel?.kind === "run" ? sel.block.run.run_id : null);
+    },
+    [setStepParam, setRunParam]
+  );
+
   useEffect(() => {
-    if (openStep) setSelected({ kind: "step", step: openStep.step });
-  }, [openStep]);
+    if (openStep) applySelection({ kind: "step", step: openStep.step });
+  }, [openStep, applySelection]);
 
   // Lane display state (all URL-persisted, comma-separated lane ids)
   const [collapsedParam, setCollapsedParam] = useQueryState(
@@ -264,7 +295,11 @@ export function TimelineView({
   // Follow mode: the timeline scrolls inside its own container (so the lane
   // header can stick); while pinned to the bottom, new rows scroll into view.
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [pinned, setPinned] = useState(true);
+  // Arriving via a deeplink starts unpinned so follow mode doesn't yank
+  // the view to the bottom before the target is seen.
+  const [pinned, setPinned] = useState(
+    () => !(pendingDeeplink.current?.step || pendingDeeplink.current?.run)
+  );
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -324,6 +359,60 @@ export function TimelineView({
     }
     return m;
   }, [layout.cells, layout.blocks]);
+
+  // --- deeplink resolution --------------------------------------------------
+
+  // Runs once, on the first layout: find the linked element, scroll its
+  // row into view, pulse it, and open its detail modal. A step outside the
+  // loaded window (or one that no longer exists) falls back to a fetch-one
+  // modal, like an old search hit — deliberately NOT auto-paging history
+  // in, which could mean tens of MB on a grown mind log.
+  useEffect(() => {
+    const want = pendingDeeplink.current;
+    if (!want) return;
+    pendingDeeplink.current = null;
+    if (!want.step && !want.run) return;
+
+    const scrollToRow = (row: number) => {
+      const el = scrollRef.current;
+      if (el) {
+        el.scrollTop = Math.max(0, layout.rowY[row] - el.clientHeight / 3);
+      }
+    };
+
+    if (want.step) {
+      const step = stepById.get(want.step);
+      if (!step) {
+        setMissing({ kind: "step", id: want.step });
+        return;
+      }
+      // Run machinery steps have no cell of their own; land on their block.
+      const cell = cellById.get(want.step);
+      const runId = typeof step.raw.run_id === "string" ? step.raw.run_id : null;
+      const block = !cell && runId ? blockById.get(runId) : undefined;
+      const row = cell?.row ?? block?.startRow;
+      if (row !== undefined) {
+        scrollToRow(row);
+        setFlashId(cell ? want.step : block!.run.run_id);
+      }
+      setSelected({ kind: "step", step });
+    } else if (want.run) {
+      const block = blockById.get(want.run);
+      if (!block) {
+        setMissing({ kind: "run", id: want.run });
+        return;
+      }
+      scrollToRow(block.startRow);
+      setFlashId(want.run);
+      setSelected({ kind: "run", block });
+    }
+  }, [layout, cellById, blockById, stepById]);
+
+  useEffect(() => {
+    if (!flashId) return;
+    const timer = setTimeout(() => setFlashId(null), 3500);
+    return () => clearTimeout(timer);
+  }, [flashId]);
 
   // --- orthogonal edge routing ----------------------------------------------
 
@@ -625,7 +714,7 @@ export function TimelineView({
                 <button
                   key={block.run.run_id}
                   type="button"
-                  onClick={() => setSelected({ kind: "run", block })}
+                  onClick={() => applySelection({ kind: "run", block })}
                   onMouseEnter={() => setHovered(block.run.run_id)}
                   onMouseLeave={() => setHovered(null)}
                   className={cn(
@@ -633,7 +722,8 @@ export function TimelineView({
                     "border-cyan-400/50 bg-cyan-400/[0.06] hover:bg-cyan-400/[0.12]",
                     running && "animate-pulse",
                     hot && "ring-2 ring-cyan-300/70",
-                    freshIds.has(block.run.run_id) && "tl-pop"
+                    freshIds.has(block.run.run_id) && "tl-pop",
+                    flashId === block.run.run_id && "tl-flash"
                   )}
                   style={{
                     left: r.left,
@@ -668,7 +758,7 @@ export function TimelineView({
                 <button
                   key={cell.step.step_id}
                   type="button"
-                  onClick={() => setSelected({ kind: "step", step: cell.step })}
+                  onClick={() => applySelection({ kind: "step", step: cell.step })}
                   onMouseEnter={() => setHovered(cell.step.step_id)}
                   onMouseLeave={() => setHovered(null)}
                   className={cn(
@@ -704,7 +794,8 @@ export function TimelineView({
                     className={cn(
                       "shrink-0 rounded-sm",
                       timelineColor(cell.step.type),
-                      hot && "ring-2 ring-cyan-200/60"
+                      hot && "ring-2 ring-cyan-200/60",
+                      flashId === cell.step.step_id && "tl-flash"
                     )}
                     style={{
                       width: CELL,
@@ -761,7 +852,7 @@ export function TimelineView({
                   {/* sticky so long blocks keep their summary in view mid-scroll */}
                   <button
                     type="button"
-                    onClick={() => setSelected({ kind: "run", block })}
+                    onClick={() => applySelection({ kind: "run", block })}
                     onMouseEnter={() => setHovered(block.run.run_id)}
                     onMouseLeave={() => setHovered(null)}
                     className="pointer-events-auto sticky flex w-full flex-col rounded border border-cyan-400/40 px-1.5 py-0.5 text-left"
@@ -843,11 +934,36 @@ export function TimelineView({
       {selected && (
         <TimelineDetailModal
           selected={selected}
-          onClose={() => setSelected(null)}
-          onSelect={setSelected}
+          onClose={() => applySelection(null)}
+          onSelect={applySelection}
           stepById={stepById}
           blockByRun={blockById}
         />
+      )}
+
+      {/* deeplink targets outside the loaded window */}
+      {missing?.kind === "step" && traj && (
+        <StepModal
+          identityId={traj.identityId}
+          stepId={missing.id}
+          onClose={() => {
+            setMissing(null);
+            void setStepParam(null);
+          }}
+        />
+      )}
+      {missing?.kind === "run" && (
+        <Modal
+          onClose={() => {
+            setMissing(null);
+            void setRunParam(null);
+          }}
+        >
+          <div className="py-4 pr-8 text-sm text-muted-foreground">
+            This run is older than the loaded part of the timeline. Use
+            “load older” to page more history in, then open the link again.
+          </div>
+        </Modal>
       )}
     </div>
   );


### PR DESCRIPTION
The timeline URL now mirrors the open detail modal as ?step= or ?run=, so the address bar is always a shareable link, and the modal has a copy link button. 

Opening a link scrolls the canvas to the element, pulses it, and opens its detail modal. 

A step older than the loaded window falls back to the fetch one step modal that search already uses, and a run older than the window gets a notice to page history in with load older, so a link never drags thousands of old steps into the page.


