### PR TITLE
fast-follows from the #91 review

### DIFF
--- a/web/viewer/app/components/timeline-detail.tsx
+++ b/web/viewer/app/components/timeline-detail.tsx
@@ -48,25 +48,33 @@ export type TimelineSelection =
   | { kind: "step"; step: NormalizedStep }
   | { kind: "run"; block: TimelineBlock };
 
+/** Copy `getUrl()` to the clipboard and flash `copied` for 1.5s; a denied
+ * clipboard (permissions, non-secure context) is silently ignored. */
+function useCopyLink(getUrl: () => string) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    void navigator.clipboard
+      ?.writeText(getUrl())
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  };
+  return { copied, copy };
+}
+
 /** While the modal is open the URL carries ?step=/?run= for the selected
  * item, so the copy just lifts the address bar. */
 function CopyLinkButton() {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyLink(() => window.location.href);
   return (
     <button
       type="button"
       aria-label="Copy link"
       title="Copy link to this item"
       className="absolute right-10 top-3 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-      onClick={() => {
-        void navigator.clipboard
-          ?.writeText(window.location.href)
-          .then(() => {
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
-          })
-          .catch(() => {});
-      }}
+      onClick={copy}
     >
       {copied ? (
         <Check className="h-4 w-4 text-green-500" />
@@ -80,22 +88,19 @@ function CopyLinkButton() {
 /** Copy a deeplink to one run substep. While the run modal is open the
  * URL carries ?run=, not the substep, so the link is built by hand. */
 function SubstepLink({ stepId }: { stepId: string }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyLink(() => {
+    const url = new URL(window.location.href);
+    url.searchParams.set("step", stepId);
+    url.searchParams.delete("run");
+    return url.toString();
+  });
   return (
     <button
       type="button"
       aria-label="Copy link to this step"
       title="Copy link to this step"
       className="absolute right-1 top-1.5 z-10 rounded-md p-1 text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover/substep:opacity-100"
-      onClick={() => {
-        const url = new URL(window.location.href);
-        url.searchParams.set("step", stepId);
-        url.searchParams.delete("run");
-        void navigator.clipboard?.writeText(url.toString()).then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        });
-      }}
+      onClick={copy}
     >
       {copied ? (
         <Check className="h-3.5 w-3.5 text-green-500" />

--- a/web/viewer/app/components/timeline-view.test.tsx
+++ b/web/viewer/app/components/timeline-view.test.tsx
@@ -1,8 +1,8 @@
 // Deeplink behavior of the Timeline tab: ?step=/?run= resolution at mount
 // (including a first layout that hasn't loaded yet), reconciliation with
 // later URL changes (soft navigation, Back/Forward), fallbacks for targets
-// outside the loaded window, follow-mode pinning, and the URL round-trip
-// of opening/closing the detail modal.
+// outside the loaded window, follow-mode pinning, the URL round-trip
+// of opening/closing the detail modal, and the substep copy-link URL.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
@@ -276,6 +276,37 @@ describe("timeline deeplinks", () => {
       await new Promise((r) => setTimeout(r, 0));
     } finally {
       delete (navigator as unknown as Record<string, unknown>).clipboard;
+    }
+  });
+
+  it("a substep copy builds a ?step= deeplink, dropping ?run= and keeping other params", async () => {
+    // SubstepLink builds from window.location.href, not the nuqs adapter, so
+    // stage a real URL carrying the run param plus an unrelated one.
+    window.history.replaceState(null, "", "/?run=r1&theme=dark");
+    const written: string[] = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn(async (t: string) => void written.push(t)) },
+    });
+    try {
+      renderTimeline({ url: "?run=r1" });
+      fireEvent.click(await screen.findByText("steps (2)"));
+      const buttons = screen.getAllByLabelText("Copy link to this step");
+      expect(buttons).toHaveLength(2);
+      for (const b of buttons) fireEvent.click(b);
+      await waitFor(() => expect(written).toHaveLength(2));
+      const urls = written.map((w) => new URL(w));
+      expect(urls.map((u) => u.searchParams.get("step")).sort()).toEqual([
+        "s-final",
+        "s-run-header",
+      ]);
+      for (const u of urls) {
+        expect(u.searchParams.get("run")).toBeNull();
+        expect(u.searchParams.get("theme")).toBe("dark");
+      }
+    } finally {
+      delete (navigator as unknown as Record<string, unknown>).clipboard;
+      window.history.replaceState(null, "", "/");
     }
   });
 


### PR DESCRIPTION
Fast-follows from the committee review of #91, applied after its merge.

## The plan implemented

1. **Deduplicate copy-link logic** (`web/viewer/app/components/timeline-detail.tsx`): extract the shared "write to clipboard, flash `copied` state for 1500ms" logic out of `CopyLinkButton` and `SubstepLink` into a small shared hook (e.g. `useCopyLink(getUrl: () => string)`) or a shared `<CopyButton>` component parameterized by URL-building and styling. Verify by confirming both call sites shrink to passing a URL-builder/className and behavior (icon swap, timeout reset) is unchanged. Contributor-side or maintainer-side, whichever picks it up first.
2. **Add a test for the substep deeplink URL construction** (`web/viewer` test suite, if one exists — check for Vitest/RTL config): assert that clicking the substep copy button produces a URL with `step=<step_id>` set and `run` absent, and does not disturb other unrelated query params. If no frontend test harness exists in this repo yet, note that as a prerequisite rather than skipping silently. Maintainer-side to scope (harness existence is unclear from this diff alone).

_Opened by rev-engine (test suite green before push: `SHELLM_ENV=local bash tests/run-all.sh`). This PR goes through the same review pipeline as any other change._
