### PR TITLE
init: first-class local (OpenAI-compatible) model server setup

### DIFF
--- a/bin/shellm
+++ b/bin/shellm
@@ -109,11 +109,57 @@ die() { echo "shellm: error: $*" >&2; exit 1; }
 
 # A local model bound to the Docker host is usually configured as localhost
 # for thinkers and other llm calls that run on that host. Code executed in a
-# shellm sandbox needs Docker's hostname for the same server.
+# shellm sandbox needs Docker's hostname for the same server. The rewrite
+# touches ONLY a loopback authority host — a substring replace would mangle
+# hosts like mylocalhost.dev or path segments containing the name, and
+# redirect a Bearer-keyed request to a host nobody configured. The same
+# helpers exist in tools/headlong-init (this repo duplicates small helpers
+# rather than sharing a lib; keep the copies identical).
+
+# _shellm_url_host <url> — the authority's host, IPv6 brackets stripped.
+_shellm_url_host() {
+    local rest="${1#*://}"
+    local authority="${rest%%[/?#]*}"
+    local hostport="${authority##*@}"
+    case "$hostport" in
+        \[*\]*) hostport="${hostport#\[}"; printf '%s' "${hostport%%]*}" ;;
+        *)      printf '%s' "${hostport%%:*}" ;;
+    esac
+}
+
+# _shellm_url_host_swap <url> <newhost> — replace only the authority's host.
+_shellm_url_host_swap() {
+    local url="$1" newhost="$2"
+    local rest="${url#*://}" scheme=""
+    [[ "$rest" == "$url" ]] || scheme="${url%%://*}://"
+    local authority="${rest%%[/?#]*}"
+    local tail="${rest#"$authority"}"
+    local userinfo=""
+    case "$authority" in
+        *@*) userinfo="${authority%@*}@" ;;
+    esac
+    local hostport="${authority##*@}" port=""
+    case "$hostport" in
+        \[*\]:*) port=":${hostport##*:}" ;;
+        \[*\])   port="" ;;
+        *:*)     port=":${hostport##*:}" ;;
+    esac
+    printf '%s%s%s%s%s' "$scheme" "$userinfo" "$newhost" "$port" "$tail"
+}
+
+# _shellm_url_is_loopback <url> — does the host name this machine's loopback?
+_shellm_url_is_loopback() {
+    case "$(_shellm_url_host "$1")" in
+        localhost|127.*|0.0.0.0|::1) return 0 ;;
+    esac
+    return 1
+}
+
 _shellm_container_api_url() {
     local url="$1"
-    url="${url//localhost/host.docker.internal}"
-    url="${url//127.0.0.1/host.docker.internal}"
+    if _shellm_url_is_loopback "$url"; then
+        url=$(_shellm_url_host_swap "$url" host.docker.internal)
+    fi
     printf '%s' "$url"
 }
 
@@ -881,14 +927,16 @@ docker_setup() {
         -w "$workspace"
         -e "HOME=$workspace"
     )
-    # Add the Docker host mapping when a localhost model URL will be
-    # translated for the sandbox below. Docker Desktop already defines the
-    # name, and this keeps the same behavior on Linux.
-    case "$SHELLM_API_URL" in
-        *//localhost:*|*//localhost/*|*//127.0.0.1:*)
-            docker_run_flags+=(--add-host "host.docker.internal:host-gateway")
-            ;;
-    esac
+    # Add the Docker host mapping when a loopback model URL will be
+    # translated for the sandbox below — the SAME predicate the rewrite in
+    # _shellm_container_api_url uses, so the two can never disagree. Docker
+    # Desktop already defines the name; this keeps Linux equivalent. Note
+    # the mapping routes to the host, so sandboxed code can reach any
+    # service bound to the host's loopback, not just the model server —
+    # documented in docs/install.md (local model server).
+    if _shellm_url_is_loopback "$SHELLM_API_URL"; then
+        docker_run_flags+=(--add-host "host.docker.internal:host-gateway")
+    fi
     local -a extra_mounts=()
     local -a seen_dirs=("$runs_mount")
     local -a install_packages=(jq curl python3 tmux sudo)

--- a/bin/shellm
+++ b/bin/shellm
@@ -107,6 +107,16 @@ _SHELLM_EXTRA_BINS=()
 
 die() { echo "shellm: error: $*" >&2; exit 1; }
 
+# A local model bound to the Docker host is usually configured as localhost
+# for thinkers and other llm calls that run on that host. Code executed in a
+# shellm sandbox needs Docker's hostname for the same server.
+_shellm_container_api_url() {
+    local url="$1"
+    url="${url//localhost/host.docker.internal}"
+    url="${url//127.0.0.1/host.docker.internal}"
+    printf '%s' "$url"
+}
+
 banner() {
     [[ "$QUIET" -eq 1 ]] && return
     [[ "${SHELLM_NO_BANNER:-0}" -eq 1 ]] && return
@@ -871,6 +881,14 @@ docker_setup() {
         -w "$workspace"
         -e "HOME=$workspace"
     )
+    # Add the Docker host mapping when a localhost model URL will be
+    # translated for the sandbox below. Docker Desktop already defines the
+    # name, and this keeps the same behavior on Linux.
+    case "$SHELLM_API_URL" in
+        *//localhost:*|*//localhost/*|*//127.0.0.1:*)
+            docker_run_flags+=(--add-host "host.docker.internal:host-gateway")
+            ;;
+    esac
     local -a extra_mounts=()
     local -a seen_dirs=("$runs_mount")
     local -a install_packages=(jq curl python3 tmux sudo)
@@ -2412,7 +2430,13 @@ set +e
 exit \$__shellm_rc
 "
 
-        # Build env var array for subprocess
+        # Build the environment for generated code. The main shellm process
+        # keeps the host URL, while a Docker sandbox gets the equivalent
+        # host.docker.internal URL.
+        local execution_api_url="$SHELLM_API_URL"
+        if [[ "${_SHELLM_DOCKER_MODE:-0}" -eq 1 ]]; then
+            execution_api_url=$(_shellm_container_api_url "$execution_api_url")
+        fi
         local -a env_vars=(
             SHELLM_WORKDIR="$workdir"
             SHELLM_ENV="$(if [[ "${_SHELLM_DOCKER_MODE:-0}" -eq 1 && "$SHELLM_ALLOW_NESTED_DOCKER" != "1" ]]; then echo "local"; else echo "${_SHELLM_ACTIVE_ENV:-}"; fi)"
@@ -2428,8 +2452,8 @@ exit \$__shellm_rc
             SHELLM_MAX_ITERATIONS="$SHELLM_MAX_ITERATIONS"
             SHELLM_EFFORT="$SHELLM_EFFORT"
             SHELLM_TRUNCATE="$SHELLM_TRUNCATE"
-            SHELLM_API_URL="$SHELLM_API_URL"
-            LLM_API_URL="$SHELLM_API_URL"
+            SHELLM_API_URL="$execution_api_url"
+            LLM_API_URL="$execution_api_url"
             SHELLM_DOCKER_IMAGE="$SHELLM_DOCKER_IMAGE"
             SHELLM_DOCKER_ACCESS="$SHELLM_DOCKER_ACCESS"
             SHELLM_DOCKER_BROKER_TRANSPORT="${_SHELLM_DOCKER_BROKER_TRANSPORT:-$SHELLM_DOCKER_BROKER_TRANSPORT}"

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,6 +53,16 @@ llama.cpp with `--host 0.0.0.0`, or configure Ollama with
 `OLLAMA_HOST=0.0.0.0:11434`. Use the machine firewall to keep the model
 server off untrusted networks.
 
+Know what the host gateway exposes. The agent writes and runs real
+shell commands in its sandbox, and `host.docker.internal` routes to the
+whole host, not just the model server. Code running in the sandbox can
+therefore reach any service bound to the host's loopback: other
+dashboards, local databases, and admin APIs that skip authentication
+because they expect to be loopback only. Ollama's own admin API is one
+example: it can pull and delete models without a password. If that
+matters for your machine, run the model server on a separate host or
+interface, or firewall the ports you do not want a container to reach.
+
 Either way it then runs a short optional interview: a name, a few words
 of personality, what they should think about when idle. The answers
 become the agent's core identity and first memories. Then their mind

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,18 +29,21 @@ On the host path it then clones the repo to `~/.headlong/app`, symlinks
 the tools into `~/.local/bin`, and asks where the model should come from:
 
 - **A local model server** (Ollama, LM Studio, vLLM, llama.cpp, ...) —
-  answer `y` at the prompt, give the server's base URL (for Ollama,
-  `http://localhost:11434/v1`; for LM Studio, `http://localhost:1234/v1`),
+  answer `y` at the prompt, give the server's address as you know it
+  (`http://localhost:1234` for LM Studio, `http://192.168.3.23:1234` for
+  a box on your LAN — `/v1` is added automatically if you leave it off),
   an API key only if the server wants one, and pick the model from the
   list the server reports. Headlong verifies the endpoint twice: the
   model list before anything is written, and a real chat completion
   before the mind starts. No cloud account or API key is involved, and
   the agent's completions all stay on your machine or network. Headlong
   never installs a server or pulls models — have the server running
-  before you install. One caveat: if the agent's shell commands run in
-  the Docker sandbox, `localhost` inside the container is the container,
-  not your machine — use `host.docker.internal` (macOS) or the Docker
-  bridge address (Linux) instead.
+  before you install. If the agent's shell commands run in the Docker
+  sandbox, `localhost` inside the container is the container, not your
+  machine: a `localhost`/`127.0.0.1` address is rewritten to
+  `host.docker.internal` in the saved configuration automatically (on
+  Linux, which lacks that name by default, give the server's LAN address
+  instead).
 - **A cloud provider** — paste an API key (Anthropic, OpenAI, Gemini,
   OpenRouter, or OpenCode); headlong-init figures out the provider from
   the key's prefix.

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,27 +26,32 @@ real shell commands and Docker is the sandbox for them.
   `yes` to continue without a sandbox.
 
 On the host path it then clones the repo to `~/.headlong/app`, symlinks
-the tools into `~/.local/bin`, and asks where the model should come from:
+the tools into `~/.local/bin`, and asks where the model should come from.
 
-- **A local model server** (Ollama, LM Studio, vLLM, llama.cpp, ...) —
-  answer `y` at the prompt, give the server's address as you know it
-  (`http://localhost:1234` for LM Studio, `http://192.168.3.23:1234` for
-  a box on your LAN — `/v1` is added automatically if you leave it off),
-  an API key only if the server wants one, and pick the model from the
-  list the server reports. Headlong verifies the endpoint twice: the
-  model list before anything is written, and a real chat completion
-  before the mind starts. No cloud account or API key is involved, and
-  the agent's completions all stay on your machine or network. Headlong
-  never installs a server or pulls models — have the server running
-  before you install. If the agent's shell commands run in the Docker
-  sandbox, `localhost` inside the container is the container, not your
-  machine: a `localhost`/`127.0.0.1` address is rewritten to
-  `host.docker.internal` in the saved configuration automatically (on
-  Linux, which lacks that name by default, give the server's LAN address
-  instead).
-- **A cloud provider** — paste an API key (Anthropic, OpenAI, Gemini,
-  OpenRouter, or OpenCode); headlong-init figures out the provider from
-  the key's prefix.
+- **A local model server.** Headlong supports Ollama, LM Studio, vLLM,
+  llama.cpp, and other servers with an OpenAI compatible API. Answer `y`
+  at the prompt and enter the server address, such as
+  `http://localhost:1234` for LM Studio. Headlong adds `/v1` when it is
+  missing. Enter an API key only when the server requires one. Headlong
+  asks the server for its model list, or lets you type a model name when
+  the server does not publish that list. It then checks a chat completion
+  before the mind starts. Headlong does not install a server or download
+  models, so start the server before you install.
+- **A cloud provider.** Paste an API key for Anthropic, OpenAI, Gemini,
+  OpenRouter, or OpenCode. `headlong-init` identifies the provider from
+  the key prefix.
+
+A host install saves a localhost model URL as localhost, so thinkers and
+ordinary `llm` calls can reach it. When shellm runs a command inside its
+Docker sandbox, shellm changes only that command's URL to
+`host.docker.internal`. A full Docker installation uses
+`host.docker.internal` for its main runtime too. On macOS and Windows,
+Docker Desktop carries that connection to a server bound to localhost.
+On Linux, the installer adds the Docker host name, but the model server
+must also listen on an address Docker can reach. For example, start
+llama.cpp with `--host 0.0.0.0`, or configure Ollama with
+`OLLAMA_HOST=0.0.0.0:11434`. Use the machine firewall to keep the model
+server off untrusted networks.
 
 Either way it then runs a short optional interview: a name, a few words
 of personality, what they should think about when idle. The answers
@@ -84,7 +89,8 @@ installer apt-installs its own dependencies (as root in a fresh
 container) and the dashboard binds `0.0.0.0` so the published port works.
 
 ```bash
-docker run -it --name headlong --restart unless-stopped -p 8080:8080 buildpack-deps:curl \
+docker run -it --name headlong --restart unless-stopped -p 8080:8080 \
+  --add-host host.docker.internal:host-gateway buildpack-deps:curl \
   bash -c 'curl -fsSL https://headlong.ai/install.sh | bash; exec bash'
 ```
 
@@ -128,7 +134,7 @@ A key must be in the environment **for a cloud provider**; everything
 else is optional. `HEADLONG_NO_DASH=1` and `HEADLONG_NO_THINKERS=1`
 skip those parts.
 
-A local model server can be selected without a tty too:
+A local model server can also be selected without a tty.
 
 ```bash
 export HEADLONG_PROVIDER=local
@@ -138,10 +144,9 @@ export HEADLONG_LOCAL_URL=http://localhost:11434/v1   # the server's base URL
 curl -fsSL https://headlong.ai/install.sh | bash
 ```
 
-With no tty and no cloud key, `HEADLONG_PROVIDER=local` plus
-`HEADLONG_LOCAL_URL` is all that is required. The endpoint must be
-reachable (the install verifies it and stops if it is not) and it must
-expose a model list or a pinned `HEADLONG_LOCAL_MODEL`.
+With no tty and no cloud key, set `HEADLONG_PROVIDER=local` and
+`HEADLONG_LOCAL_URL`. The server must be reachable. If the server does
+not publish a model list, also set `HEADLONG_LOCAL_MODEL`.
 
 With no tty there is nobody to answer the sandbox question, so on a
 machine without a working Docker daemon the install stops unless

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,11 +26,29 @@ real shell commands and Docker is the sandbox for them.
   `yes` to continue without a sandbox.
 
 On the host path it then clones the repo to `~/.headlong/app`, symlinks
-the tools into `~/.local/bin`, asks for an LLM API key, and runs a short
-optional interview: a name, a few words of personality, what they should
-think about when idle. The answers become the agent's core identity and
-first memories. Then their mind starts and the dashboard opens. Their
-name becomes a command:
+the tools into `~/.local/bin`, and asks where the model should come from:
+
+- **A local model server** (Ollama, LM Studio, vLLM, llama.cpp, ...) —
+  answer `y` at the prompt, give the server's base URL (for Ollama,
+  `http://localhost:11434/v1`; for LM Studio, `http://localhost:1234/v1`),
+  an API key only if the server wants one, and pick the model from the
+  list the server reports. Headlong verifies the endpoint twice: the
+  model list before anything is written, and a real chat completion
+  before the mind starts. No cloud account or API key is involved, and
+  the agent's completions all stay on your machine or network. Headlong
+  never installs a server or pulls models — have the server running
+  before you install. One caveat: if the agent's shell commands run in
+  the Docker sandbox, `localhost` inside the container is the container,
+  not your machine — use `host.docker.internal` (macOS) or the Docker
+  bridge address (Linux) instead.
+- **A cloud provider** — paste an API key (Anthropic, OpenAI, Gemini,
+  OpenRouter, or OpenCode); headlong-init figures out the provider from
+  the key's prefix.
+
+Either way it then runs a short optional interview: a name, a few words
+of personality, what they should think about when idle. The answers
+become the agent's core identity and first memories. Then their mind
+starts and the dashboard opens. Their name becomes a command:
 
 ```bash
 ada                  # chat with them
@@ -103,8 +121,24 @@ export HEADLONG_IDENTITY_USER="I'm Sam, a programmer trying Headlong out"
 curl -fsSL https://headlong.ai/install.sh | bash
 ```
 
-A key must be in the environment; everything else is optional.
-`HEADLONG_NO_DASH=1` and `HEADLONG_NO_THINKERS=1` skip those parts.
+A key must be in the environment **for a cloud provider**; everything
+else is optional. `HEADLONG_NO_DASH=1` and `HEADLONG_NO_THINKERS=1`
+skip those parts.
+
+A local model server can be selected without a tty too:
+
+```bash
+export HEADLONG_PROVIDER=local
+export HEADLONG_LOCAL_URL=http://localhost:11434/v1   # the server's base URL
+# export HEADLONG_LOCAL_API_KEY=...   # only if the server wants a token
+# export HEADLONG_LOCAL_MODEL=qwen3:8b  # default: first model the server lists
+curl -fsSL https://headlong.ai/install.sh | bash
+```
+
+With no tty and no cloud key, `HEADLONG_PROVIDER=local` plus
+`HEADLONG_LOCAL_URL` is all that is required. The endpoint must be
+reachable (the install verifies it and stops if it is not) and it must
+expose a model list or a pinned `HEADLONG_LOCAL_MODEL`.
 
 With no tty there is nobody to answer the sandbox question, so on a
 machine without a working Docker daemon the install stops unless

--- a/install.sh
+++ b/install.sh
@@ -486,6 +486,17 @@ main() {
         esac
     done
 
+    # A from-scratch `install.sh --init` in a checkout is the same decision
+    # the one-liner makes: container or this machine. Offer it when nothing
+    # has been installed yet; an existing identity (or no tty / no Docker)
+    # keeps the plain checkout-mode behavior.
+    if [[ "$RUN_INIT" -eq 1 && ! -e "$HEADLONG_HOME/app/.identities/default" \
+            && ! -e "$script_dir/.identities/default" && ! -f /.dockerenv \
+            && ! -f /run/.containerenv ]] \
+            && (: </dev/tty) 2>/dev/null && _docker_daemon_ok; then
+        _offer_docker_install
+    fi
+
     _require_deps jq curl
 
     mkdir -p "$PREFIX"

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,10 @@ set -euo pipefail
 # State home: HEADLONG_HOME if set; else ~/.headlong. (An install from a
 # pre-headlong era lives in ~/.shelly or ~/.shellm — move it:
 # mv ~/.shelly ~/.headlong)
+# Whether the OPERATOR exported HEADLONG_REPO (before the default below
+# replaces "unset" with the public URL): decides if the container path may
+# retarget to this checkout's own origin/branch.
+HEADLONG_REPO_OPERATOR_SET="${HEADLONG_REPO+set}"
 HEADLONG_REPO="${HEADLONG_REPO:-https://github.com/laude-institute/headlong.git}"
 HEADLONG_BRANCH="${HEADLONG_BRANCH:-main}"
 HEADLONG_HOME="${HEADLONG_HOME:-$HOME/.headlong}"
@@ -494,6 +498,21 @@ main() {
             && ! -e "$script_dir/.identities/default" && ! -f /.dockerenv \
             && ! -f /run/.containerenv ]] \
             && (: </dev/tty) 2>/dev/null && _docker_daemon_ok; then
+        # The container path curls the PUBLIC installer, which would install
+        # upstream main — not the code being installed right now. Default the
+        # forwarded repo/branch to this checkout's own origin and branch so
+        # choice 1 runs the same code (an operator-exported HEADLONG_REPO
+        # still wins).
+        if [[ -z "$HEADLONG_REPO_OPERATOR_SET" ]] && git -C "$script_dir" rev-parse --git-dir >/dev/null 2>&1; then
+            local origin_url branch_name
+            origin_url=$(git -C "$script_dir" remote get-url origin 2>/dev/null || true)
+            branch_name=$(git -C "$script_dir" branch --show-current 2>/dev/null || true)
+            if [[ -n "$origin_url" && -n "$branch_name" ]]; then
+                HEADLONG_REPO="$origin_url"
+                HEADLONG_BRANCH="$branch_name"
+                export HEADLONG_REPO HEADLONG_BRANCH
+            fi
+        fi
         _offer_docker_install
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -100,19 +100,66 @@ _docker_daemon_ok() {
     command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
 }
 
+# URL helpers for the local-model endpoint: replace only a loopback
+# authority host, never substrings elsewhere in the URL (a host like
+# mylocalhost.dev, or a path segment, must survive untouched). The same
+# helpers live in bin/shellm and tools/headlong-init — this repo duplicates
+# small helpers rather than sharing a lib; keep the copies identical.
+_url_host() {
+    local rest="${1#*://}"
+    local authority="${rest%%[/?#]*}"
+    local hostport="${authority##*@}"
+    case "$hostport" in
+        \[*\]*) hostport="${hostport#\[}"; printf '%s' "${hostport%%]*}" ;;
+        *)      printf '%s' "${hostport%%:*}" ;;
+    esac
+}
+
+_url_host_swap() {
+    local url="$1" newhost="$2"
+    local rest="${url#*://}" scheme=""
+    [[ "$rest" == "$url" ]] || scheme="${url%%://*}://"
+    local authority="${rest%%[/?#]*}"
+    local tail="${rest#"$authority"}"
+    local userinfo=""
+    case "$authority" in
+        *@*) userinfo="${authority%@*}@" ;;
+    esac
+    local hostport="${authority##*@}" port=""
+    case "$hostport" in
+        \[*\]:*) port=":${hostport##*:}" ;;
+        \[*\])   port="" ;;
+        *:*)     port=":${hostport##*:}" ;;
+    esac
+    printf '%s%s%s%s%s' "$scheme" "$userinfo" "$newhost" "$port" "$tail"
+}
+
+_url_is_loopback() {
+    case "$(_url_host "$1")" in
+        localhost|127.*|0.0.0.0|::1) return 0 ;;
+    esac
+    return 1
+}
+
 # The `docker run` arguments that carry the operator's environment into the
 # container, NUL-delimited for the caller to read into an array: the interview
 # answers are free text, so a value may contain a newline.
 #
-# Keys go by NAME. `-e VAR=value` puts the value in the docker client's argv,
-# where `ps` shows it to every other user on the machine for as long as the
-# client runs; thinkers/_lib/common.sh forwards keys the same way for the same
-# reason, and tests/test_var_secrets.sh pins the rule for shellm. Docker reads a name-only
-# `-e VAR` from its own environment, so the name must be exported, which is why
-# the answers below do NOT use it: install.sh assigns HEADLONG_REPO and
-# HEADLONG_BRANCH itself without exporting them, so a bare name would forward
-# nothing and the container would clone the default repo instead of the
-# operator's. They are not secrets, so inline is fine.
+# Secrets go by NAME. `-e VAR=value` puts the value in the docker client's
+# argv, where `ps` shows it to every other user on the machine for as long as
+# the client runs; thinkers/_lib/common.sh forwards keys the same way for the
+# same reason, and tests/test_var_secrets.sh pins the rule for shellm. Docker
+# reads a name-only `-e VAR` from its own environment, so the name must be
+# exported.
+#
+# The interview answers are not secrets and stay inline: two of them
+# (HEADLONG_REPO, HEADLONG_BRANCH) are assigned by install.sh WITHOUT export,
+# so a bare name would forward nothing. The one exception is HEADLONG_LOCAL_URL
+# — an endpoint URL can carry user:pass@ credentials or a query token — so it
+# is treated like a secret and forwarded by name (it always arrives exported,
+# from the operator's own environment). This function is collected with a
+# redirect, not a pipe (see _offer_docker_install), so the export persists to
+# where `docker run` reads it.
 _docker_forward_args() {
     local var
     for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
@@ -122,24 +169,24 @@ _docker_forward_args() {
             printf '%s\0%s\0' "-e" "$var"
         fi
     done
-    # The local-model server choice and its endpoint are not secrets: forward
-    # them by value so the in-container headlong-init offers / keeps the same
-    # setup without re-asking. (LLM_PROVIDER itself travels inside the state
-    # .env, which the container's init re-persists; exporting it here would
-    # also pin it for the whole container, which the operator did not ask for.)
+    if [[ -n "${HEADLONG_LOCAL_URL:-}" ]]; then
+        # The installer receiving the URL runs inside the full Headlong
+        # container, where localhost names that container. Use Docker's
+        # hostname for a model server running on the host.
+        if _url_is_loopback "$HEADLONG_LOCAL_URL"; then
+            HEADLONG_LOCAL_URL=$(_url_host_swap "$HEADLONG_LOCAL_URL" host.docker.internal)
+        fi
+        export HEADLONG_LOCAL_URL
+        printf '%s\0%s\0' "-e" "HEADLONG_LOCAL_URL"
+    fi
+    # (LLM_PROVIDER itself travels inside the state .env, which the
+    # container's init re-persists; exporting it here would also pin it for
+    # the whole container, which the operator did not ask for.)
     for var in HEADLONG_IDENTITY_NAME HEADLONG_IDENTITY_VIBE HEADLONG_IDENTITY_FOCUS \
                HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME HEADLONG_REPO HEADLONG_BRANCH \
-               HEADLONG_PROVIDER HEADLONG_LOCAL_URL HEADLONG_LOCAL_MODEL; do
+               HEADLONG_PROVIDER HEADLONG_LOCAL_MODEL; do
         if [[ -n "${!var:-}" ]]; then
-            local value="${!var}"
-            # The installer receiving this value runs inside the full
-            # Headlong container, where localhost names that container. Use
-            # Docker's hostname for a model server running on the host.
-            if [[ "$var" == "HEADLONG_LOCAL_URL" ]]; then
-                value="${value//localhost/host.docker.internal}"
-                value="${value//127.0.0.1/host.docker.internal}"
-            fi
-            printf '%s\0%s\0' "-e" "$var=$value"
+            printf '%s\0%s\0' "-e" "$var=${!var}"
         fi
     done
 }
@@ -518,6 +565,27 @@ main() {
             local origin_url branch_name
             origin_url=$(git -C "$script_dir" remote get-url origin 2>/dev/null || true)
             branch_name=$(git -C "$script_dir" branch --show-current 2>/dev/null || true)
+            # The clone happens inside a fresh container with no SSH keys,
+            # so only an http(s) URL can work there. Rewrite the common SSH
+            # forms; a local path or anything else falls back to upstream —
+            # with a warning, so choice 1 is an informed one.
+            case "$origin_url" in
+                http://*|https://*) ;;
+                ssh://git@*)
+                    origin_url="https://${origin_url#ssh://git@}"
+                    ;;
+                git@*:*)
+                    origin_url="${origin_url#git@}"
+                    origin_url="https://${origin_url/://}"
+                    ;;
+                *)
+                    if [[ -n "$origin_url" ]]; then
+                        echo "note: this checkout's origin ($origin_url) cannot be cloned from inside a container;" >&2
+                        echo "      the container choice below would install upstream main instead (export HEADLONG_REPO to override)." >&2
+                    fi
+                    origin_url=""
+                    ;;
+            esac
             if [[ -n "$origin_url" && -n "$branch_name" ]]; then
                 HEADLONG_REPO="$origin_url"
                 HEADLONG_BRANCH="$branch_name"

--- a/install.sh
+++ b/install.sh
@@ -116,7 +116,7 @@ _docker_daemon_ok() {
 _docker_forward_args() {
     local var
     for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
-               OPENCODE_API_KEY LLM_API_KEY; do
+               OPENCODE_API_KEY LLM_API_KEY HEADLONG_LOCAL_API_KEY; do
         if [[ -n "${!var:-}" ]]; then
             export "${var?}"
             printf '%s\0%s\0' "-e" "$var"
@@ -130,7 +130,17 @@ _docker_forward_args() {
     for var in HEADLONG_IDENTITY_NAME HEADLONG_IDENTITY_VIBE HEADLONG_IDENTITY_FOCUS \
                HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME HEADLONG_REPO HEADLONG_BRANCH \
                HEADLONG_PROVIDER HEADLONG_LOCAL_URL HEADLONG_LOCAL_MODEL; do
-        if [[ -n "${!var:-}" ]]; then printf '%s\0%s\0' "-e" "$var=${!var}"; fi
+        if [[ -n "${!var:-}" ]]; then
+            local value="${!var}"
+            # The installer receiving this value runs inside the full
+            # Headlong container, where localhost names that container. Use
+            # Docker's hostname for a model server running on the host.
+            if [[ "$var" == "HEADLONG_LOCAL_URL" ]]; then
+                value="${value//localhost/host.docker.internal}"
+                value="${value//127.0.0.1/host.docker.internal}"
+            fi
+            printf '%s\0%s\0' "-e" "$var=$value"
+        fi
     done
 }
 
@@ -213,6 +223,7 @@ EOF
     echo
     local rc=0
     docker run -it --name headlong --restart unless-stopped -p 8080:8080 \
+        --add-host "host.docker.internal:host-gateway" \
         ${fwd[@]+"${fwd[@]}"} buildpack-deps:curl \
         bash -c 'curl -fsSL https://headlong.ai/install.sh | bash; exec bash' </dev/tty || rc=$?
     if [[ "$rc" -eq 0 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -112,14 +112,20 @@ _docker_daemon_ok() {
 _docker_forward_args() {
     local var
     for var in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
-               OPENCODE_API_KEY; do
+               OPENCODE_API_KEY LLM_API_KEY; do
         if [[ -n "${!var:-}" ]]; then
             export "${var?}"
             printf '%s\0%s\0' "-e" "$var"
         fi
     done
+    # The local-model server choice and its endpoint are not secrets: forward
+    # them by value so the in-container headlong-init offers / keeps the same
+    # setup without re-asking. (LLM_PROVIDER itself travels inside the state
+    # .env, which the container's init re-persists; exporting it here would
+    # also pin it for the whole container, which the operator did not ask for.)
     for var in HEADLONG_IDENTITY_NAME HEADLONG_IDENTITY_VIBE HEADLONG_IDENTITY_FOCUS \
-               HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME HEADLONG_REPO HEADLONG_BRANCH; do
+               HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME HEADLONG_REPO HEADLONG_BRANCH \
+               HEADLONG_PROVIDER HEADLONG_LOCAL_URL HEADLONG_LOCAL_MODEL; do
         if [[ -n "${!var:-}" ]]; then printf '%s\0%s\0' "-e" "$var=${!var}"; fi
     done
 }

--- a/status.sh
+++ b/status.sh
@@ -72,7 +72,10 @@ else
         for k in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY; do
             grep -q "^$k=" "$HEADLONG_HOME/.env" 2>/dev/null && keys="$keys $k"
         done
+        # .env values are single-quoted (headlong-init _env_set); strip a
+        # matching pair of surrounding quotes for display.
         model=$(sed -n 's/^SHELLM_MODEL=//p' "$HEADLONG_HOME/.env" 2>/dev/null | tail -1)
+        model="${model#\'}"; model="${model%\'}"
         say "  state home: $HEADLONG_HOME   (.env has:${keys:- no API key}${model:+; model $model})"
     else
         say "  state home: $HEADLONG_HOME   (missing)"

--- a/tests/test_install_secret_argv.sh
+++ b/tests/test_install_secret_argv.sh
@@ -29,10 +29,13 @@ sed '$ d' "$REPO/install.sh" > "$WORK/install.lib"
 
 SECRET=sk-or-ARGVCANARY
 OPENCODE_SECRET=sk-OPENCODECANARY
+LOCAL_SECRET=local-ARGVCANARY
 args=$(
     export OPENROUTER_API_KEY="$SECRET"
     export OPENCODE_API_KEY="$OPENCODE_SECRET"
+    export HEADLONG_LOCAL_API_KEY="$LOCAL_SECRET"
     export HEADLONG_IDENTITY_NAME=ada
+    export HEADLONG_LOCAL_URL=http://127.0.0.1:8090/v1
     # Set, deliberately NOT exported, which is how install.sh leaves them.
     # shellcheck disable=SC2034  # read by _docker_forward_args through ${!var}
     HEADLONG_REPO=https://example.invalid/fork.git
@@ -58,6 +61,15 @@ case "$flat" in
     *"$OPENCODE_SECRET"*) bad "every provider key goes by name, not just the first" "found $OPENCODE_SECRET in: $flat" ;;
     *"-e OPENCODE_API_KEY "*) ok "every provider key goes by name, not just the first" ;;
     *) bad "every provider key goes by name, not just the first" "got: $flat" ;;
+esac
+case "$flat" in
+    *"$LOCAL_SECRET"*) bad "the local server key stays off the docker command line" "found $LOCAL_SECRET in: $flat" ;;
+    *"-e HEADLONG_LOCAL_API_KEY "*) ok "the local server key is forwarded by name" ;;
+    *) bad "the local server key is forwarded by name" "got: $flat" ;;
+esac
+case "$flat" in
+    *"-e HEADLONG_LOCAL_URL=http://host.docker.internal:8090/v1 "*) ok "a localhost model URL is translated for the full container" ;;
+    *) bad "a localhost model URL is translated for the full container" "got: $flat" ;;
 esac
 case "$flat" in
     *"-e HEADLONG_IDENTITY_NAME=ada "*) ok "interview answers are still forwarded inline" ;;
@@ -95,6 +107,7 @@ exported=$(
 # fills in are forwarded, and no key name appears at all.
 none=$(
     unset OPENROUTER_API_KEY ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENCODE_API_KEY
+    unset LLM_API_KEY HEADLONG_LOCAL_API_KEY HEADLONG_LOCAL_URL
     unset HEADLONG_IDENTITY_NAME HEADLONG_IDENTITY_VIBE HEADLONG_IDENTITY_FOCUS
     unset HEADLONG_IDENTITY_USER HEADLONG_OPERATOR_NAME
     # shellcheck disable=SC1090  # generated copy of the installer under test

--- a/tests/test_install_secret_argv.sh
+++ b/tests/test_install_secret_argv.sh
@@ -7,10 +7,12 @@
 # so it is readable from `ps` by any other local user for as long as that
 # process lives; tests/test_var_secrets.sh already pins the same rule for the
 # shellm path, and thinkers/_lib/common.sh already forwards keys by bare name
-# for the same reason. Keys therefore go by NAME, which requires them to be exported, and
-# the non-secret answers stay inline because two of them (HEADLONG_REPO,
-# HEADLONG_BRANCH) are assigned by install.sh without export and a bare name
-# would silently forward nothing.
+# for the same reason. Keys therefore go by NAME, which requires them to be exported.
+# HEADLONG_LOCAL_URL is treated the same way: an endpoint URL can carry
+# user:pass@ credentials or a query token, so its value must not reach argv.
+# The remaining non-secret answers stay inline because two of them
+# (HEADLONG_REPO, HEADLONG_BRANCH) are assigned by install.sh without export
+# and a bare name would silently forward nothing.
 
 set -uo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -67,10 +69,26 @@ case "$flat" in
     *"-e HEADLONG_LOCAL_API_KEY "*) ok "the local server key is forwarded by name" ;;
     *) bad "the local server key is forwarded by name" "got: $flat" ;;
 esac
+# The endpoint URL can carry user:pass@ credentials or a query token, so it
+# is forwarded by NAME (not inline), like the keys — its value must not reach
+# the docker client's argv.
 case "$flat" in
-    *"-e HEADLONG_LOCAL_URL=http://host.docker.internal:8090/v1 "*) ok "a localhost model URL is translated for the full container" ;;
-    *) bad "a localhost model URL is translated for the full container" "got: $flat" ;;
+    *"http://host.docker.internal:8090/v1"*) bad "the local model URL stays off the docker command line" "found the URL value in: $flat" ;;
+    *"-e HEADLONG_LOCAL_URL "*) ok "the local model URL is forwarded by name" ;;
+    *) bad "the local model URL is forwarded by name" "got: $flat" ;;
 esac
+# Forwarding by name only works if the (possibly rewritten) URL is exported.
+url_exported=$(
+    export HEADLONG_LOCAL_URL=http://127.0.0.1:8090/v1
+    # shellcheck disable=SC1090  # generated copy of the installer under test
+    source "$WORK/install.lib"
+    _docker_forward_args > "$WORK/fwd_url"
+    # shellcheck disable=SC2034  # records drained, not inspected
+    while IFS= read -r -d '' line; do :; done < "$WORK/fwd_url"
+    export -p | grep -c '^declare -x HEADLONG_LOCAL_URL=.*host.docker.internal' || true
+)
+[[ "$url_exported" -ge 1 ]] && ok "the rewritten URL is exported for the bare name" \
+    || bad "the rewritten URL is exported for the bare name" "not exported/rewritten after the call"
 case "$flat" in
     *"-e HEADLONG_IDENTITY_NAME=ada "*) ok "interview answers are still forwarded inline" ;;
     *) bad "interview answers are still forwarded inline" "got: $flat" ;;

--- a/tests/test_key_var_resolution.sh
+++ b/tests/test_key_var_resolution.sh
@@ -51,11 +51,11 @@ run_init() {
 # --- the reported case: OpenRouter key exported as OPENAI_API_KEY ------------
 run_init "$WORK/h1" OPENAI_API_KEY=sk-or-v1-EXAMPLE-NOT-A-REAL-KEY
 check "misplaced sk-or- key: model follows the key, not the variable" \
-    grep -qx 'SHELLM_MODEL=anthropic/claude-sonnet-4.5' "$WORK/h1/.headlong/.env"
+    grep -qx "SHELLM_MODEL='anthropic/claude-sonnet-4.5'" "$WORK/h1/.headlong/.env"
 check "misplaced sk-or- key: says which variable it should be in" \
     grep -q 'OPENROUTER_API_KEY' "$WORK/out"
 check_not "misplaced sk-or- key: never defaults to an OpenAI model" \
-    grep -q 'SHELLM_MODEL=gpt-' "$WORK/h1/.headlong/.env"
+    grep -q "SHELLM_MODEL='gpt-" "$WORK/h1/.headlong/.env"
 # The correction must outlive this process: a later persona or llm run in a
 # fresh shell reads the .env, not the reconciler's exports.
 check "misplaced sk-or- key: persisted under the right variable, once" \
@@ -66,14 +66,14 @@ check "misplaced sk-or- key: the state env stays private (mode 600)" \
 # --- a correctly placed OpenAI key is untouched ------------------------------
 run_init "$WORK/h2" OPENAI_API_KEY=sk-proj-EXAMPLE-NOT-A-REAL-KEY
 check "consistent OpenAI key: keeps the OpenAI default" \
-    grep -qx 'SHELLM_MODEL=gpt-5.5' "$WORK/h2/.headlong/.env"
+    grep -qx "SHELLM_MODEL='gpt-5.5'" "$WORK/h2/.headlong/.env"
 check_not "consistent OpenAI key: warns about nothing" \
     grep -qi 'prefix belongs to' "$WORK/out"
 
 # --- a bare sk- key is OpenAI *or* OpenCode: ambiguous, so never moved -------
 run_init "$WORK/h3" OPENCODE_API_KEY=sk-EXAMPLE-NOT-A-REAL-KEY
 check "bare sk- in OPENCODE_API_KEY: left where it is" \
-    grep -qx 'SHELLM_MODEL=opencode-go/deepseek-v4-flash' "$WORK/h3/.headlong/.env"
+    grep -qx "SHELLM_MODEL='opencode-go/deepseek-v4-flash'" "$WORK/h3/.headlong/.env"
 check_not "bare sk- in OPENCODE_API_KEY: not remapped to OpenAI" \
     grep -qi 'prefix belongs to' "$WORK/out"
 
@@ -82,12 +82,12 @@ run_init "$WORK/h4" \
     OPENAI_API_KEY=sk-or-v1-EXAMPLE-MISPLACED-KEY \
     OPENROUTER_API_KEY=sk-or-v1-EXAMPLE-CORRECT-KEY
 check "both set: picks the consistent variable" \
-    grep -qx 'SHELLM_MODEL=anthropic/claude-sonnet-4.5' "$WORK/h4/.headlong/.env"
+    grep -qx "SHELLM_MODEL='anthropic/claude-sonnet-4.5'" "$WORK/h4/.headlong/.env"
 
 # --- an Anthropic key in the wrong slot is corrected too ---------------------
 run_init "$WORK/h5" OPENAI_API_KEY=sk-ant-api03-EXAMPLE-NOT-A-REAL-KEY
 check "misplaced sk-ant- key: model follows the key" \
-    grep -qx 'SHELLM_MODEL=claude-sonnet-4-5-20250929' "$WORK/h5/.headlong/.env"
+    grep -qx "SHELLM_MODEL='claude-sonnet-4-5-20250929'" "$WORK/h5/.headlong/.env"
 
 # --- a stale SHELLM_MODEL pinned from the misfiled variable heals ------------
 # An earlier init derived gpt-5.5 from the key sitting in OPENAI_API_KEY;
@@ -97,7 +97,7 @@ mkdir -p "$WORK/h7/.headlong"
 printf 'SHELLM_MODEL=gpt-5.5\n' > "$WORK/h7/.headlong/.env"
 run_init "$WORK/h7" OPENAI_API_KEY=sk-or-v1-EXAMPLE-NOT-A-REAL-KEY
 check "stale model from the misfiled variable: re-pinned to the key's provider" \
-    grep -qx 'SHELLM_MODEL=anthropic/claude-sonnet-4.5' "$WORK/h7/.headlong/.env"
+    grep -qx "SHELLM_MODEL='anthropic/claude-sonnet-4.5'" "$WORK/h7/.headlong/.env"
 
 # --- bin/llm honors LLM_MAX_TOKENS from the environment ----------------------
 # curl stub records the request body; llm builds it with jq before sending.

--- a/tests/test_local_llm_setup.sh
+++ b/tests/test_local_llm_setup.sh
@@ -103,10 +103,10 @@ ACTEOF
 STUBEOF
 chmod +x "$APP/tools/identity"
 
-# thinkers / headlong-web: init starts the dash (no HEADLONG_NO_DASH in
-# these runs), so the web stub must look alive: background itself quietly and
-# print the serving line init greps for, then keep running so the pid check
-# passes. thinkers is a no-op.
+# thinkers / headlong-web: dash startup is skipped in these runs
+# (HEADLONG_NO_DASH=1: the dash is not this suite's subject, and a live
+# dash makes init open a browser and poll readiness). The stubs exist so
+# a stray call fails loudly in $WORK/out instead of 'command not found'.
 printf '#!/usr/bin/env bash\nexit 0\n' > "$APP/tools/thinkers"
 cat > "$APP/tools/headlong-web" <<'STUBEOF'
 #!/usr/bin/env bash
@@ -136,7 +136,8 @@ run_init() {
     mkdir -p "$home"
     env -i \
         HOME="$home" HEADLONG_HOME="$home/.headlong" HEADLONG_APP_DIR="$APP" \
-        HEADLONG_NO_TTY=1 HEADLONG_UNSANDBOXED=1 PATH="$STUB:$PATH" \
+        HEADLONG_NO_TTY=1 HEADLONG_UNSANDBOXED="${HEADLONG_UNSANDBOXED:-1}" \
+        HEADLONG_NO_DASH=1 PATH="$STUB:$PATH" \
         CURL_MODELS_FILE="$MODELS_FILE" CURL_MODELS_HITS="$CURL_MODELS_HITS" \
         CURL_MODELS_UP="${CURL_MODELS_UP:-1}" LLM_STUB_RC="${LLM_STUB_RC:-0}" "$@" \
         bash "$REPO/tools/headlong-init" </dev/null > "$WORK/out" 2>&1
@@ -260,6 +261,28 @@ run_init "$WORK/h8" \
 check "re-run: still exits 0"                                test "$RC" -eq 0
 check "re-run: config survives, exactly once per var" \
     test "$(grep -c '^SHELLM_API_URL=' "$WORK/h8/.headlong/.env")" -eq 1
+
+# ---------------------------------------------------------------------------
+# sandbox-aware URL: with the Docker sandbox on, a localhost address is
+# rewritten to host.docker.internal (the container's name for the host) in
+# the PERSISTED url; the operator-facing probe still succeeded through the
+# localhost twin. HEADLONG_LOCAL_URL given as host.docker.internal passes
+# through unchanged.
+# ---------------------------------------------------------------------------
+HEADLONG_UNSANDBOXED=0 run_init "$WORK/h9" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "sandbox rewrite: exits 0"                             test "$RC" -eq 0
+check "sandbox rewrite: persisted url is container-reachable" grep -qx 'SHELLM_API_URL=http://host.docker.internal:11434/v1/chat/completions' "$WORK/h9/.headlong/.env"
+check "sandbox rewrite: announced the rewrite"               grep -q 'host.docker.internal' "$WORK/out"
+
+HEADLONG_UNSANDBOXED=0 run_init "$WORK/h9b" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://host.docker.internal:1234 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "explicit container url: exits 0"                      test "$RC" -eq 0
+check "explicit container url: kept as-is"                   grep -qx 'SHELLM_API_URL=http://host.docker.internal:1234/v1/chat/completions' "$WORK/h9b/.headlong/.env"
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_local_llm_setup.sh
+++ b/tests/test_local_llm_setup.sh
@@ -52,10 +52,17 @@ cat > "$STUB/curl" <<'STUBEOF'
 #!/usr/bin/env bash
 url=""
 prev=""
+out_file=""
 for a in "$@"; do
     [[ "$prev" != -* && "$a" == http* ]] && url="$a"
+    [[ "$prev" == "-o" ]] && out_file="$a"
+    if [[ "$prev" == "-K" ]]; then
+        cat "$a" > "$CURL_AUTH_FILE"
+        { stat -c %a "$a" 2>/dev/null || stat -f %Lp "$a"; } > "$CURL_AUTH_MODE"
+    fi
     prev="$a"
 done
+printf '%s\n' "$@" >> "$CURL_ARGS"
 case "$url" in
     */models)
         if [[ "${CURL_MODELS_UP:-1}" != "1" ]]; then
@@ -63,7 +70,12 @@ case "$url" in
             exit 7
         fi
         printf '%s\n' "$url" >> "$CURL_MODELS_HITS"
-        cat "$CURL_MODELS_FILE" 2>/dev/null || printf '{"data":[]}'
+        if [[ -n "$out_file" ]]; then
+            cat "$CURL_MODELS_FILE" > "$out_file" 2>/dev/null || printf '{"data":[]}' > "$out_file"
+        else
+            cat "$CURL_MODELS_FILE" 2>/dev/null || printf '{"data":[]}'
+        fi
+        printf '%s' "${CURL_MODELS_STATUS:-200}"
         exit 0
         ;;
 esac
@@ -87,6 +99,7 @@ chmod +x "$STUB/curl" "$STUB/docker" "$STUB/llm"
 # cloud tests drive it all the way there), so the tools it calls must exist.
 APP="$WORK/app"; mkdir -p "$APP/bin" "$APP/tools"
 : > "$APP/bin/shellm"
+cp "$REPO/tools/headlong-init" "$APP/tools/headlong-init"
 
 # identity: create the directory structure init writes into (memories, chat),
 # without the real tool's behavior.
@@ -124,7 +137,13 @@ printf '<html></html>' > "$APP/web/src/headlong_web/static/index.html"
 
 MODELS_FILE="$WORK/models.json"
 CURL_MODELS_HITS="$WORK/models_hits"
+CURL_ARGS="$WORK/curl_args"
+CURL_AUTH_FILE="$WORK/curl_auth"
+CURL_AUTH_MODE="$WORK/curl_auth_mode"
 : > "$CURL_MODELS_HITS"
+: > "$CURL_ARGS"
+: > "$CURL_AUTH_FILE"
+: > "$CURL_AUTH_MODE"
 
 # run_init <home> [VAR=VAL ...] — headlong-init with no tty, no inherited
 # keys or local config, stubs first on PATH. Output to $WORK/out; the exit
@@ -139,8 +158,10 @@ run_init() {
         HEADLONG_NO_TTY=1 HEADLONG_UNSANDBOXED="${HEADLONG_UNSANDBOXED:-1}" \
         HEADLONG_NO_DASH=1 PATH="$STUB:$PATH" \
         CURL_MODELS_FILE="$MODELS_FILE" CURL_MODELS_HITS="$CURL_MODELS_HITS" \
-        CURL_MODELS_UP="${CURL_MODELS_UP:-1}" LLM_STUB_RC="${LLM_STUB_RC:-0}" "$@" \
-        bash "$REPO/tools/headlong-init" </dev/null > "$WORK/out" 2>&1
+        CURL_MODELS_UP="${CURL_MODELS_UP:-1}" CURL_MODELS_STATUS="${CURL_MODELS_STATUS:-200}" \
+        CURL_ARGS="$CURL_ARGS" CURL_AUTH_FILE="$CURL_AUTH_FILE" CURL_AUTH_MODE="$CURL_AUTH_MODE" \
+        LLM_STUB_RC="${LLM_STUB_RC:-0}" "$@" \
+        bash "$APP/tools/headlong-init" </dev/null > "$WORK/out" 2>&1
     RC=$?
 }
 
@@ -163,10 +184,12 @@ check "local path: models probe hit /v1/models"              grep -q '127.0.0.1:
 run_init "$WORK/h1b" \
     HEADLONG_PROVIDER=local \
     HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
-    HEADLONG_LOCAL_MODEL=qwen3:8b \
+    SHELLM_MODEL=openai/gpt-oss-120b \
     ANTHROPIC_API_KEY=«redacted:sk-ant-…»
 check "local path: a cloud key in the env stays out of the local .env" \
     check_not grep -q 'ANTHROPIC_API_KEY' "$WORK/h1b/.headlong/.env"
+check "local path: a cloud model does not override the server list" \
+    grep -qx 'SHELLM_MODEL=qwen3:8b' "$WORK/h1b/.headlong/.env"
 
 # ---------------------------------------------------------------------------
 # a dead endpoint: verify first, write nothing
@@ -212,6 +235,17 @@ run_init "$WORK/h4" \
     HEADLONG_LOCAL_API_KEY=«redacted:lm-studio-…»
 check "local key: exits 0"                                   test "$RC" -eq 0
 check "local key: persisted"                                 grep -qx 'LLM_API_KEY=«redacted:lm-studio-…»' "$WORK/h4/.headlong/.env"
+check "local key: stays off curl argv"                       check_not grep -q 'lm-studio' "$CURL_ARGS"
+check "local key: auth file is private"                      grep -qx '600' "$CURL_AUTH_MODE"
+
+# A reachable server may support chat without exposing its model catalog.
+# An explicit model is enough in that case.
+CURL_MODELS_STATUS=404 run_init "$WORK/h4b" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:1234/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "models 404: explicit model still works"               test "$RC" -eq 0
+check "models 404: requested model is persisted"             grep -qx 'SHELLM_MODEL=qwen3:8b' "$WORK/h4b/.headlong/.env"
 
 # ---------------------------------------------------------------------------
 # no model pinned, server exposes several: first in the list is used
@@ -245,6 +279,22 @@ LLM_STUB_RC=1 run_init "$WORK/h7" \
 check "cloud explicit: exits nonzero (stub llm fails, as in the key tests)" test "$RC" -ne 0
 check "cloud explicit: no local config written"              check_not grep -q 'SHELLM_API_URL' "$WORK/h7/.headlong/.env"
 
+# An explicit cloud choice on a configured local install removes every local
+# routing value and picks the cloud provider's default model.
+run_init "$WORK/h7b" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b \
+    HEADLONG_LOCAL_API_KEY=local-secret
+run_init "$WORK/h7b" \
+    HEADLONG_PROVIDER=cloud \
+    OPENAI_API_KEY=«redacted:sk-…»
+check "local to cloud: exits 0"                              test "$RC" -eq 0
+check "local to cloud: removes the local provider"           check_not grep -q '^LLM_PROVIDER=' "$WORK/h7b/.headlong/.env"
+check "local to cloud: removes the local URL"                check_not grep -q '^SHELLM_API_URL=' "$WORK/h7b/.headlong/.env"
+check "local to cloud: removes the local key"                check_not grep -q '^LLM_API_KEY=' "$WORK/h7b/.headlong/.env"
+check "local to cloud: selects the OpenAI model"             grep -qx 'SHELLM_MODEL=gpt-5.5' "$WORK/h7b/.headlong/.env"
+
 # ---------------------------------------------------------------------------
 # re-run idempotence: the same local config persists again (keyless), and
 # an already-configured healthy local endpoint is kept without any
@@ -254,35 +304,31 @@ run_init "$WORK/h8" \
     HEADLONG_PROVIDER=local \
     HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
     HEADLONG_LOCAL_MODEL=qwen3:8b
-run_init "$WORK/h8" \
-    HEADLONG_PROVIDER=local \
-    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
-    HEADLONG_LOCAL_MODEL=qwen3:8b
+run_init "$WORK/h8"
 check "re-run: still exits 0"                                test "$RC" -eq 0
 check "re-run: config survives, exactly once per var" \
     test "$(grep -c '^SHELLM_API_URL=' "$WORK/h8/.headlong/.env")" -eq 1
 
 # ---------------------------------------------------------------------------
-# sandbox-aware URL: with the Docker sandbox on, a localhost address is
-# rewritten to host.docker.internal (the container's name for the host) in
-# the PERSISTED url; the operator-facing probe still succeeded through the
-# localhost twin. HEADLONG_LOCAL_URL given as host.docker.internal passes
-# through unchanged.
+# A host install keeps its host-reachable URL even when the Docker sandbox is
+# on. shellm translates it only for commands executed inside that sandbox.
 # ---------------------------------------------------------------------------
 HEADLONG_UNSANDBOXED=0 run_init "$WORK/h9" \
     HEADLONG_PROVIDER=local \
     HEADLONG_LOCAL_URL=http://127.0.0.1:11434 \
     HEADLONG_LOCAL_MODEL=qwen3:8b
 check "sandbox rewrite: exits 0"                             test "$RC" -eq 0
-check "sandbox rewrite: persisted url is container-reachable" grep -qx 'SHELLM_API_URL=http://host.docker.internal:11434/v1/chat/completions' "$WORK/h9/.headlong/.env"
-check "sandbox rewrite: announced the rewrite"               grep -q 'host.docker.internal' "$WORK/out"
+check "host install: persisted url stays host-reachable"     grep -qx 'SHELLM_API_URL=http://127.0.0.1:11434/v1/chat/completions' "$WORK/h9/.headlong/.env"
 
+# A full Headlong container uses host.docker.internal for a server on the
+# Docker host, and it probes the same address from inside that container.
 HEADLONG_UNSANDBOXED=0 run_init "$WORK/h9b" \
-    HEADLONG_PROVIDER=local \
-    HEADLONG_LOCAL_URL=http://host.docker.internal:1234 \
+    HEADLONG_FAKE_CONTAINER=1 HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:1234 \
     HEADLONG_LOCAL_MODEL=qwen3:8b
-check "explicit container url: exits 0"                      test "$RC" -eq 0
-check "explicit container url: kept as-is"                   grep -qx 'SHELLM_API_URL=http://host.docker.internal:1234/v1/chat/completions' "$WORK/h9b/.headlong/.env"
+check "container install: exits 0"                           test "$RC" -eq 0
+check "container install: persists the Docker host URL"      grep -qx 'SHELLM_API_URL=http://host.docker.internal:1234/v1/chat/completions' "$WORK/h9b/.headlong/.env"
+check "container install: probes the Docker host URL"        grep -q 'host.docker.internal:1234/v1/models' "$CURL_MODELS_HITS"
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_local_llm_setup.sh
+++ b/tests/test_local_llm_setup.sh
@@ -174,11 +174,32 @@ run_init "$WORK/h1" \
     HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
     HEADLONG_LOCAL_MODEL=qwen3:8b
 check "local path: exits 0"                                  test "$RC" -eq 0
-check "local path: persists LLM_PROVIDER=openai-compatible"  grep -qx 'LLM_PROVIDER=openai-compatible' "$WORK/h1/.headlong/.env"
-check "local path: persists the chat-completions URL"        grep -qx 'SHELLM_API_URL=http://127.0.0.1:11434/v1/chat/completions' "$WORK/h1/.headlong/.env"
-check "local path: persists the requested model"             grep -qx 'SHELLM_MODEL=qwen3:8b' "$WORK/h1/.headlong/.env"
-check "local path: no key written"                           check_not grep -q '^LLM_API_KEY=' "$WORK/h1/.headlong/.env"
+check "local path: persists LLM_PROVIDER=openai-compatible"  grep -qx "LLM_PROVIDER='openai-compatible'" "$WORK/h1/.headlong/.env"
+check "local path: persists the chat-completions URL"        grep -qx "SHELLM_API_URL='http://127.0.0.1:11434/v1/chat/completions'" "$WORK/h1/.headlong/.env"
+check "local path: persists the requested model"             grep -qx "SHELLM_MODEL='qwen3:8b'" "$WORK/h1/.headlong/.env"
+check_not "local path: no key written"                       grep -q '^LLM_API_KEY=' "$WORK/h1/.headlong/.env"
 check "local path: models probe hit /v1/models"              grep -q '127.0.0.1:11434/v1/models' "$CURL_MODELS_HITS"
+
+# .env values are single-quoted, so a server-supplied model id carrying
+# shell metacharacters can neither execute when the file is sourced nor
+# even be stored: the id is rejected before anything is written.
+rm -f "$WORK/pwned"
+printf '{"data":[{"id":"qwen3$(touch %s/pwned)"}]}' "$WORK" > "$MODELS_FILE"
+run_init "$WORK/hrce" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1
+check "malicious model id: init refuses"                      test "$RC" -ne 0
+check_not "malicious model id: nothing executed on the host"  test -e "$WORK/pwned"
+check_not "malicious model id: not persisted"                 grep -q 'pwned' "$WORK/hrce/.headlong/.env"
+
+# A whitespace-bearing id is likewise refused (it would break sourcing).
+printf '{"data":[{"id":"qwen3 8b"}]}' > "$MODELS_FILE"
+run_init "$WORK/hrce2" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1
+check "space in model id: init refuses"                       test "$RC" -ne 0
+
+printf '{"data":[{"id":"qwen3:8b"},{"id":"gemma3:12b"},{"id":"llama3.2"}]}' > "$MODELS_FILE"
 
 # A stray cloud key in the environment must not leak into the local .env.
 run_init "$WORK/h1b" \
@@ -186,10 +207,10 @@ run_init "$WORK/h1b" \
     HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
     SHELLM_MODEL=openai/gpt-oss-120b \
     ANTHROPIC_API_KEY=«redacted:sk-ant-…»
-check "local path: a cloud key in the env stays out of the local .env" \
-    check_not grep -q 'ANTHROPIC_API_KEY' "$WORK/h1b/.headlong/.env"
+check_not "local path: a cloud key in the env stays out of the local .env" \
+    grep -q 'ANTHROPIC_API_KEY' "$WORK/h1b/.headlong/.env"
 check "local path: a cloud model does not override the server list" \
-    grep -qx 'SHELLM_MODEL=qwen3:8b' "$WORK/h1b/.headlong/.env"
+    grep -qx "SHELLM_MODEL='qwen3:8b'" "$WORK/h1b/.headlong/.env"
 
 # ---------------------------------------------------------------------------
 # a dead endpoint: verify first, write nothing
@@ -203,7 +224,7 @@ check "dead endpoint: exits nonzero"                         test "$RC" -ne 0
 check "dead endpoint: says it could not reach the server"    grep -qi 'could not reach\|could not list' "$WORK/out"
 # The sandbox gate writes its own lines before the provider step; what matters
 # is that no local-model config was persisted for a server that is not there.
-check "dead endpoint: no local config persisted"             check_not grep -q 'LLM_PROVIDER=openai-compatible' "$WORK/h2/.headlong/.env"
+check_not "dead endpoint: no local config persisted"         grep -q '^LLM_PROVIDER=' "$WORK/h2/.headlong/.env"
 
 # ---------------------------------------------------------------------------
 # URL normalization: a full chat-completions URL is accepted as given
@@ -213,7 +234,7 @@ run_init "$WORK/h3" \
     HEADLONG_LOCAL_URL=http://127.0.0.1:8080/v1/chat/completions \
     HEADLONG_LOCAL_MODEL=gemma3:12b
 check "full URL accepted: exits 0"                           test "$RC" -eq 0
-check "full URL accepted: kept as the chat URL"              grep -qx 'SHELLM_API_URL=http://127.0.0.1:8080/v1/chat/completions' "$WORK/h3/.headlong/.env"
+check "full URL accepted: kept as the chat URL"              grep -qx "SHELLM_API_URL='http://127.0.0.1:8080/v1/chat/completions'" "$WORK/h3/.headlong/.env"
 check "full URL accepted: model probe still hit /v1/models"  grep -q '127.0.0.1:8080/v1/models' "$CURL_MODELS_HITS"
 
 # A trailing slash on the base URL must not double up.
@@ -222,7 +243,7 @@ run_init "$WORK/h3b" \
     HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1/ \
     HEADLONG_LOCAL_MODEL=llama3.2
 check "trailing slash: exits 0"                              test "$RC" -eq 0
-check "trailing slash: normalized chat URL"                  grep -qx 'SHELLM_API_URL=http://127.0.0.1:11434/v1/chat/completions' "$WORK/h3b/.headlong/.env"
+check "trailing slash: normalized chat URL"                  grep -qx "SHELLM_API_URL='http://127.0.0.1:11434/v1/chat/completions'" "$WORK/h3b/.headlong/.env"
 
 # ---------------------------------------------------------------------------
 # a key for a locked-down endpoint is persisted
@@ -234,9 +255,23 @@ run_init "$WORK/h4" \
     HEADLONG_LOCAL_MODEL=qwen3:8b \
     HEADLONG_LOCAL_API_KEY=«redacted:lm-studio-…»
 check "local key: exits 0"                                   test "$RC" -eq 0
-check "local key: persisted"                                 grep -qx 'LLM_API_KEY=«redacted:lm-studio-…»' "$WORK/h4/.headlong/.env"
-check "local key: stays off curl argv"                       check_not grep -q 'lm-studio' "$CURL_ARGS"
+check "local key: persisted"                                 grep -qx "LLM_API_KEY='«redacted:lm-studio-…»'" "$WORK/h4/.headlong/.env"
+check_not "local key: stays off curl argv"                   grep -q 'lm-studio' "$CURL_ARGS"
 check "local key: auth file is private"                      grep -qx '600' "$CURL_AUTH_MODE"
+
+# A stale LLM_API_KEY inherited from a prior/keyed .env must NOT be sent as
+# a Bearer token to a newly selected server, nor persisted for it: a key
+# belongs to the endpoint it was set for. Selecting a fresh HEADLONG_LOCAL_URL
+# means no key unless one is given for that server.
+: > "$CURL_AUTH_FILE"
+run_init "$WORK/h4e" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:5678/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b \
+    LLM_API_KEY=stale-cloud-secret
+check "stale key: exits 0"                                   test "$RC" -eq 0
+check_not "stale key: no Bearer sent to the new server"      test -s "$CURL_AUTH_FILE"
+check_not "stale key: not persisted for the new endpoint"    grep -q '^LLM_API_KEY=' "$WORK/h4e/.headlong/.env"
 
 # A reachable server may support chat without exposing its model catalog.
 # An explicit model is enough in that case.
@@ -245,7 +280,24 @@ CURL_MODELS_STATUS=404 run_init "$WORK/h4b" \
     HEADLONG_LOCAL_URL=http://127.0.0.1:1234/v1 \
     HEADLONG_LOCAL_MODEL=qwen3:8b
 check "models 404: explicit model still works"               test "$RC" -eq 0
-check "models 404: requested model is persisted"             grep -qx 'SHELLM_MODEL=qwen3:8b' "$WORK/h4b/.headlong/.env"
+check "models 404: requested model is persisted"             grep -qx "SHELLM_MODEL='qwen3:8b'" "$WORK/h4b/.headlong/.env"
+
+# An OpenAI-compatible server with NO models pulled yet ({"data":[]}) is a
+# healthy server, not a protocol error: with an explicit model it succeeds,
+# and without one it dies telling the operator to provide a model — never
+# the misleading "is it an OpenAI-compatible server?" message.
+printf '{"data":[]}' > "$MODELS_FILE"
+run_init "$WORK/h4c" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:1234/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "empty model list + explicit model: exits 0"           test "$RC" -eq 0
+run_init "$WORK/h4d" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:1234/v1
+check "empty model list, no model: exits nonzero"            test "$RC" -ne 0
+check_not "empty model list: not blamed as incompatible"     grep -qi 'OpenAI-compatible server?' "$WORK/out"
+printf '{"data":[{"id":"qwen3:8b"}]}' > "$MODELS_FILE"
 
 # ---------------------------------------------------------------------------
 # no model pinned, server exposes several: first in the list is used
@@ -254,7 +306,7 @@ run_init "$WORK/h5" \
     HEADLONG_PROVIDER=local \
     HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1
 check "no model pin: exits 0"                                test "$RC" -eq 0
-check "no model pin: first listed model chosen"              grep -qx 'SHELLM_MODEL=qwen3:8b' "$WORK/h5/.headlong/.env"
+check "no model pin: first listed model chosen"              grep -qx "SHELLM_MODEL='qwen3:8b'" "$WORK/h5/.headlong/.env"
 
 # ---------------------------------------------------------------------------
 # the final check is a real completion: a failing chain fails the setup
@@ -265,6 +317,10 @@ LLM_STUB_RC=1 run_init "$WORK/h6" \
     HEADLONG_LOCAL_MODEL=qwen3:8b
 check "failing completion: exits nonzero"                    test "$RC" -ne 0
 check "failing completion: says chat did not answer"         grep -qi 'did not answer\|chat completion' "$WORK/out"
+# A failed chat check must persist nothing: a broken local provider left in
+# .env would shadow a working cloud key on every later run.
+check_not "failing completion: no local provider persisted"  grep -q '^LLM_PROVIDER=' "$WORK/h6/.headlong/.env"
+check_not "failing completion: no local URL persisted"       grep -q '^SHELLM_API_URL=' "$WORK/h6/.headlong/.env"
 
 # ---------------------------------------------------------------------------
 # cloud wins explicitly: local env vars are ignored. The stub llm fails, so a
@@ -277,7 +333,7 @@ LLM_STUB_RC=1 run_init "$WORK/h7" \
     HEADLONG_LOCAL_MODEL=qwen3:8b \
     OPENAI_API_KEY=«redacted:sk-…»
 check "cloud explicit: exits nonzero (stub llm fails, as in the key tests)" test "$RC" -ne 0
-check "cloud explicit: no local config written"              check_not grep -q 'SHELLM_API_URL' "$WORK/h7/.headlong/.env"
+check_not "cloud explicit: no local config written"          grep -q 'SHELLM_API_URL' "$WORK/h7/.headlong/.env"
 
 # An explicit cloud choice on a configured local install removes every local
 # routing value and picks the cloud provider's default model.
@@ -290,10 +346,22 @@ run_init "$WORK/h7b" \
     HEADLONG_PROVIDER=cloud \
     OPENAI_API_KEY=«redacted:sk-…»
 check "local to cloud: exits 0"                              test "$RC" -eq 0
-check "local to cloud: removes the local provider"           check_not grep -q '^LLM_PROVIDER=' "$WORK/h7b/.headlong/.env"
-check "local to cloud: removes the local URL"                check_not grep -q '^SHELLM_API_URL=' "$WORK/h7b/.headlong/.env"
-check "local to cloud: removes the local key"                check_not grep -q '^LLM_API_KEY=' "$WORK/h7b/.headlong/.env"
-check "local to cloud: selects the OpenAI model"             grep -qx 'SHELLM_MODEL=gpt-5.5' "$WORK/h7b/.headlong/.env"
+check_not "local to cloud: removes the local provider"       grep -q '^LLM_PROVIDER=' "$WORK/h7b/.headlong/.env"
+check_not "local to cloud: removes the local URL"            grep -q '^SHELLM_API_URL=' "$WORK/h7b/.headlong/.env"
+check_not "local to cloud: removes the local key"            grep -q '^LLM_API_KEY=' "$WORK/h7b/.headlong/.env"
+check "local to cloud: selects the OpenAI model"             grep -qx "SHELLM_MODEL='gpt-5.5'" "$WORK/h7b/.headlong/.env"
+
+# A cloud switch that FAILS (no key) must leave the working local config
+# intact: the wipe is committed only after a cloud key validates. Otherwise
+# a plain re-run could not recover the box.
+run_init "$WORK/h7c" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+run_init "$WORK/h7c" HEADLONG_PROVIDER=cloud   # no cloud key given
+check "failed switch: exits nonzero"                         test "$RC" -ne 0
+check "failed switch: local provider still present"          grep -qx "LLM_PROVIDER='openai-compatible'" "$WORK/h7c/.headlong/.env"
+check "failed switch: local URL still present"               grep -qx "SHELLM_API_URL='http://127.0.0.1:11434/v1/chat/completions'" "$WORK/h7c/.headlong/.env"
 
 # ---------------------------------------------------------------------------
 # re-run idempotence: the same local config persists again (keyless), and
@@ -318,7 +386,7 @@ HEADLONG_UNSANDBOXED=0 run_init "$WORK/h9" \
     HEADLONG_LOCAL_URL=http://127.0.0.1:11434 \
     HEADLONG_LOCAL_MODEL=qwen3:8b
 check "sandbox rewrite: exits 0"                             test "$RC" -eq 0
-check "host install: persisted url stays host-reachable"     grep -qx 'SHELLM_API_URL=http://127.0.0.1:11434/v1/chat/completions' "$WORK/h9/.headlong/.env"
+check "host install: persisted url stays host-reachable"     grep -qx "SHELLM_API_URL='http://127.0.0.1:11434/v1/chat/completions'" "$WORK/h9/.headlong/.env"
 
 # A full Headlong container uses host.docker.internal for a server on the
 # Docker host, and it probes the same address from inside that container.
@@ -327,8 +395,18 @@ HEADLONG_UNSANDBOXED=0 run_init "$WORK/h9b" \
     HEADLONG_LOCAL_URL=http://127.0.0.1:1234 \
     HEADLONG_LOCAL_MODEL=qwen3:8b
 check "container install: exits 0"                           test "$RC" -eq 0
-check "container install: persists the Docker host URL"      grep -qx 'SHELLM_API_URL=http://host.docker.internal:1234/v1/chat/completions' "$WORK/h9b/.headlong/.env"
+check "container install: persists the Docker host URL"      grep -qx "SHELLM_API_URL='http://host.docker.internal:1234/v1/chat/completions'" "$WORK/h9b/.headlong/.env"
 check "container install: probes the Docker host URL"        grep -q 'host.docker.internal:1234/v1/models' "$CURL_MODELS_HITS"
+
+# A URL whose host merely CONTAINS 'localhost' (or 'host.docker.internal')
+# as a substring must survive the container rewrite untouched: only the
+# authority host is swapped, never a substring elsewhere.
+HEADLONG_UNSANDBOXED=0 run_init "$WORK/h9c" \
+    HEADLONG_FAKE_CONTAINER=1 HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://mylocalhost.example:1234 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "substring host: exits 0"                              test "$RC" -eq 0
+check "substring host: host is left untouched"               grep -qx "SHELLM_API_URL='http://mylocalhost.example:1234/v1/chat/completions'" "$WORK/h9c/.headlong/.env"
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_local_llm_setup.sh
+++ b/tests/test_local_llm_setup.sh
@@ -85,10 +85,19 @@ STUBEOF
 # docker: daemon up, nothing else (no image pull).
 printf '#!/usr/bin/env bash\ncase "${1:-}" in info) exit 0 ;; *) exit 0 ;; esac\n' > "$STUB/docker"
 
-# llm: an init that gets this far proves the chain — record the exit and let
-# the caller decide the verdict via LLM_STUB_RC.
+# llm: an init that gets this far proves the chain. Optionally record whether
+# local routing variables were present in the environment. A cloud switch
+# must pass them as explicitly empty so the real llm cannot reload them from
+# the saved state .env.
 cat > "$STUB/llm" <<'STUBEOF'
 #!/usr/bin/env bash
+if [[ -n "${LLM_ENV_CAPTURE:-}" ]]; then
+    printf 'LLM_PROVIDER=%s:%s\n' "${LLM_PROVIDER+x}" "${LLM_PROVIDER-}" > "$LLM_ENV_CAPTURE"
+    printf 'SHELLM_API_URL=%s:%s\n' "${SHELLM_API_URL+x}" "${SHELLM_API_URL-}" >> "$LLM_ENV_CAPTURE"
+    printf 'LLM_API_URL=%s:%s\n' "${LLM_API_URL+x}" "${LLM_API_URL-}" >> "$LLM_ENV_CAPTURE"
+    printf 'LLM_API_KEY=%s:%s\n' "${LLM_API_KEY+x}" "${LLM_API_KEY-}" >> "$LLM_ENV_CAPTURE"
+    printf 'SHELLM_MODEL=%s\n' "${SHELLM_MODEL-}" >> "$LLM_ENV_CAPTURE"
+fi
 exit "${LLM_STUB_RC:-0}"
 STUBEOF
 
@@ -140,6 +149,7 @@ CURL_MODELS_HITS="$WORK/models_hits"
 CURL_ARGS="$WORK/curl_args"
 CURL_AUTH_FILE="$WORK/curl_auth"
 CURL_AUTH_MODE="$WORK/curl_auth_mode"
+LLM_ENV_CAPTURE="$WORK/llm_env"
 : > "$CURL_MODELS_HITS"
 : > "$CURL_ARGS"
 : > "$CURL_AUTH_FILE"
@@ -160,7 +170,7 @@ run_init() {
         CURL_MODELS_FILE="$MODELS_FILE" CURL_MODELS_HITS="$CURL_MODELS_HITS" \
         CURL_MODELS_UP="${CURL_MODELS_UP:-1}" CURL_MODELS_STATUS="${CURL_MODELS_STATUS:-200}" \
         CURL_ARGS="$CURL_ARGS" CURL_AUTH_FILE="$CURL_AUTH_FILE" CURL_AUTH_MODE="$CURL_AUTH_MODE" \
-        LLM_STUB_RC="${LLM_STUB_RC:-0}" "$@" \
+        LLM_STUB_RC="${LLM_STUB_RC:-0}" LLM_ENV_CAPTURE="${LLM_ENV_CAPTURE_ACTIVE:+$LLM_ENV_CAPTURE}" "$@" \
         bash "$APP/tools/headlong-init" </dev/null > "$WORK/out" 2>&1
     RC=$?
 }
@@ -225,6 +235,21 @@ check "dead endpoint: says it could not reach the server"    grep -qi 'could not
 # The sandbox gate writes its own lines before the provider step; what matters
 # is that no local-model config was persisted for a server that is not there.
 check_not "dead endpoint: no local config persisted"         grep -q '^LLM_PROVIDER=' "$WORK/h2/.headlong/.env"
+
+# Credentials embedded in an endpoint URL are needed by the HTTP client but
+# must not be repeated in terminal or CI output, on success or failure.
+CURL_MODELS_UP=0 run_init "$WORK/h2b" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://local-user:local-pass@127.0.0.1:9999/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "credential URL: failure still identifies the host"    grep -q '127.0.0.1:9999' "$WORK/out"
+check_not "credential URL: userinfo is redacted from output"  grep -q 'local-user\|local-pass' "$WORK/out"
+run_init "$WORK/h2c" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://local-user:local-pass@127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "credential URL: successful setup exits 0"             test "$RC" -eq 0
+check_not "credential URL: success output is also redacted"   grep -q 'local-user\|local-pass' "$WORK/out"
 
 # ---------------------------------------------------------------------------
 # URL normalization: a full chat-completions URL is accepted as given
@@ -342,7 +367,7 @@ run_init "$WORK/h7b" \
     HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
     HEADLONG_LOCAL_MODEL=qwen3:8b \
     HEADLONG_LOCAL_API_KEY=local-secret
-run_init "$WORK/h7b" \
+LLM_ENV_CAPTURE_ACTIVE=1 run_init "$WORK/h7b" \
     HEADLONG_PROVIDER=cloud \
     OPENAI_API_KEY=«redacted:sk-…»
 check "local to cloud: exits 0"                              test "$RC" -eq 0
@@ -350,6 +375,14 @@ check_not "local to cloud: removes the local provider"       grep -q '^LLM_PROVI
 check_not "local to cloud: removes the local URL"            grep -q '^SHELLM_API_URL=' "$WORK/h7b/.headlong/.env"
 check_not "local to cloud: removes the local key"            grep -q '^LLM_API_KEY=' "$WORK/h7b/.headlong/.env"
 check "local to cloud: selects the OpenAI model"             grep -qx "SHELLM_MODEL='gpt-5.5'" "$WORK/h7b/.headlong/.env"
+check "local to cloud: masks saved provider during validation" \
+    grep -qx 'LLM_PROVIDER=x:' "$LLM_ENV_CAPTURE"
+check "local to cloud: masks saved URL during validation" \
+    grep -qx 'SHELLM_API_URL=x:' "$LLM_ENV_CAPTURE"
+check "local to cloud: masks saved local key during validation" \
+    grep -qx 'LLM_API_KEY=x:' "$LLM_ENV_CAPTURE"
+check "local to cloud: validates the cloud model" \
+    grep -qx 'SHELLM_MODEL=gpt-5.5' "$LLM_ENV_CAPTURE"
 
 # A cloud switch that FAILS (no key) must leave the working local config
 # intact: the wipe is committed only after a cloud key validates. Otherwise
@@ -362,6 +395,38 @@ run_init "$WORK/h7c" HEADLONG_PROVIDER=cloud   # no cloud key given
 check "failed switch: exits nonzero"                         test "$RC" -ne 0
 check "failed switch: local provider still present"          grep -qx "LLM_PROVIDER='openai-compatible'" "$WORK/h7c/.headlong/.env"
 check "failed switch: local URL still present"               grep -qx "SHELLM_API_URL='http://127.0.0.1:11434/v1/chat/completions'" "$WORK/h7c/.headlong/.env"
+
+# An existing identity does not make a newly supplied cloud key trusted. If
+# that key fails validation, the installer must fail and preserve the entire
+# working local route instead of treating it as a transient revalidation.
+run_init "$WORK/h7d" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b \
+    HEADLONG_LOCAL_API_KEY=local-secret
+grep -E '^(LLM_PROVIDER|SHELLM_API_URL|LLM_API_URL|LLM_API_KEY|SHELLM_MODEL)=' \
+    "$WORK/h7d/.headlong/.env" > "$WORK/h7d.route.before"
+LLM_STUB_RC=1 run_init "$WORK/h7d" \
+    HEADLONG_PROVIDER=cloud \
+    OPENAI_API_KEY=«redacted:sk-…»
+check "invalid cloud key switch: exits nonzero"              test "$RC" -ne 0
+grep -E '^(LLM_PROVIDER|SHELLM_API_URL|LLM_API_URL|LLM_API_KEY|SHELLM_MODEL)=' \
+    "$WORK/h7d/.headlong/.env" > "$WORK/h7d.route.after"
+check "invalid cloud key switch: saved route is unchanged"   cmp -s "$WORK/h7d.route.before" "$WORK/h7d.route.after"
+
+# Prefix-based key correction is staged too. Once the cloud check succeeds,
+# the corrected provider variable must be durable for future processes, not
+# merely exported in this init process.
+run_init "$WORK/h7e" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+run_init "$WORK/h7e" \
+    HEADLONG_PROVIDER=cloud \
+    OPENAI_API_KEY=sk-or-example-redacted-value
+check "corrected-key switch: exits 0"                        test "$RC" -eq 0
+check "corrected-key switch: corrected key is persisted"    grep -qx "OPENROUTER_API_KEY='sk-or-example-redacted-value'" "$WORK/h7e/.headlong/.env"
+check "corrected-key switch: model follows corrected key"    grep -qx "SHELLM_MODEL='anthropic/claude-sonnet-4.5'" "$WORK/h7e/.headlong/.env"
 
 # ---------------------------------------------------------------------------
 # re-run idempotence: the same local config persists again (keyless), and
@@ -397,6 +462,14 @@ HEADLONG_UNSANDBOXED=0 run_init "$WORK/h9b" \
 check "container install: exits 0"                           test "$RC" -eq 0
 check "container install: persists the Docker host URL"      grep -qx "SHELLM_API_URL='http://host.docker.internal:1234/v1/chat/completions'" "$WORK/h9b/.headlong/.env"
 check "container install: probes the Docker host URL"        grep -q 'host.docker.internal:1234/v1/models' "$CURL_MODELS_HITS"
+
+HEADLONG_UNSANDBOXED=0 run_init "$WORK/h9d" \
+    HEADLONG_FAKE_CONTAINER=1 HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://local-user:local-pass@127.0.0.1:1234 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "container credential URL: exits 0"                    test "$RC" -eq 0
+check_not "container credential URL: rewrite output is redacted" \
+    grep -q 'local-user\|local-pass' "$WORK/out"
 
 # A URL whose host merely CONTAINS 'localhost' (or 'host.docker.internal')
 # as a substring must survive the container rewrite untouched: only the

--- a/tests/test_local_llm_setup.sh
+++ b/tests/test_local_llm_setup.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# tests/test_local_llm_setup.sh — headlong-init's local (OpenAI-compatible)
+# model-server setup path.
+#
+# Usage: tests/test_local_llm_setup.sh
+#
+# Why: the openai-compatible provider existed in bin/llm, but the installer
+# only knew how to ask for a cloud API key — a local Ollama/LM Studio setup
+# had to be configured by hand after install (issue #65). This pins the
+# installer flow:
+#
+#   - HEADLONG_PROVIDER=local with HEADLONG_LOCAL_URL + HEADLONG_LOCAL_MODEL
+#     completes with NO cloud key of any kind set, and persists
+#     LLM_PROVIDER=openai-compatible, SHELLM_API_URL and SHELLM_MODEL
+#   - the endpoint is verified with GET <base>/v1/models before anything is
+#     written (a bad URL dies with a clear message, writes nothing)
+#   - a base URL is normalized to the chat-completions URL bin/llm wants;
+#     a full .../v1/chat/completions URL is accepted and kept as-is
+#   - HEADLONG_LOCAL_MODEL wins over the server's list order (the operator's
+#     explicit pick, not "first model in the list")
+#   - the final proof is a real chat completion through bin/llm, so the
+#     probe covers the exact chain a thinker will use
+#   - HEADLONG_PROVIDER=cloud ignores local env vars entirely (the old path)
+#   - a re-run keeps the local config without re-asking (idempotence)
+#
+# curl, docker, jq and llm are stubs; no network and no daemon are touched.
+# Fixture keys below carry only a prefix shape and are deliberately not valid
+# provider keys.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+trap 'cd /; rm -rf "$WORK"' EXIT
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+check()     { local l="$1"; shift; if "$@" >/dev/null 2>&1; then ok "$l"; else bad "$l"; fi; }
+check_not() { local l="$1"; shift; if "$@" >/dev/null 2>&1; then bad "$l"; else ok "$l"; fi; }
+
+# --- stubs -------------------------------------------------------------------
+STUB="$WORK/stub"; mkdir -p "$STUB"
+
+# curl: answer GET <base>/models from $CURL_MODELS_FILE (JSON body); append
+# every /models hit to $CURL_MODELS_HITS (append, not last-write: init's
+# dash-readiness poll curls too, and those must not erase the probe record).
+# Every other request "fails" (empty reply), which is what a dead endpoint
+# looks like to the caller. CURL_MODELS_UP=0 makes even /models unreachable
+# (connection refused, rc 7) — a server that is simply down.
+cat > "$STUB/curl" <<'STUBEOF'
+#!/usr/bin/env bash
+url=""
+prev=""
+for a in "$@"; do
+    [[ "$prev" != -* && "$a" == http* ]] && url="$a"
+    prev="$a"
+done
+case "$url" in
+    */models)
+        if [[ "${CURL_MODELS_UP:-1}" != "1" ]]; then
+            printf 'curl: (7) Failed to connect\n' >&2
+            exit 7
+        fi
+        printf '%s\n' "$url" >> "$CURL_MODELS_HITS"
+        cat "$CURL_MODELS_FILE" 2>/dev/null || printf '{"data":[]}'
+        exit 0
+        ;;
+esac
+exit 7
+STUBEOF
+
+# docker: daemon up, nothing else (no image pull).
+printf '#!/usr/bin/env bash\ncase "${1:-}" in info) exit 0 ;; *) exit 0 ;; esac\n' > "$STUB/docker"
+
+# llm: an init that gets this far proves the chain — record the exit and let
+# the caller decide the verdict via LLM_STUB_RC.
+cat > "$STUB/llm" <<'STUBEOF'
+#!/usr/bin/env bash
+exit "${LLM_STUB_RC:-0}"
+STUBEOF
+
+chmod +x "$STUB/curl" "$STUB/docker" "$STUB/llm"
+
+# A minimal fake checkout: headlong-init only checks that bin/shellm exists
+# under HEADLONG_APP_DIR, but the no-tty path still creates an identity (the
+# cloud tests drive it all the way there), so the tools it calls must exist.
+APP="$WORK/app"; mkdir -p "$APP/bin" "$APP/tools"
+: > "$APP/bin/shellm"
+
+# identity: create the directory structure init writes into (memories, chat),
+# without the real tool's behavior.
+cat > "$APP/tools/identity" <<'STUBEOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "new" ]] || exit 0
+name="${2:-ada}"; shift 2 || true
+root="${IDENTITY_DIR:?IDENTITY_DIR not set}"
+mkdir -p "$root/$name/memories" "$root/$name/chat"
+# init sources activate and requires IDENTITY_NAME from it (thinkers start).
+cat > "$root/$name/activate" <<'ACTEOF'
+export IDENTITY_NAME=ada
+ACTEOF
+STUBEOF
+chmod +x "$APP/tools/identity"
+
+# thinkers / headlong-web: init starts the dash (no HEADLONG_NO_DASH in
+# these runs), so the web stub must look alive: background itself quietly and
+# print the serving line init greps for, then keep running so the pid check
+# passes. thinkers is a no-op.
+printf '#!/usr/bin/env bash\nexit 0\n' > "$APP/tools/thinkers"
+cat > "$APP/tools/headlong-web" <<'STUBEOF'
+#!/usr/bin/env bash
+echo "headlong-web serving http://127.0.0.1:8099"
+sleep 9999
+STUBEOF
+chmod +x "$APP/tools/thinkers" "$APP/tools/headlong-web"
+
+# The persona phase reads the checkout's starter template (and the dash phase
+# checks web/src/headlong_web/static/index.html).
+mkdir -p "$APP/identities" "$APP/web/src/headlong_web/static"
+printf 'name: {{identity_name}}\nvibe: {{vibe}}\nfocus: {{focus}}\n' \
+    > "$APP/identities/starter-persona.md"
+printf '<html></html>' > "$APP/web/src/headlong_web/static/index.html"
+
+MODELS_FILE="$WORK/models.json"
+CURL_MODELS_HITS="$WORK/models_hits"
+: > "$CURL_MODELS_HITS"
+
+# run_init <home> [VAR=VAL ...] — headlong-init with no tty, no inherited
+# keys or local config, stubs first on PATH. Output to $WORK/out; the exit
+# code lands in $RC (captured immediately — a following check() call would
+# otherwise overwrite $?).
+RC=0
+run_init() {
+    local home="$1"; shift
+    mkdir -p "$home"
+    env -i \
+        HOME="$home" HEADLONG_HOME="$home/.headlong" HEADLONG_APP_DIR="$APP" \
+        HEADLONG_NO_TTY=1 HEADLONG_UNSANDBOXED=1 PATH="$STUB:$PATH" \
+        CURL_MODELS_FILE="$MODELS_FILE" CURL_MODELS_HITS="$CURL_MODELS_HITS" \
+        CURL_MODELS_UP="${CURL_MODELS_UP:-1}" LLM_STUB_RC="${LLM_STUB_RC:-0}" "$@" \
+        bash "$REPO/tools/headlong-init" </dev/null > "$WORK/out" 2>&1
+    RC=$?
+}
+
+# ---------------------------------------------------------------------------
+# local + URL + model: the full no-tty happy path
+# ---------------------------------------------------------------------------
+printf '{"data":[{"id":"qwen3:8b"},{"id":"gemma3:12b"},{"id":"llama3.2"}]}' > "$MODELS_FILE"
+run_init "$WORK/h1" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "local path: exits 0"                                  test "$RC" -eq 0
+check "local path: persists LLM_PROVIDER=openai-compatible"  grep -qx 'LLM_PROVIDER=openai-compatible' "$WORK/h1/.headlong/.env"
+check "local path: persists the chat-completions URL"        grep -qx 'SHELLM_API_URL=http://127.0.0.1:11434/v1/chat/completions' "$WORK/h1/.headlong/.env"
+check "local path: persists the requested model"             grep -qx 'SHELLM_MODEL=qwen3:8b' "$WORK/h1/.headlong/.env"
+check "local path: no key written"                           check_not grep -q '^LLM_API_KEY=' "$WORK/h1/.headlong/.env"
+check "local path: models probe hit /v1/models"              grep -q '127.0.0.1:11434/v1/models' "$CURL_MODELS_HITS"
+
+# A stray cloud key in the environment must not leak into the local .env.
+run_init "$WORK/h1b" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b \
+    ANTHROPIC_API_KEY=«redacted:sk-ant-…»
+check "local path: a cloud key in the env stays out of the local .env" \
+    check_not grep -q 'ANTHROPIC_API_KEY' "$WORK/h1b/.headlong/.env"
+
+# ---------------------------------------------------------------------------
+# a dead endpoint: verify first, write nothing
+# ---------------------------------------------------------------------------
+printf '{"data":[{"id":"qwen3:8b"}]}' > "$MODELS_FILE"
+CURL_MODELS_UP=0 run_init "$WORK/h2" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:9999/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "dead endpoint: exits nonzero"                         test "$RC" -ne 0
+check "dead endpoint: says it could not reach the server"    grep -qi 'could not reach\|could not list' "$WORK/out"
+# The sandbox gate writes its own lines before the provider step; what matters
+# is that no local-model config was persisted for a server that is not there.
+check "dead endpoint: no local config persisted"             check_not grep -q 'LLM_PROVIDER=openai-compatible' "$WORK/h2/.headlong/.env"
+
+# ---------------------------------------------------------------------------
+# URL normalization: a full chat-completions URL is accepted as given
+# ---------------------------------------------------------------------------
+run_init "$WORK/h3" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:8080/v1/chat/completions \
+    HEADLONG_LOCAL_MODEL=gemma3:12b
+check "full URL accepted: exits 0"                           test "$RC" -eq 0
+check "full URL accepted: kept as the chat URL"              grep -qx 'SHELLM_API_URL=http://127.0.0.1:8080/v1/chat/completions' "$WORK/h3/.headlong/.env"
+check "full URL accepted: model probe still hit /v1/models"  grep -q '127.0.0.1:8080/v1/models' "$CURL_MODELS_HITS"
+
+# A trailing slash on the base URL must not double up.
+run_init "$WORK/h3b" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1/ \
+    HEADLONG_LOCAL_MODEL=llama3.2
+check "trailing slash: exits 0"                              test "$RC" -eq 0
+check "trailing slash: normalized chat URL"                  grep -qx 'SHELLM_API_URL=http://127.0.0.1:11434/v1/chat/completions' "$WORK/h3b/.headlong/.env"
+
+# ---------------------------------------------------------------------------
+# a key for a locked-down endpoint is persisted
+# ---------------------------------------------------------------------------
+printf '{"data":[{"id":"qwen3:8b"}]}' > "$MODELS_FILE"
+run_init "$WORK/h4" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:1234/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b \
+    HEADLONG_LOCAL_API_KEY=«redacted:lm-studio-…»
+check "local key: exits 0"                                   test "$RC" -eq 0
+check "local key: persisted"                                 grep -qx 'LLM_API_KEY=«redacted:lm-studio-…»' "$WORK/h4/.headlong/.env"
+
+# ---------------------------------------------------------------------------
+# no model pinned, server exposes several: first in the list is used
+# ---------------------------------------------------------------------------
+run_init "$WORK/h5" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1
+check "no model pin: exits 0"                                test "$RC" -eq 0
+check "no model pin: first listed model chosen"              grep -qx 'SHELLM_MODEL=qwen3:8b' "$WORK/h5/.headlong/.env"
+
+# ---------------------------------------------------------------------------
+# the final check is a real completion: a failing chain fails the setup
+# ---------------------------------------------------------------------------
+LLM_STUB_RC=1 run_init "$WORK/h6" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "failing completion: exits nonzero"                    test "$RC" -ne 0
+check "failing completion: says chat did not answer"         grep -qi 'did not answer\|chat completion' "$WORK/out"
+
+# ---------------------------------------------------------------------------
+# cloud wins explicitly: local env vars are ignored. The stub llm fails, so a
+# nonzero exit proves the cloud key path was taken (and its failure mode is
+# the key check, not the local flow).
+# ---------------------------------------------------------------------------
+LLM_STUB_RC=1 run_init "$WORK/h7" \
+    HEADLONG_PROVIDER=cloud \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b \
+    OPENAI_API_KEY=«redacted:sk-…»
+check "cloud explicit: exits nonzero (stub llm fails, as in the key tests)" test "$RC" -ne 0
+check "cloud explicit: no local config written"              check_not grep -q 'SHELLM_API_URL' "$WORK/h7/.headlong/.env"
+
+# ---------------------------------------------------------------------------
+# re-run idempotence: the same local config persists again (keyless), and
+# an already-configured healthy local endpoint is kept without any
+# HEADLONG_PROVIDER hint (the .env alone steers the re-run)
+# ---------------------------------------------------------------------------
+run_init "$WORK/h8" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+run_init "$WORK/h8" \
+    HEADLONG_PROVIDER=local \
+    HEADLONG_LOCAL_URL=http://127.0.0.1:11434/v1 \
+    HEADLONG_LOCAL_MODEL=qwen3:8b
+check "re-run: still exits 0"                                test "$RC" -eq 0
+check "re-run: config survives, exactly once per var" \
+    test "$(grep -c '^SHELLM_API_URL=' "$WORK/h8/.headlong/.env")" -eq 1
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_sandbox_gate.sh
+++ b/tests/test_sandbox_gate.sh
@@ -70,18 +70,18 @@ check_not "no docker, no consent: never reaches the key step" grep -qi "API key"
 run_init "$WORK/h2" DOCKER_STUB_INFO_RC=1 HEADLONG_UNSANDBOXED=1; rc=$?
 check "consented: passes the gate (fails later, at the key step)" grep -q "no API key" "$WORK/out"
 check "consented: prints the unsandboxed warning"        grep -qi "directly on this machine" "$WORK/out"
-check "consented: SHELLM_REQUIRE_DOCKER=0 in state .env" grep -qx "SHELLM_REQUIRE_DOCKER=0" "$WORK/h2/.headlong/.env"
+check "consented: SHELLM_REQUIRE_DOCKER=0 in state .env" grep -qx "SHELLM_REQUIRE_DOCKER='0'" "$WORK/h2/.headlong/.env"
 
 # --- headlong-init: docker up -> sandbox promised and enforced ---------------
 run_init "$WORK/h3" DOCKER_STUB_INFO_RC=0; rc=$?
 check "docker up: announces the sandbox"                 grep -q "sandboxed in Docker" "$WORK/out"
-check "docker up: SHELLM_REQUIRE_DOCKER=1 in state .env" grep -qx "SHELLM_REQUIRE_DOCKER=1" "$WORK/h3/.headlong/.env"
+check "docker up: SHELLM_REQUIRE_DOCKER=1 in state .env" grep -qx "SHELLM_REQUIRE_DOCKER='1'" "$WORK/h3/.headlong/.env"
 check "docker up: gate passes (fails later, at the key step)" grep -q "no API key" "$WORK/out"
 
 # --- explicit unsandboxed choice beats a live daemon (installer menu 3) ------
 run_init "$WORK/h7" DOCKER_STUB_INFO_RC=0 HEADLONG_UNSANDBOXED=1; rc=$?
-check "menu 3: unsandboxed sticks even with docker up"   grep -qx "SHELLM_REQUIRE_DOCKER=0" "$WORK/h7/.headlong/.env"
-check "menu 3: choice persisted for re-runs"             grep -qx "HEADLONG_UNSANDBOXED=1" "$WORK/h7/.headlong/.env"
+check "menu 3: unsandboxed sticks even with docker up"   grep -qx "SHELLM_REQUIRE_DOCKER='0'" "$WORK/h7/.headlong/.env"
+check "menu 3: choice persisted for re-runs"             grep -qx "HEADLONG_UNSANDBOXED='1'" "$WORK/h7/.headlong/.env"
 check_not "menu 3: sandbox not announced"                grep -q "sandboxed in Docker" "$WORK/out"
 
 # --- the HEADLONG_FAKE_DOCKER knob overrides real detection ------------------
@@ -90,7 +90,7 @@ run_init "$WORK/h4" DOCKER_STUB_INFO_RC=0 HEADLONG_FAKE_DOCKER=missing; rc=$?
 check "fake missing: gate stops despite a live daemon"   test "$rc" -ne 0
 check "fake missing: names HEADLONG_UNSANDBOXED"         grep -q "HEADLONG_UNSANDBOXED" "$WORK/out"
 run_init "$WORK/h5" DOCKER_STUB_INFO_RC=1 HEADLONG_FAKE_DOCKER=ok; rc=$?
-check "fake ok: sandbox promised despite a down daemon"  grep -qx "SHELLM_REQUIRE_DOCKER=1" "$WORK/h5/.headlong/.env"
+check "fake ok: sandbox promised despite a down daemon"  grep -qx "SHELLM_REQUIRE_DOCKER='1'" "$WORK/h5/.headlong/.env"
 
 # --- --dry-run: walks the gate, writes nothing, exits 0 ----------------------
 mkdir -p "$WORK/h6"

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -408,6 +408,53 @@ _llm_ok() {
     llm -t 256 "Reply with the single word: ok" >/dev/null 2>>"$INIT_LOG"
 }
 
+_prompt_key() {
+    local key="" var="" tries=0
+    # Empty input (a stray Enter, a paste that didn't take) just asks again;
+    # Ctrl-C or Ctrl-D (EOF on the tty) gives up.
+    while [[ -z "$key" ]]; do
+        printf 'Paste your API key (input hidden; Ctrl-C to quit): ' >/dev/tty
+        if ! IFS= read -rs key </dev/tty; then
+            printf '\n' >/dev/tty
+            return 1
+        fi
+        printf '\n' >/dev/tty
+        key="${key//[[:space:]]/}"   # trailing newline/space from a paste
+        if [[ -z "$key" ]]; then
+            tries=$((tries+1))
+            [[ "$tries" -ge 5 ]] && return 1
+            echo "  Nothing entered. Paste the key and press Enter, or Ctrl-C to quit." >/dev/tty
+        fi
+    done
+    var=$(_key_var_for "$key")
+    if [[ "$key" == sk-* && "$key" != sk-ant-* && "$key" != sk-or-* ]]; then
+        # OpenAI and OpenCode keys share the bare sk- prefix, and a wrong
+        # guess sends the handshake to api.openai.com where it fails
+        # confusingly. Ask rather than guess; OpenAI stays the default so
+        # the common case is just Enter.
+        local which
+        which=$(ask "Is that an OpenAI or an OpenCode key? (1) OpenAI (2) OpenCode" "1")
+        case "$which" in
+            2) var=OPENCODE_API_KEY ;;
+            *) var=OPENAI_API_KEY ;;
+        esac
+    elif [[ -z "$var" ]]; then
+        local which
+        which=$(ask "Which provider is that key for? (1) Anthropic (2) OpenAI (3) Gemini (4) OpenRouter (5) OpenCode" "1")
+        case "$which" in
+            2) var=OPENAI_API_KEY ;;
+            3) var=GEMINI_API_KEY ;;
+            4) var=OPENROUTER_API_KEY ;;
+            5) var=OPENCODE_API_KEY ;;
+            *) var=ANTHROPIC_API_KEY ;;
+        esac
+    fi
+    _env_set "$HEADLONG_HOME/.env" "$var" "$key"
+    # Pin the model to this key's provider so a stale key for another
+    # provider's default can't shadow the one we just validated.
+    _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$(_default_model_for "$var")"
+}
+
 # ---------------------------------------------------------------------------
 # Local (OpenAI-compatible) endpoint setup
 # ---------------------------------------------------------------------------
@@ -657,24 +704,28 @@ EOF
 # inferred: silent inference is how a keyless box quietly picks a default.
 # ---------------------------------------------------------------------------
 
-# _ask_local_or_cloud — 1 = local, 0 = cloud. Preceded by env and by a
-# usable local endpoint already in the state .env (a re-run re-checks it
-# rather than re-asking), and defaults to cloud when a key is present.
+# _ask_local_or_cloud — 1 = local, 0 = cloud. Preceded by HEADLONG_PROVIDER,
+# then a tty offer (first run), then a configured-but-unverified local
+# endpoint in the state .env (a re-run re-checks it rather than re-asking),
+# and defaults to cloud otherwise.
 _ask_local_or_cloud() {
     [[ "${HEADLONG_PROVIDER:-}" == "local" ]] && return 0
     [[ "${HEADLONG_PROVIDER:-}" == "cloud" ]] && return 1
-    # Nothing in the environment. A configured-but-unverified local endpoint
-    # (a re-run, an env carried from another setup) is worth one probe before
-    # falling through to the key prompts.
+    # First run with a human at a tty: offer the local server before demanding
+    # a cloud key. No tty means no asking — fall through to the key checks
+    # (which die with a clear message when there is no key and no server).
+    if [[ "$HAS_TTY" -eq 1 ]]; then
+        ask_yn "Use a local model server (Ollama, LM Studio, vLLM; no API key)? [y/N]" && return 0
+        return 1
+    fi
+    # No tty: only an already-configured local endpoint (a re-run, an env
+    # carried from another setup) is worth one probe before falling through.
     local probe_url="${SHELLM_API_URL:-${LLM_API_URL:-}}"
     [[ -n "$probe_url" && -n "${LLM_PROVIDER:-}" && "$LLM_PROVIDER" == "openai-compatible" ]] || return 1
-    # Only worth asking about when the endpoint still answers; a dead one
+    # Only worth keeping when the endpoint still answers; a dead one
     # falls through to the ordinary prompts (and HEADLONG_PROVIDER=local
     # above forces the repair path regardless).
-    _local_models_get "$(_local_base_url "$probe_url")" "${LLM_API_KEY:-}" >/dev/null 2>&1 || return 1
-    [[ "$HAS_TTY" -eq 0 ]] && return 0
-    ask_yn "Keep using the local model server at ${probe_url}? [Y/n]" && return 0
-    return 1
+    _local_models_get "$(_local_base_url "$probe_url")" "${LLM_API_KEY:-}" >/dev/null 2>&1
 }
 
 _ensure_api_key() {

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -168,9 +168,12 @@ _load_env "$APP_DIR/.env" || true
 _load_env "$HEADLONG_HOME/.env" || true
 
 # _env_set <file> <key> <value> — set KEY in an env file (replacing any
-# existing line) and export it into this process.
+# existing line) and export it into this process. The value is written
+# single-quoted with embedded quotes escaped: the file is SOURCED by
+# bin/llm, bin/shellm and this script, so an unquoted value that came from
+# outside (a server-supplied model id, say) would otherwise run as shell.
 _env_set() {
-    local file="$1" key="$2" val="$3" tmp
+    local file="$1" key="$2" val="$3" tmp esc
     if [[ "$DRY_RUN" -eq 1 ]]; then
         echo "    dry-run: would set $key=$val in $file"
         export "$key=$val"
@@ -184,7 +187,8 @@ _env_set() {
         cat "$tmp" > "$file"
         rm -f "$tmp"
     fi
-    printf '%s=%s\n' "$key" "$val" >> "$file"
+    esc=${val//"'"/"'\\''"}
+    printf "%s='%s'\n" "$key" "$esc" >> "$file"
     export "$key=$val"
 }
 
@@ -519,10 +523,9 @@ _local_models_get() {
     _local_models_err=""
     _LOCAL_MODELS=""
     local url="$1" key="$2" body err body_file auth_file="" status rc
-    local -a curl_args=(-sS --max-time 10 -o "" -w '%{http_code}')
     err=$(mktemp)
     body_file=$(mktemp)
-    curl_args[4]="$body_file"
+    local -a curl_args=(-sS --max-time 10 -o "$body_file" -w '%{http_code}')
     if [[ -n "$key" ]]; then
         local header="Authorization: Bearer $key"
         header="${header//\\/\\\\}"
@@ -552,12 +555,15 @@ _local_models_get() {
     fi
     body=$(cat "$body_file")
     rm -f "$body_file"
-    # The OpenAI ListModels shape is {"data":[{"id":...},...]}; jq -e makes a
-    # missing/broken body a loud failure instead of an empty, plausible list.
-    if ! _LOCAL_MODELS=$(printf '%s' "$body" | jq -r -e '.data[]?.id // empty' 2>/dev/null); then
+    # The OpenAI ListModels shape is {"data":[{"id":...},...]}. Shape
+    # validation is separate from id extraction: a body without a data array
+    # is a protocol failure, while a present-but-EMPTY list is a healthy
+    # server with no models pulled yet (_LOCAL_MODELS="", rc 0).
+    if ! printf '%s' "$body" | jq -e '.data | type == "array"' >/dev/null 2>&1; then
         _local_models_err="$url did not return a model list (is it an OpenAI-compatible server?)"
         return 1
     fi
+    _LOCAL_MODELS=$(printf '%s' "$body" | jq -r '.data[]?.id // empty' 2>/dev/null)
 }
 
 # _prompt_local_url <default> — ask until the URL answers, on a tty; one try
@@ -586,24 +592,69 @@ _prompt_local_key() {
     printf '%s' "$key"
 }
 
+# _url_host <url> — the authority's host, with IPv6 brackets stripped.
+# Plain bash 3.2 parameter expansion (same idiom as bin/llm's override
+# warning): scheme, userinfo, port, path, query and fragment all drop away.
+_url_host() {
+    local rest="${1#*://}"
+    local authority="${rest%%[/?#]*}"
+    local hostport="${authority##*@}"
+    case "$hostport" in
+        \[*\]*) hostport="${hostport#\[}"; printf '%s' "${hostport%%]*}" ;;
+        *)      printf '%s' "${hostport%%:*}" ;;
+    esac
+}
+
+# _url_host_swap <url> <newhost> — replace ONLY the authority's host,
+# keeping scheme, userinfo, port and path. A substring replace would also
+# mangle hosts like mylocalhost.dev or path segments containing the name.
+_url_host_swap() {
+    local url="$1" newhost="$2"
+    local rest="${url#*://}" scheme=""
+    [[ "$rest" == "$url" ]] || scheme="${url%%://*}://"
+    local authority="${rest%%[/?#]*}"
+    local tail="${rest#"$authority"}"
+    local userinfo=""
+    case "$authority" in
+        *@*) userinfo="${authority%@*}@" ;;
+    esac
+    local hostport="${authority##*@}" port=""
+    case "$hostport" in
+        \[*\]:*) port=":${hostport##*:}" ;;
+        \[*\])   port="" ;;
+        *:*)     port=":${hostport##*:}" ;;
+    esac
+    printf '%s%s%s%s%s' "$scheme" "$userinfo" "$newhost" "$port" "$tail"
+}
+
+# _url_is_loopback <url> — does the URL's host name this machine's loopback?
+_url_is_loopback() {
+    case "$(_url_host "$1")" in
+        localhost|127.*|0.0.0.0|::1) return 0 ;;
+    esac
+    return 1
+}
+
 # _local_probe_url <url> — the URL this init process can reach. A host-side
 # installer probes the localhost twin of host.docker.internal. An installer
 # running inside the full Headlong container must keep host.docker.internal,
 # because localhost there means the Headlong container itself.
 _local_probe_url() {
     local url="$1"
-    if [[ "$IN_CONTAINER" -eq 0 ]]; then
-        url="${url//host.docker.internal/localhost}"
+    if [[ "$IN_CONTAINER" -eq 0 && "$(_url_host "$url")" == "host.docker.internal" ]]; then
+        url=$(_url_host_swap "$url" localhost)
     fi
     printf '%s' "$url"
 }
 
 # _local_container_url <url> — the URL a container uses to reach a model
-# server bound to the machine running Docker.
+# server bound to the machine running Docker. Non-loopback URLs pass
+# through untouched.
 _local_container_url() {
     local url="$1"
-    url="${url//localhost/host.docker.internal}"
-    url="${url//127.0.0.1/host.docker.internal}"
+    if _url_is_loopback "$url"; then
+        url=$(_url_host_swap "$url" host.docker.internal)
+    fi
     printf '%s' "$url"
 }
 
@@ -658,16 +709,19 @@ _pick_from_list() {
 # and proves the whole chain with a real completion through bin/llm.
 _setup_local_llm() {
     local base chat key models chosen url_env="${HEADLONG_LOCAL_URL:-${SHELLM_API_URL:-${LLM_API_URL:-}}}"
-    local key_env="${HEADLONG_LOCAL_API_KEY:-${LLM_API_KEY:-}}"
+    local key_env="${HEADLONG_LOCAL_API_KEY:-}"
     local model_env="${HEADLONG_LOCAL_MODEL:-}"
     local revalidating=0
 
-    # Keep a saved local model only when the saved local URL is also being
-    # reused. A cloud model from a checkout .env must not override the model
-    # list returned by a newly selected local server.
-    if [[ -z "$model_env" && -z "${HEADLONG_LOCAL_URL:-}" \
+    # Keep a saved local model — or a saved LLM_API_KEY — only when the
+    # saved local URL is also being reused. A cloud model from a checkout
+    # .env must not override the model list returned by a newly selected
+    # server, and a key saved for one endpoint must never be sent as a
+    # Bearer token to a different one.
+    if [[ -z "${HEADLONG_LOCAL_URL:-}" \
             && "${LLM_PROVIDER:-}" == "openai-compatible" ]]; then
-        model_env="${SHELLM_MODEL:-}"
+        [[ -n "$model_env" ]] || model_env="${SHELLM_MODEL:-}"
+        [[ -n "$key_env" ]] || key_env="${LLM_API_KEY:-}"
     fi
 
     # A URL supplied directly to an init process already running in the full
@@ -734,10 +788,18 @@ EOF
         # localhost twin; the persisted URL keeps the name the agent needs.
         local def_url="${url_env:-http://localhost:1234}"
         base=""
+        # An inherited key covers only the first attempt; a retry re-asks so
+        # a mistyped (or no-longer-wanted) key can actually be replaced.
+        key="$key_env"
         while :; do
             url_env=$(_prompt_local_url "$def_url")
+            # A URL typed at an in-container prompt needs the Docker host
+            # name, same as the env-supplied path above: localhost inside
+            # the full Headlong container is the container itself.
+            if [[ "$IN_CONTAINER" -eq 1 ]]; then
+                url_env=$(_local_container_url "$url_env")
+            fi
             base=$(_local_base_url "$(_local_probe_url "$url_env")")
-            key="$key_env"
             if [[ -z "$key" ]]; then
                 key=$(_prompt_local_key)
             fi
@@ -753,6 +815,7 @@ EOF
                 die "local endpoint unreachable. Start the server and re-run headlong-init."
             fi
             def_url="$url_env"
+            key=""
         done
     fi
 
@@ -781,22 +844,44 @@ EOF
     fi
     [[ -n "$chosen" ]] || die "no model selected"
 
-    # Persist the URL the main runtime will dial. A host install keeps its
+    # The model id ends up in the shell-sourced .env and in request
+    # payloads. The server hands us this string, so a compromised (or
+    # merely weird) server must not be able to smuggle shell syntax or
+    # whitespace through it. _env_set quotes on write as well; this keeps
+    # the id sane for every other consumer too.
+    case "$chosen" in
+        *[!A-Za-z0-9._:/@-]*)
+            die "model id '$chosen' contains characters headlong will not store (allowed: letters, digits, . _ : / @ -)"
+            ;;
+    esac
+
+    # The URL the main runtime will dial. A host install keeps its
     # localhost URL because thinkers and ordinary llm calls run on the host;
     # bin/shellm translates that URL only for code it runs in its Docker
     # sandbox. A full Headlong container needs host.docker.internal here
     # because its main runtime is already inside Docker.
     chat=$(_local_chat_url "$url_env")
-    if [[ "$IN_CONTAINER" -eq 1 ]]; then
-        case "$chat" in
-            *//localhost:*|*//localhost/*|*//127.0.0.1:*)
-                local container_chat
-                container_chat=$(_local_container_url "$chat")
-                echo "    Container install: the agent reaches the server at $container_chat (was $chat)."
-                chat="$container_chat"
-                ;;
-        esac
+    if [[ "$IN_CONTAINER" -eq 1 ]] && _url_is_loopback "$chat"; then
+        local container_chat
+        container_chat=$(_local_container_url "$chat")
+        echo "    Container install: the agent reaches the server at $container_chat (was $chat)."
+        chat="$container_chat"
     fi
+
+    # Prove the whole chain with a real completion BEFORE persisting
+    # anything (this is the same handshake a thinker will make): a failed
+    # chat check must not leave a broken local provider in .env shadowing a
+    # working cloud key on the next run. Everything the call needs is passed
+    # inline — an explicitly empty LLM_API_KEY keeps a stale one in the
+    # .env files from riding along. The init process probes through its own
+    # network view.
+    info "Checking the LLM connection (model: $chosen at $base)"
+    if ! LLM_PROVIDER="openai-compatible" SHELLM_MODEL="$chosen" \
+            LLM_API_KEY="$key" LLM_API_URL="$(_local_probe_url "$chat")" _llm_ok; then
+        die "the endpoint did not answer a chat completion (models list worked, chat did not); nothing was saved. Details: $INIT_LOG"
+    fi
+    echo "    OK — $chosen answered."
+
     _env_set "$HEADLONG_HOME/.env" "LLM_PROVIDER" "openai-compatible"
     _env_set "$HEADLONG_HOME/.env" "SHELLM_API_URL" "$chat"
     if [[ -n "$key" ]]; then
@@ -804,26 +889,19 @@ EOF
     else
         # An old key would ride along to the new endpoint; the openai-compat
         # provider must be keyless here, not mis-keyed.
-        if grep -q '^LLM_API_KEY=' "$HEADLONG_HOME/.env" 2>/dev/null; then
-            local tmp
-            tmp=$(mktemp)
-            grep -v '^LLM_API_KEY=' "$HEADLONG_HOME/.env" > "$tmp" || true
-            cat "$tmp" > "$HEADLONG_HOME/.env"
-            rm -f "$tmp"
-            unset LLM_API_KEY
-        fi
+        _env_unset "$HEADLONG_HOME/.env" "LLM_API_KEY"
     fi
     _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$chosen"
 
-    # Prove the whole chain with a real completion (bin/llm reads the same
-    # .env; this is the same handshake a thinker will make). When the
-    # Use the same network view as the init process for the final check.
-    info "Checking the LLM connection (model: $chosen at $base)"
-    if LLM_API_URL="$(_local_probe_url "$chat")" _llm_ok; then
-        echo "    OK — $chosen answered."
-        return 0
+    # The sandbox reaches a loopback server via Docker's host gateway, which
+    # also exposes every other service bound to this machine's loopback to
+    # code the agent runs there. Worth knowing; see docs/install.md.
+    if [[ "$IN_CONTAINER" -eq 0 ]] && _url_is_loopback "$chat"; then
+        echo "    Note: sandboxed agent code reaches this server through Docker's host"
+        echo "    gateway, which can also reach other services bound to this machine's"
+        echo "    loopback. See docs/install.md (local model server) for details."
     fi
-    die "the endpoint did not answer a chat completion (models list worked, chat did not). Details: $INIT_LOG"
+    return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -832,10 +910,10 @@ EOF
 # inferred: silent inference is how a keyless box quietly picks a default.
 # ---------------------------------------------------------------------------
 
-# _ask_local_or_cloud — 1 = local, 0 = cloud. Preceded by HEADLONG_PROVIDER,
-# then a tty offer (first run), then a configured-but-unverified local
-# endpoint in the state .env (a re-run re-checks it rather than re-asking),
-# and defaults to cloud otherwise.
+# _ask_local_or_cloud — returns 0 for local, nonzero for cloud. Preceded by
+# HEADLONG_PROVIDER, then a tty offer (first run), then a
+# configured-but-unverified local endpoint in the state .env (a re-run
+# re-checks it rather than re-asking), and defaults to cloud otherwise.
 _ask_local_or_cloud() {
     [[ "${HEADLONG_PROVIDER:-}" == "local" ]] && return 0
     [[ "${HEADLONG_PROVIDER:-}" == "cloud" ]] && return 1
@@ -850,6 +928,18 @@ _ask_local_or_cloud() {
     # to the ordinary missing-key error.
     [[ "$HAS_TTY" -eq 1 ]] || return 1
     ask_yn "Use a local model server (Ollama, LM Studio, vLLM; no API key)?"
+}
+
+# _commit_local_wipe — remove a saved local provider from .env, keeping the
+# cloud model chosen for this run. Called only once a cloud key has actually
+# answered (or answered before, on a revalidating re-run): committing the
+# switch any earlier could destroy the only working configuration.
+_commit_local_wipe() {
+    local keep_model="${SHELLM_MODEL:-}" local_var
+    for local_var in LLM_PROVIDER SHELLM_API_URL LLM_API_URL LLM_API_KEY SHELLM_MODEL; do
+        _env_unset "$HEADLONG_HOME/.env" "$local_var"
+    done
+    [[ -z "$keep_model" ]] || _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$keep_model"
 }
 
 _ensure_api_key() {
@@ -871,10 +961,11 @@ _ensure_api_key() {
     fi
 
     if [[ "$switching_from_local" -eq 1 ]]; then
-        local local_var
-        for local_var in LLM_PROVIDER SHELLM_API_URL LLM_API_URL LLM_API_KEY SHELLM_MODEL; do
-            _env_unset "$HEADLONG_HOME/.env" "$local_var"
-        done
+        # Clear the local provider for THIS process so the check below dials
+        # the cloud provider — but leave .env alone until a cloud key has
+        # actually validated (_commit_local_wipe). Dying between a wipe and
+        # a working key would strand the box with no provider at all.
+        unset LLM_PROVIDER SHELLM_API_URL LLM_API_URL LLM_API_KEY SHELLM_MODEL
     fi
 
     if ! _have_key && [[ "$HAS_TTY" -eq 0 ]]; then
@@ -900,9 +991,15 @@ EOF
 
     # A predictable default model keeps first-run spend sane (the thinkers
     # otherwise default to an expensive model). Never overrides an existing
-    # SHELLM_MODEL from the env or either .env file.
+    # SHELLM_MODEL from the env or either .env file. Mid-switch it stays
+    # in-process only: nothing may touch .env before the key validates.
     if [[ -z "${SHELLM_MODEL:-}" ]]; then
-        _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$(_default_model_for "$(_first_key_var)")"
+        if [[ "$switching_from_local" -eq 1 ]]; then
+            SHELLM_MODEL="$(_default_model_for "$(_first_key_var)")"
+            export SHELLM_MODEL
+        else
+            _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$(_default_model_for "$(_first_key_var)")"
+        fi
     fi
 
     # A default identity means an earlier init already validated a key.
@@ -917,6 +1014,7 @@ EOF
         info "Checking the LLM connection (model: ${SHELLM_MODEL})"
         if _llm_ok; then
             echo "    OK — ${SHELLM_MODEL} answered."
+            [[ "$switching_from_local" -eq 0 ]] || _commit_local_wipe
             return 0
         fi
         var=$(_first_key_var || true)
@@ -933,6 +1031,7 @@ EOF
     done
     if [[ "$revalidating" -eq 1 ]]; then
         echo "headlong-init: continuing anyway — this key worked before, so the API may just be having a moment" >&2
+        [[ "$switching_from_local" -eq 0 ]] || _commit_local_wipe
         return 0
     fi
     die "could not validate an API key after 3 attempts"

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -127,7 +127,8 @@ ask() {
     printf '%s' "${reply:-$def}"
 }
 
-ask_yn() {  # ask_yn <prompt> — succeeds unless the answer starts with n/N
+ask_yn() {  # ask_yn <prompt> — succeeds unless the answer starts with n/N.
+    # The [Y/n] hint is appended here; pass <prompt> WITHOUT one.
     local reply
     reply=$(ask "$1 [Y/n]" "y")
     [[ ! "$reply" =~ ^[Nn] ]]
@@ -756,7 +757,7 @@ _ask_local_or_cloud() {
     # a cloud key. No tty means no asking — fall through to the key checks
     # (which die with a clear message when there is no key and no server).
     if [[ "$HAS_TTY" -eq 1 ]]; then
-        ask_yn "Use a local model server (Ollama, LM Studio, vLLM; no API key)? [y/N]" && return 0
+        ask_yn "Use a local model server (Ollama, LM Studio, vLLM; no API key)?" && return 0
         return 1
     fi
     # No tty: only an already-configured local endpoint (a re-run, an env

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -365,6 +365,7 @@ _key_var_unambiguous() {  # the ONLY provider var a key's prefix can belong to
 }
 
 _reconcile_key_vars() {
+    local persist="${1:-1}"
     # A key exported into the wrong provider variable -- an sk-or- OpenRouter
     # key sitting in OPENAI_API_KEY, say -- otherwise picks that variable's
     # default model (gpt-5.5), which detect_provider maps to openai, so the
@@ -389,15 +390,26 @@ _reconcile_key_vars() {
         fi
         printf 'headlong-init: warning: %s holds a key whose prefix belongs to %s; using it as %s.\n' \
             "$var" "$want" "$want" >&2
-        # Persist, not just export: later processes (tools/persona, bin/llm
-        # from a fresh shell) must see the same key the model default was
-        # derived from. _env_set also exports it here. Reconciliation runs
-        # only past the --dry-run exit, so the dry-run echo cannot print a key.
-        _env_set "$HEADLONG_HOME/.env" "$want" "${!var}"
+        # Persist on an ordinary setup so later processes see the corrected
+        # variable. During a local-to-cloud switch, stage the correction in
+        # this process only: the working local .env remains byte-for-byte
+        # intact until the cloud handshake succeeds.
+        if [[ "$persist" -eq 1 ]]; then
+            _env_set "$HEADLONG_HOME/.env" "$want" "${!var}"
+        else
+            export "$want=${!var}"
+            _STAGED_CLOUD_KEY_VAR="$want"
+            _STAGED_CLOUD_KEY_VALUE="${!var}"
+        fi
         # A SHELLM_MODEL pinned earlier from the misfiled variable's default
         # would keep routing to the wrong provider; follow the key.
         if [[ "${SHELLM_MODEL:-}" == "$(_default_model_for "$var")" ]]; then
-            _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$(_default_model_for "$want")"
+            if [[ "$persist" -eq 1 ]]; then
+                _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$(_default_model_for "$want")"
+            else
+                SHELLM_MODEL="$(_default_model_for "$want")"
+                export SHELLM_MODEL
+            fi
         fi
     done
 }
@@ -431,8 +443,21 @@ _llm_ok() {
     llm -t 256 "Reply with the single word: ok" >/dev/null 2>>"$INIT_LOG"
 }
 
+_cloud_llm_ok() {
+    # bin/llm fills variables that are UNSET from the saved state .env. Keep
+    # these variables present but empty so an explicit cloud switch cannot
+    # silently reload the old openai-compatible provider, URL, or local key.
+    # A subshell keeps the masking scoped to this one validation call.
+    (
+        export LLM_PROVIDER="" SHELLM_API_URL="" LLM_API_URL="" LLM_API_KEY=""
+        _llm_ok
+    )
+}
+
+_STAGED_CLOUD_KEY_VAR=""
+_STAGED_CLOUD_KEY_VALUE=""
 _prompt_key() {
-    local key="" var="" tries=0
+    local persist="${1:-1}" key="" var="" tries=0
     # Empty input (a stray Enter, a paste that didn't take) just asks again;
     # Ctrl-C or Ctrl-D (EOF on the tty) gives up.
     while [[ -z "$key" ]]; do
@@ -474,10 +499,21 @@ _prompt_key() {
             *) var=ANTHROPIC_API_KEY ;;
         esac
     fi
-    _env_set "$HEADLONG_HOME/.env" "$var" "$key"
-    # Pin the model to this key's provider so a stale key for another
-    # provider's default can't shadow the one we just validated.
-    _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$(_default_model_for "$var")"
+    if [[ "$persist" -eq 1 ]]; then
+        _env_set "$HEADLONG_HOME/.env" "$var" "$key"
+        # Pin the model to this key's provider so a stale key for another
+        # provider's default can't shadow the one we just validated.
+        _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$(_default_model_for "$var")"
+    else
+        # A prompted key would otherwise be lost when this init exits. Stage
+        # it until validation, then _commit_local_wipe persists it as part of
+        # the provider switch.
+        export "$var=$key"
+        SHELLM_MODEL="$(_default_model_for "$var")"
+        export SHELLM_MODEL
+        _STAGED_CLOUD_KEY_VAR="$var"
+        _STAGED_CLOUD_KEY_VALUE="$key"
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -522,7 +558,8 @@ _LOCAL_MODELS=""
 _local_models_get() {
     _local_models_err=""
     _LOCAL_MODELS=""
-    local url="$1" key="$2" body err body_file auth_file="" status rc
+    local url="$1" key="$2" body err body_file auth_file="" status rc safe_url
+    safe_url=$(_url_safe_display "$url")
     err=$(mktemp)
     body_file=$(mktemp)
     local -a curl_args=(-sS --max-time 10 -o "$body_file" -w '%{http_code}')
@@ -543,13 +580,16 @@ _local_models_get() {
     rc=$?
     [[ -z "$auth_file" ]] || rm -f "$auth_file"
     if [[ "$rc" -ne 0 ]]; then
-        _local_models_err="could not reach $url ($(head -c 200 "$err" | tr -d '\n'))"
+        # curl diagnostics may repeat a credential-bearing URL. The status
+        # is enough here; never copy the raw URL or stderr into terminal/CI
+        # output.
+        _local_models_err="could not reach $safe_url"
         rm -f "$err" "$body_file"
         return "$rc"
     fi
     rm -f "$err"
     if [[ ! "$status" =~ ^2[0-9][0-9]$ ]]; then
-        _local_models_err="$url/models returned HTTP ${status:-unknown}"
+        _local_models_err="$safe_url/models returned HTTP ${status:-unknown}"
         rm -f "$body_file"
         return 1
     fi
@@ -560,7 +600,7 @@ _local_models_get() {
     # is a protocol failure, while a present-but-EMPTY list is a healthy
     # server with no models pulled yet (_LOCAL_MODELS="", rc 0).
     if ! printf '%s' "$body" | jq -e '.data | type == "array"' >/dev/null 2>&1; then
-        _local_models_err="$url did not return a model list (is it an OpenAI-compatible server?)"
+        _local_models_err="$safe_url did not return a model list (is it an OpenAI-compatible server?)"
         return 1
     fi
     _LOCAL_MODELS=$(printf '%s' "$body" | jq -r '.data[]?.id // empty' 2>/dev/null)
@@ -569,9 +609,19 @@ _local_models_get() {
 # _prompt_local_url <default> — ask until the URL answers, on a tty; one try
 # with the default (or env value) when there is none.
 _prompt_local_url() {
-    local def="$1" url
+    local def="$1" url reply prompt="Server address as your agent will reach it (e.g. http://localhost:1234 or http://192.168.3.23:1234; /v1 is added if missing)"
     while :; do
-        url=$(ask "Server address as your agent will reach it (e.g. http://localhost:1234 or http://192.168.3.23:1234; /v1 is added if missing)" "$def")
+        if [[ "$HAS_TTY" -eq 1 ]]; then
+            if [[ -n "$def" ]]; then
+                printf '%s [%s]: ' "$prompt" "$(_url_safe_display "$def")" >/dev/tty
+            else
+                printf '%s: ' "$prompt" >/dev/tty
+            fi
+            IFS= read -r reply </dev/tty || reply=""
+            url="${reply:-$def}"
+        else
+            url="$def"
+        fi
         [[ -n "$url" ]] || { def=""; continue; }
         printf '%s' "$url"
         return 0
@@ -603,6 +653,19 @@ _url_host() {
         \[*\]*) hostport="${hostport#\[}"; printf '%s' "${hostport%%]*}" ;;
         *)      printf '%s' "${hostport%%:*}" ;;
     esac
+}
+
+# _url_safe_display <url> — retain the useful server location while dropping
+# userinfo, query parameters, and fragments, all of which may carry secrets.
+_url_safe_display() {
+    local url="$1" rest="${1#*://}" scheme=""
+    [[ "$rest" == "$url" ]] || scheme="${url%%://*}://"
+    local authority="${rest%%[/?#]*}"
+    local hostport="${authority##*@}"
+    local tail="${rest#"$authority"}"
+    tail="${tail%%\?*}"
+    tail="${tail%%#*}"
+    printf '%s%s%s' "$scheme" "$hostport" "$tail"
 }
 
 # _url_host_swap <url> <newhost> — replace ONLY the authority's host,
@@ -864,7 +927,7 @@ EOF
     if [[ "$IN_CONTAINER" -eq 1 ]] && _url_is_loopback "$chat"; then
         local container_chat
         container_chat=$(_local_container_url "$chat")
-        echo "    Container install: the agent reaches the server at $container_chat (was $chat)."
+        echo "    Container install: the agent reaches the server at $(_url_safe_display "$container_chat") (was $(_url_safe_display "$chat"))."
         chat="$container_chat"
     fi
 
@@ -875,7 +938,7 @@ EOF
     # inline — an explicitly empty LLM_API_KEY keeps a stale one in the
     # .env files from riding along. The init process probes through its own
     # network view.
-    info "Checking the LLM connection (model: $chosen at $base)"
+    info "Checking the LLM connection (model: $chosen at $(_url_safe_display "$base"))"
     if ! LLM_PROVIDER="openai-compatible" SHELLM_MODEL="$chosen" \
             LLM_API_KEY="$key" LLM_API_URL="$(_local_probe_url "$chat")" _llm_ok; then
         die "the endpoint did not answer a chat completion (models list worked, chat did not); nothing was saved. Details: $INIT_LOG"
@@ -932,19 +995,20 @@ _ask_local_or_cloud() {
 
 # _commit_local_wipe — remove a saved local provider from .env, keeping the
 # cloud model chosen for this run. Called only once a cloud key has actually
-# answered (or answered before, on a revalidating re-run): committing the
-# switch any earlier could destroy the only working configuration.
+# answered: committing the switch any earlier could destroy the only working
+# configuration.
 _commit_local_wipe() {
     local keep_model="${SHELLM_MODEL:-}" local_var
     for local_var in LLM_PROVIDER SHELLM_API_URL LLM_API_URL LLM_API_KEY SHELLM_MODEL; do
         _env_unset "$HEADLONG_HOME/.env" "$local_var"
     done
+    if [[ -n "$_STAGED_CLOUD_KEY_VAR" ]]; then
+        _env_set "$HEADLONG_HOME/.env" "$_STAGED_CLOUD_KEY_VAR" "$_STAGED_CLOUD_KEY_VALUE"
+    fi
     [[ -z "$keep_model" ]] || _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$keep_model"
 }
 
 _ensure_api_key() {
-    _reconcile_key_vars
-
     # An explicit cloud choice replaces a saved local provider. Clear the
     # local URL, optional key, and model before selecting the cloud default.
     local switching_from_local=0
@@ -952,6 +1016,7 @@ _ensure_api_key() {
             && "${LLM_PROVIDER:-}" == "openai-compatible" ]]; then
         switching_from_local=1
     fi
+    _reconcile_key_vars "$((1 - switching_from_local))"
 
     # Re-runs with a working local endpoint already configured stay on it;
     # otherwise offer the local path before demanding a cloud key.
@@ -986,7 +1051,7 @@ Paste just the key itself; headlong-init figures out the provider from it.
   * If the key runs out of credit, `ada status` and the dash say so.
 
 EOF
-        _prompt_key || die "no key entered (quit)"
+        _prompt_key "$((1 - switching_from_local))" || die "no key entered (quit)"
     fi
 
     # A predictable default model keeps first-run spend sane (the thinkers
@@ -1007,12 +1072,15 @@ EOF
     # attached) must then never die or block on a prompt over what may be
     # a transient API failure.
     local revalidating=0
-    [[ -L "$APP_DIR/.identities/default" ]] && revalidating=1
+    if [[ "$switching_from_local" -eq 0 && -L "$APP_DIR/.identities/default" ]]; then
+        revalidating=1
+    fi
 
     local _ var
     for _ in 1 2 3; do
         info "Checking the LLM connection (model: ${SHELLM_MODEL})"
-        if _llm_ok; then
+        if { [[ "$switching_from_local" -eq 1 ]] && _cloud_llm_ok; } \
+                || { [[ "$switching_from_local" -eq 0 ]] && _llm_ok; }; then
             echo "    OK — ${SHELLM_MODEL} answered."
             [[ "$switching_from_local" -eq 0 ]] || _commit_local_wipe
             return 0
@@ -1027,11 +1095,10 @@ EOF
         [[ "$HAS_TTY" -eq 1 ]] || die "LLM check failed with the configured key"
         echo >&2
         echo "Paste a different key to try again, or press Ctrl-C to quit." >&2
-        _prompt_key || die "no key entered (quit)"
+        _prompt_key "$((1 - switching_from_local))" || die "no key entered (quit)"
     done
-    if [[ "$revalidating" -eq 1 ]]; then
+    if [[ "$revalidating" -eq 1 && "$switching_from_local" -eq 0 ]]; then
         echo "headlong-init: continuing anyway — this key worked before, so the API may just be having a moment" >&2
-        [[ "$switching_from_local" -eq 0 ]] || _commit_local_wipe
         return 0
     fi
     die "could not validate an API key after 3 attempts"

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -424,6 +424,8 @@ _prompt_key() {
             tries=$((tries+1))
             [[ "$tries" -ge 5 ]] && return 1
             echo "  Nothing entered. Paste the key and press Enter, or Ctrl-C to quit." >/dev/tty
+            echo "  (If you meant to use a local model server instead, re-run and answer 'y'" >/dev/tty
+            echo "   at the 'Use a local model server?' prompt.)" >/dev/tty
         fi
     done
     var=$(_key_var_for "$key")

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -23,6 +23,15 @@ set -euo pipefail
 #   HEADLONG_NO_DASH=1       don't start the web dash
 #   HEADLONG_WEB_ARGS        extra args for headlong-web (e.g. "--host 0.0.0.0"
 #                          to reach the dash through a Docker port mapping)
+#   HEADLONG_PROVIDER        "cloud" (default: pick a provider from an API
+#                          key) or "local" (OpenAI-compatible endpoint: ask
+#                          for a URL + optional key, verify with /v1/models,
+#                          pick the model from that list)
+#   HEADLONG_LOCAL_URL       endpoint for the local provider (skips the URL
+#                          prompt; e.g. http://localhost:11434/v1)
+#   HEADLONG_LOCAL_API_KEY   bearer token for the local endpoint, when it
+#                          wants one (LM Studio and router proxies often do)
+#   HEADLONG_LOCAL_MODEL     model to pin (skips the model-picker prompt)
 #
 # --dry-run walks the Docker sandbox gate interactively, writes nothing,
 # starts nothing, and exits. Pair with HEADLONG_FAKE_DOCKER=ok|down|missing
@@ -286,7 +295,14 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# API key: find one, or ask for one, and prove it works
+# Model backend: a cloud provider keyed by an API key, or a local
+# OpenAI-compatible endpoint (Ollama, LM Studio, vLLM, llama.cpp, a router
+# proxy). Everything downstream only cares that bin/llm can serve a
+# completion, so both paths end in the same place: a working model and,
+# for the local path, a provider + URL (+ optional key) persisted in .env.
+#
+# The local path never auto-detects (design/providers.md: arbitrary model
+# names imply nothing), so it is always an explicit choice.
 # ---------------------------------------------------------------------------
 
 _have_key() {
@@ -392,55 +408,285 @@ _llm_ok() {
     llm -t 256 "Reply with the single word: ok" >/dev/null 2>>"$INIT_LOG"
 }
 
-_prompt_key() {
-    local key="" var="" tries=0
-    # Empty input (a stray Enter, a paste that didn't take) just asks again;
-    # Ctrl-C or Ctrl-D (EOF on the tty) gives up.
-    while [[ -z "$key" ]]; do
-        printf 'Paste your API key (input hidden; Ctrl-C to quit): ' >/dev/tty
-        if ! IFS= read -rs key </dev/tty; then
-            printf '\n' >/dev/tty
-            return 1
-        fi
-        printf '\n' >/dev/tty
-        key="${key//[[:space:]]/}"   # trailing newline/space from a paste
-        if [[ -z "$key" ]]; then
-            tries=$((tries+1))
-            [[ "$tries" -ge 5 ]] && return 1
-            echo "  Nothing entered. Paste the key and press Enter, or Ctrl-C to quit." >/dev/tty
-        fi
-    done
-    var=$(_key_var_for "$key")
-    if [[ "$key" == sk-* && "$key" != sk-ant-* && "$key" != sk-or-* ]]; then
-        # OpenAI and OpenCode keys share the bare sk- prefix, and a wrong
-        # guess sends the handshake to api.openai.com where it fails
-        # confusingly. Ask rather than guess; OpenAI stays the default so
-        # the common case is just Enter.
-        local which
-        which=$(ask "Is that an OpenAI or an OpenCode key? (1) OpenAI (2) OpenCode" "1")
-        case "$which" in
-            2) var=OPENCODE_API_KEY ;;
-            *) var=OPENAI_API_KEY ;;
-        esac
-    elif [[ -z "$var" ]]; then
-        local which
-        which=$(ask "Which provider is that key for? (1) Anthropic (2) OpenAI (3) Gemini (4) OpenRouter (5) OpenCode" "1")
-        case "$which" in
-            2) var=OPENAI_API_KEY ;;
-            3) var=GEMINI_API_KEY ;;
-            4) var=OPENROUTER_API_KEY ;;
-            5) var=OPENCODE_API_KEY ;;
-            *) var=ANTHROPIC_API_KEY ;;
-        esac
+# ---------------------------------------------------------------------------
+# Local (OpenAI-compatible) endpoint setup
+# ---------------------------------------------------------------------------
+# bin/llm's openai-compatible provider takes the full chat-completions URL
+# (LLM_API_URL / SHELLM_API_URL), while servers advertise their base URL
+# (/v1). Operators think in base URLs, so accept either: anything already
+# ending in /chat/completions is left alone; anything else gets
+# /chat/completions appended. /v1/models is always probed at the BASE url.
+
+_local_base_url() {  # base URL (for /v1/models) from whatever was given
+    local url="$1"
+    url="${url%/}"
+    url="${url%/chat/completions}"
+    printf '%s' "$url"
+}
+
+_local_chat_url() {  # chat-completions URL from whatever was given
+    local url="$1"
+    url="${url%/}"
+    case "$url" in
+        */chat/completions) printf '%s' "$url" ;;
+        *)                  printf '%s/chat/completions' "$url" ;;
+    esac
+}
+
+# _local_models_get <base-url> <key> — fetch GET <base>/models. On success
+# sets _LOCAL_MODELS to the model ids, one per line (empty means the server
+# exposed no models), and returns 0. On failure sets _local_models_err —
+# "could not reach ..." when the server is unreachable, a parse complaint
+# when it answered with something else — and returns nonzero. Globals rather
+# than stdout because callers need the error message after a failure, which
+# a command substitution cannot carry back.
+_local_models_err=""
+_LOCAL_MODELS=""
+_local_models_get() {
+    _local_models_err=""
+    _LOCAL_MODELS=""
+    local url="$1" key="$2" body err rc
+    local -a curl_args=(fsS --max-time 10 "$url/models")
+    [[ -z "$key" ]] || curl_args+=(-H "Authorization: Bearer $key")
+    err=$(mktemp)
+    body=$(curl "${curl_args[@]}" 2>"$err")
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        _local_models_err="could not reach $url ($(head -c 200 "$err" | tr -d '\n'))"
+        rm -f "$err"
+        return "$rc"
     fi
-    _env_set "$HEADLONG_HOME/.env" "$var" "$key"
-    # Pin the model to this key's provider so a stale key for another
-    # provider in the env can't shadow the one we just validated.
-    _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$(_default_model_for "$var")"
+    rm -f "$err"
+    # The OpenAI ListModels shape is {"data":[{"id":...},...]}; jq -e makes a
+    # missing/broken body a loud failure instead of an empty, plausible list.
+    if ! _LOCAL_MODELS=$(printf '%s' "$body" | jq -r -e '.data[]?.id // empty' 2>/dev/null); then
+        _local_models_err="$url did not return a model list (is it an OpenAI-compatible server?)"
+        return 1
+    fi
+}
+
+# _prompt_local_url <default> — ask until the URL answers, on a tty; one try
+# with the default (or env value) when there is none.
+_prompt_local_url() {
+    local def="$1" url
+    while :; do
+        url=$(ask "Base URL of your OpenAI-compatible server (Ollama: http://localhost:11434/v1)" "$def")
+        [[ -n "$url" ]] || { def=""; continue; }
+        printf '%s' "$url"
+        return 0
+    done
+}
+
+# _prompt_local_key — hidden-input key prompt; empty input means "no key".
+_prompt_local_key() {
+    local key=""
+    if [[ "$HAS_TTY" -eq 0 ]]; then return 0; fi
+    printf 'API key for the server, if it wants one (Enter for none; input hidden): ' >/dev/tty
+    if ! IFS= read -rs key </dev/tty; then
+        printf '\n' >/dev/tty
+        return 0
+    fi
+    printf '\n' >/dev/tty
+    key="${key//[[:space:]]/}"
+    printf '%s' "$key"
+}
+
+# _pick_from_list <prompt> <one-choice-per-line> [default] — numbered menu on
+# the tty; empty reply keeps the default, a number picks from the list, and
+# anything else is taken as a literal model name (servers with hundreds of
+# entries are easier to type at than to page through).
+_pick_from_list() {
+    local prompt="$1" list="$2" def="${3:-}" reply
+    local count
+    count=$(printf '%s\n' "$list" | grep -c .)
+    printf '\n%s — %d available:\n' "$prompt" "$count" >/dev/tty
+    local i=0
+    while IFS= read -r m; do
+        [[ -n "$m" ]] || continue
+        i=$((i + 1))
+        if [[ -n "$def" && "$m" == "$def" ]]; then
+            printf '  %3d) %s   (current)\n' "$i" "$m" >/dev/tty
+        else
+            printf '  %3d) %s\n' "$i" "$m" >/dev/tty
+        fi
+    done <<<"$list"
+    while :; do
+        if [[ -n "$def" ]]; then
+            printf '%s [number, a name, or Enter for %s]: ' "$prompt" "$def" >/dev/tty
+        else
+            printf '%s [number or name]: ' "$prompt" >/dev/tty
+        fi
+        IFS= read -r reply </dev/tty || reply=""
+        reply="${reply//[[:space:]]/}"
+        if [[ -z "$reply" ]]; then
+            [[ -n "$def" ]] && { printf '%s' "$def"; return 0; }
+            continue
+        fi
+        if [[ "$reply" =~ ^[0-9]+$ ]]; then
+            local picked
+            picked=$(printf '%s\n' "$list" | grep -v '^$' | sed -n "${reply}p")
+            if [[ -n "$picked" ]]; then
+                printf '%s' "$picked"
+                return 0
+            fi
+            echo "  No such entry (1-$count)." >/dev/tty
+            continue
+        fi
+        printf '%s' "$reply"
+        return 0
+    done
+}
+
+# _setup_local_llm — the whole local path. Sets LLM_PROVIDER,
+# SHELLM_API_URL, LLM_API_KEY (when given) and SHELLM_MODEL, persists them,
+# and proves the whole chain with a real completion through bin/llm.
+_setup_local_llm() {
+    local base chat key models chosen url_env="${HEADLONG_LOCAL_URL:-${SHELLM_API_URL:-${LLM_API_URL:-}}}"
+    local key_env="${HEADLONG_LOCAL_API_KEY:-${LLM_API_KEY:-}}"
+    local model_env="${HEADLONG_LOCAL_MODEL:-${SHELLM_MODEL:-}}"
+
+    if [[ "$HAS_TTY" -eq 1 ]]; then
+        cat >/dev/tty <<'EOF'
+
+Local model server (Ollama, LM Studio, vLLM, llama.cpp, ...). Headlong
+talks to it through its OpenAI-compatible chat API; no cloud API key is
+needed, and the agent's completions all stay on this machine or your
+network. The server must already be running — Headlong never installs
+one or pulls models.
+
+EOF
+    fi
+
+    # --- URL -----------------------------------------------------------------
+    # No-tty: HEADLONG_LOCAL_URL (or an inherited URL) is required — there is
+    # no one to ask and no trustworthy default port (every server differs).
+    # A server that is DOWN is a hard error (starting the mind against it
+    # just fails later, unattended); a server that answers but exposes no
+    # model list (some proxies) only warns.
+    if [[ "$HAS_TTY" -eq 0 ]]; then
+        [[ -n "$url_env" ]] || die "local provider selected with no URL. Set HEADLONG_LOCAL_URL (e.g. http://localhost:11434/v1)"
+        base=$(_local_base_url "$url_env")
+        key="$key_env"
+        if ! _local_models_get "$base" "$key"; then
+            if [[ -n "$_local_models_err" && "$_local_models_err" == could\ not\ reach* ]]; then
+                die "local endpoint unreachable: $_local_models_err. Start the server and re-run headlong-init."
+            fi
+            echo "headlong-init: warning: could not list models: $_local_models_err" >&2
+            echo "headlong-init: continuing with the given URL — set HEADLONG_LOCAL_MODEL if the model name is not already pinned" >&2
+        fi
+    else
+        # A tty: default to the env/inherited value; otherwise suggest Ollama's
+        # — the common case — and let the operator correct it.
+        local def_url="${url_env:-http://localhost:11434/v1}"
+        base=""
+        while :; do
+            url_env=$(_prompt_local_url "$def_url")
+            base=$(_local_base_url "$url_env")
+            key="$key_env"
+            if [[ -z "$key" ]]; then
+                key=$(_prompt_local_key)
+            fi
+            if _local_models_get "$base" "$key"; then
+                break
+            fi
+            echo "  Could not list models: $_local_models_err" >/dev/tty
+            if ! ask_yn "Try a different URL/key?"; then
+                die "local endpoint unreachable. Start the server and re-run headlong-init."
+            fi
+            def_url="$url_env"
+        done
+    fi
+
+    # --- model ---------------------------------------------------------------
+    # The model comes from the server's own list (the point of this flow:
+    # local model names are arbitrary, so guessing one is how setups break).
+    models="$_LOCAL_MODELS"
+    if [[ -n "$models" ]]; then
+        if [[ "$HAS_TTY" -eq 1 ]]; then
+            chosen=$(_pick_from_list "Model to run your agent on" "$models" "${model_env:-}")
+        else
+            chosen="${model_env:-$(printf '%s\n' "$models" | head -1)}"
+        fi
+    else
+        # A server may hide /v1/models (some proxies do) while chat still
+        # works; accept an explicit model rather than dying.
+        chosen="${model_env:-}"
+        if [[ -z "$chosen" ]]; then
+            if [[ "$HAS_TTY" -eq 1 ]]; then
+                chosen=$(ask "The server did not expose a model list. Type the model name to use")
+                [[ -n "$chosen" ]] || die "no model given"
+            else
+                die "no model: the server exposed no model list. Set HEADLONG_LOCAL_MODEL."
+            fi
+        fi
+    fi
+    [[ -n "$chosen" ]] || die "no model selected"
+
+    chat=$(_local_chat_url "$url_env")
+    _env_set "$HEADLONG_HOME/.env" "LLM_PROVIDER" "openai-compatible"
+    _env_set "$HEADLONG_HOME/.env" "SHELLM_API_URL" "$chat"
+    if [[ -n "$key" ]]; then
+        _env_set "$HEADLONG_HOME/.env" "LLM_API_KEY" "$key"
+    else
+        # An old key would ride along to the new endpoint; the openai-compat
+        # provider must be keyless here, not mis-keyed.
+        if grep -q '^LLM_API_KEY=' "$HEADLONG_HOME/.env" 2>/dev/null; then
+            local tmp
+            tmp=$(mktemp)
+            grep -v '^LLM_API_KEY=' "$HEADLONG_HOME/.env" > "$tmp" || true
+            cat "$tmp" > "$HEADLONG_HOME/.env"
+            rm -f "$tmp"
+            unset LLM_API_KEY
+        fi
+    fi
+    _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$chosen"
+
+    # Prove the whole chain with a real completion (bin/llm reads the same
+    # .env; this is the same handshake a thinker will make).
+    info "Checking the LLM connection (model: $chosen at $base)"
+    if _llm_ok; then
+        echo "    OK — $chosen answered."
+        return 0
+    fi
+    die "the endpoint did not answer a chat completion (models list worked, chat did not). Details: $INIT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Provider selection: local vs cloud. Cloud needs an API key; local needs a
+# reachable OpenAI-compatible endpoint. The choice is explicit, never
+# inferred: silent inference is how a keyless box quietly picks a default.
+# ---------------------------------------------------------------------------
+
+# _ask_local_or_cloud — 1 = local, 0 = cloud. Preceded by env and by a
+# usable local endpoint already in the state .env (a re-run re-checks it
+# rather than re-asking), and defaults to cloud when a key is present.
+_ask_local_or_cloud() {
+    [[ "${HEADLONG_PROVIDER:-}" == "local" ]] && return 0
+    [[ "${HEADLONG_PROVIDER:-}" == "cloud" ]] && return 1
+    # Nothing in the environment. A configured-but-unverified local endpoint
+    # (a re-run, an env carried from another setup) is worth one probe before
+    # falling through to the key prompts.
+    local probe_url="${SHELLM_API_URL:-${LLM_API_URL:-}}"
+    [[ -n "$probe_url" && -n "${LLM_PROVIDER:-}" && "$LLM_PROVIDER" == "openai-compatible" ]] || return 1
+    # Only worth asking about when the endpoint still answers; a dead one
+    # falls through to the ordinary prompts (and HEADLONG_PROVIDER=local
+    # above forces the repair path regardless).
+    _local_models_get "$(_local_base_url "$probe_url")" "${LLM_API_KEY:-}" >/dev/null 2>&1 || return 1
+    [[ "$HAS_TTY" -eq 0 ]] && return 0
+    ask_yn "Keep using the local model server at ${probe_url}? [Y/n]" && return 0
+    return 1
 }
 
 _ensure_api_key() {
     _reconcile_key_vars
+
+    # Re-runs with a working local endpoint already configured stay on it;
+    # otherwise offer the local path before demanding a cloud key.
+    if _ask_local_or_cloud; then
+        _setup_local_llm
+        return 0
+    fi
+
     if ! _have_key && [[ "$HAS_TTY" -eq 0 ]]; then
         die "no API key found. Set ANTHROPIC_API_KEY (or OPENAI/GEMINI/OPENROUTER/OPENCODE_API_KEY), or put it in $HEADLONG_HOME/.env"
     fi
@@ -870,7 +1116,8 @@ case "${1:-}" in
     --dry-run)
         DRY_RUN=1
         ;;
-    "") ;;
+    "")
+        ;;
     *)
         die "unknown option: $1 (try --help)"
         ;;

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -109,6 +109,7 @@ if [[ "${HEADLONG_NO_TTY:-0}" == "1" ]]; then HAS_TTY=0; fi
 # through a port mapping. Explicit HEADLONG_WEB_ARGS still wins.
 IN_CONTAINER=0
 [[ -f /.dockerenv || -f /run/.containerenv ]] && IN_CONTAINER=1
+[[ "${HEADLONG_FAKE_CONTAINER:-0}" == "1" ]] && IN_CONTAINER=1
 if [[ "$IN_CONTAINER" -eq 1 && -z "${HEADLONG_WEB_ARGS:-}" ]]; then
     HEADLONG_WEB_ARGS="--host 0.0.0.0"
 fi
@@ -185,6 +186,23 @@ _env_set() {
     fi
     printf '%s=%s\n' "$key" "$val" >> "$file"
     export "$key=$val"
+}
+
+# _env_unset <file> <key> — remove KEY from an env file and this process.
+_env_unset() {
+    local file="$1" key="$2" tmp
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "    dry-run: would remove $key from $file"
+        unset "$key"
+        return 0
+    fi
+    if [[ -f "$file" ]] && grep -q "^${key}=" "$file" 2>/dev/null; then
+        tmp=$(mktemp)
+        grep -v "^${key}=" "$file" > "$tmp" || true
+        cat "$tmp" > "$file"
+        rm -f "$tmp"
+    fi
+    unset "$key"
 }
 
 # ---------------------------------------------------------------------------
@@ -500,18 +518,40 @@ _LOCAL_MODELS=""
 _local_models_get() {
     _local_models_err=""
     _LOCAL_MODELS=""
-    local url="$1" key="$2" body err rc
-    local -a curl_args=(fsS --max-time 10 "$url/models")
-    [[ -z "$key" ]] || curl_args+=(-H "Authorization: Bearer $key")
+    local url="$1" key="$2" body err body_file auth_file="" status rc
+    local -a curl_args=(-sS --max-time 10 -o "" -w '%{http_code}')
     err=$(mktemp)
-    body=$(curl "${curl_args[@]}" 2>"$err")
+    body_file=$(mktemp)
+    curl_args[4]="$body_file"
+    if [[ -n "$key" ]]; then
+        local header="Authorization: Bearer $key"
+        header="${header//\\/\\\\}"
+        header="${header//\"/\\\"}"
+        header="${header//$'\t'/\\t}"
+        header="${header//$'\n'/\\n}"
+        header="${header//$'\r'/\\r}"
+        header="${header//$'\v'/\\v}"
+        auth_file=$(mktemp "${TMPDIR:-/tmp}/headlong-init-auth.XXXXXX")
+        chmod 600 "$auth_file" 2>/dev/null || true
+        printf 'header = "%s"\n' "$header" > "$auth_file"
+        curl_args+=(-K "$auth_file")
+    fi
+    status=$(curl "${curl_args[@]}" "$url/models" 2>"$err")
     rc=$?
+    [[ -z "$auth_file" ]] || rm -f "$auth_file"
     if [[ "$rc" -ne 0 ]]; then
         _local_models_err="could not reach $url ($(head -c 200 "$err" | tr -d '\n'))"
-        rm -f "$err"
+        rm -f "$err" "$body_file"
         return "$rc"
     fi
     rm -f "$err"
+    if [[ ! "$status" =~ ^2[0-9][0-9]$ ]]; then
+        _local_models_err="$url/models returned HTTP ${status:-unknown}"
+        rm -f "$body_file"
+        return 1
+    fi
+    body=$(cat "$body_file")
+    rm -f "$body_file"
     # The OpenAI ListModels shape is {"data":[{"id":...},...]}; jq -e makes a
     # missing/broken body a loud failure instead of an empty, plausible list.
     if ! _LOCAL_MODELS=$(printf '%s' "$body" | jq -r -e '.data[]?.id // empty' 2>/dev/null); then
@@ -546,14 +586,25 @@ _prompt_local_key() {
     printf '%s' "$key"
 }
 
-# _local_host_url <url> — the HOST-side twin of a container-reachable URL.
-# host.docker.internal names the host from inside Docker's VM; on the host
-# itself (where this installer runs) it does not resolve, so a probe against
-# it would always fail even with the server up. Swap it for localhost when
-# probing from here. No sandbox (or a LAN address): returned unchanged.
-_local_host_url() {
+# _local_probe_url <url> — the URL this init process can reach. A host-side
+# installer probes the localhost twin of host.docker.internal. An installer
+# running inside the full Headlong container must keep host.docker.internal,
+# because localhost there means the Headlong container itself.
+_local_probe_url() {
     local url="$1"
-    printf '%s' "${url//host.docker.internal/localhost}"
+    if [[ "$IN_CONTAINER" -eq 0 ]]; then
+        url="${url//host.docker.internal/localhost}"
+    fi
+    printf '%s' "$url"
+}
+
+# _local_container_url <url> — the URL a container uses to reach a model
+# server bound to the machine running Docker.
+_local_container_url() {
+    local url="$1"
+    url="${url//localhost/host.docker.internal}"
+    url="${url//127.0.0.1/host.docker.internal}"
+    printf '%s' "$url"
 }
 
 # _pick_from_list <prompt> <one-choice-per-line> [default] — numbered menu on
@@ -608,7 +659,43 @@ _pick_from_list() {
 _setup_local_llm() {
     local base chat key models chosen url_env="${HEADLONG_LOCAL_URL:-${SHELLM_API_URL:-${LLM_API_URL:-}}}"
     local key_env="${HEADLONG_LOCAL_API_KEY:-${LLM_API_KEY:-}}"
-    local model_env="${HEADLONG_LOCAL_MODEL:-${SHELLM_MODEL:-}}"
+    local model_env="${HEADLONG_LOCAL_MODEL:-}"
+    local revalidating=0
+
+    # Keep a saved local model only when the saved local URL is also being
+    # reused. A cloud model from a checkout .env must not override the model
+    # list returned by a newly selected local server.
+    if [[ -z "$model_env" && -z "${HEADLONG_LOCAL_URL:-}" \
+            && "${LLM_PROVIDER:-}" == "openai-compatible" ]]; then
+        model_env="${SHELLM_MODEL:-}"
+    fi
+
+    # A URL supplied directly to an init process already running in the full
+    # Headlong container needs the Docker host name before the first probe.
+    if [[ "$IN_CONTAINER" -eq 1 ]]; then
+        url_env=$(_local_container_url "$url_env")
+    fi
+
+    # A completed local install must be safe to restart with a tty allocated
+    # and nobody attached. Keep its working configuration without asking the
+    # setup questions again. A transiently stopped server should not prevent
+    # the rest of init from restarting the mind and dashboard.
+    if [[ -L "$APP_DIR/.identities/default" && -n "${SHELLM_API_URL:-}" \
+            && "${LLM_PROVIDER:-}" == "openai-compatible" \
+            && -z "${HEADLONG_PROVIDER:-}" && -z "${HEADLONG_LOCAL_URL:-}" \
+            && -z "${HEADLONG_LOCAL_MODEL:-}" && -z "${HEADLONG_LOCAL_API_KEY:-}" ]]; then
+        revalidating=1
+    fi
+
+    if [[ "$revalidating" -eq 1 ]]; then
+        info "Checking the LLM connection (model: ${SHELLM_MODEL})"
+        if LLM_API_URL="$(_local_probe_url "$SHELLM_API_URL")" _llm_ok; then
+            echo "    OK — ${SHELLM_MODEL} answered."
+        else
+            echo "headlong-init: warning: the existing local model server did not answer; keeping its configuration" >&2
+        fi
+        return 0
+    fi
 
     if [[ "$HAS_TTY" -eq 1 ]]; then
         cat >/dev/tty <<'EOF'
@@ -630,7 +717,7 @@ EOF
     # model list (some proxies) only warns.
     if [[ "$HAS_TTY" -eq 0 ]]; then
         [[ -n "$url_env" ]] || die "local provider selected with no URL. Set HEADLONG_LOCAL_URL (e.g. http://localhost:11434)"
-        base=$(_local_base_url "$(_local_host_url "$url_env")")
+        base=$(_local_base_url "$(_local_probe_url "$url_env")")
         key="$key_env"
         if ! _local_models_get "$base" "$key"; then
             if [[ -n "$_local_models_err" && "$_local_models_err" == could\ not\ reach* ]]; then
@@ -649,7 +736,7 @@ EOF
         base=""
         while :; do
             url_env=$(_prompt_local_url "$def_url")
-            base=$(_local_base_url "$(_local_host_url "$url_env")")
+            base=$(_local_base_url "$(_local_probe_url "$url_env")")
             key="$key_env"
             if [[ -z "$key" ]]; then
                 key=$(_prompt_local_key)
@@ -658,6 +745,10 @@ EOF
                 break
             fi
             echo "  Could not list models: $_local_models_err" >/dev/tty
+            if [[ "$_local_models_err" != could\ not\ reach* ]]; then
+                echo "  The server answered, so you can type a model name instead." >/dev/tty
+                break
+            fi
             if ! ask_yn "Try a different URL/key?"; then
                 die "local endpoint unreachable. Start the server and re-run headlong-init."
             fi
@@ -690,21 +781,19 @@ EOF
     fi
     [[ -n "$chosen" ]] || die "no model selected"
 
-    # Persist the URL the AGENT's runtime will dial. With the Docker sandbox
-    # on (or inside a container), localhost/127.0.0.1 in generated code means
-    # the container, not this machine — rewrite it to host.docker.internal
-    # (Docker Desktop: macOS/Windows; on Linux add --add-host to the sandbox
-    # or give a LAN address). A LAN IP or an explicit host.docker.internal
-    # URL passes through unchanged. Without the sandbox the host URL is the
-    # agent URL and nothing is rewritten.
+    # Persist the URL the main runtime will dial. A host install keeps its
+    # localhost URL because thinkers and ordinary llm calls run on the host;
+    # bin/shellm translates that URL only for code it runs in its Docker
+    # sandbox. A full Headlong container needs host.docker.internal here
+    # because its main runtime is already inside Docker.
     chat=$(_local_chat_url "$url_env")
-    if [[ "${SHELLM_REQUIRE_DOCKER:-0}" == "1" || "$IN_CONTAINER" -eq 1 ]]; then
+    if [[ "$IN_CONTAINER" -eq 1 ]]; then
         case "$chat" in
             *//localhost:*|*//localhost/*|*//127.0.0.1:*)
-                local host_chat="${chat//localhost/host.docker.internal}"
-                host_chat="${host_chat//127.0.0.1/host.docker.internal}"
-                echo "    Sandbox is on: the agent reaches the server at $host_chat (was $chat)."
-                chat="$host_chat"
+                local container_chat
+                container_chat=$(_local_container_url "$chat")
+                echo "    Container install: the agent reaches the server at $container_chat (was $chat)."
+                chat="$container_chat"
                 ;;
         esac
     fi
@@ -728,12 +817,9 @@ EOF
 
     # Prove the whole chain with a real completion (bin/llm reads the same
     # .env; this is the same handshake a thinker will make). When the
-    # persisted URL is the container form (host.docker.internal), override
-    # LLM_API_URL with its localhost twin for THIS host-side check — the
-    # name only resolves inside containers, and the twin was already
-    # proven reachable by the models probe above.
+    # Use the same network view as the init process for the final check.
     info "Checking the LLM connection (model: $chosen at $base)"
-    if LLM_API_URL="$(_local_host_url "$chat")" _llm_ok; then
+    if LLM_API_URL="$(_local_probe_url "$chat")" _llm_ok; then
         echo "    OK — $chosen answered."
         return 0
     fi
@@ -753,31 +839,42 @@ EOF
 _ask_local_or_cloud() {
     [[ "${HEADLONG_PROVIDER:-}" == "local" ]] && return 0
     [[ "${HEADLONG_PROVIDER:-}" == "cloud" ]] && return 1
-    # First run with a human at a tty: offer the local server before demanding
-    # a cloud key. No tty means no asking — fall through to the key checks
-    # (which die with a clear message when there is no key and no server).
-    if [[ "$HAS_TTY" -eq 1 ]]; then
-        ask_yn "Use a local model server (Ollama, LM Studio, vLLM; no API key)?" && return 0
-        return 1
+    # Existing configuration wins before any tty prompt. This keeps both
+    # cloud and local re-runs unattended after the first successful install.
+    if [[ -n "${SHELLM_API_URL:-${LLM_API_URL:-}}" \
+            && "${LLM_PROVIDER:-}" == "openai-compatible" ]]; then
+        return 0
     fi
-    # No tty: only an already-configured local endpoint (a re-run, an env
-    # carried from another setup) is worth one probe before falling through.
-    local probe_url="${SHELLM_API_URL:-${LLM_API_URL:-}}"
-    [[ -n "$probe_url" && -n "${LLM_PROVIDER:-}" && "$LLM_PROVIDER" == "openai-compatible" ]] || return 1
-    # Only worth keeping when the endpoint still answers; a dead one
-    # falls through to the ordinary prompts (and HEADLONG_PROVIDER=local
-    # above forces the repair path regardless).
-    _local_models_get "$(_local_base_url "$probe_url")" "${LLM_API_KEY:-}" >/dev/null 2>&1
+    _have_key && return 1
+    # A first run with no configured provider can ask. No tty falls through
+    # to the ordinary missing-key error.
+    [[ "$HAS_TTY" -eq 1 ]] || return 1
+    ask_yn "Use a local model server (Ollama, LM Studio, vLLM; no API key)?"
 }
 
 _ensure_api_key() {
     _reconcile_key_vars
+
+    # An explicit cloud choice replaces a saved local provider. Clear the
+    # local URL, optional key, and model before selecting the cloud default.
+    local switching_from_local=0
+    if [[ "${HEADLONG_PROVIDER:-}" == "cloud" \
+            && "${LLM_PROVIDER:-}" == "openai-compatible" ]]; then
+        switching_from_local=1
+    fi
 
     # Re-runs with a working local endpoint already configured stay on it;
     # otherwise offer the local path before demanding a cloud key.
     if _ask_local_or_cloud; then
         _setup_local_llm
         return 0
+    fi
+
+    if [[ "$switching_from_local" -eq 1 ]]; then
+        local local_var
+        for local_var in LLM_PROVIDER SHELLM_API_URL LLM_API_URL LLM_API_KEY SHELLM_MODEL; do
+            _env_unset "$HEADLONG_HOME/.env" "$local_var"
+        done
     fi
 
     if ! _have_key && [[ "$HAS_TTY" -eq 0 ]]; then

--- a/tools/headlong-init
+++ b/tools/headlong-init
@@ -462,22 +462,27 @@ _prompt_key() {
 # (LLM_API_URL / SHELLM_API_URL), while servers advertise their base URL
 # (/v1). Operators think in base URLs, so accept either: anything already
 # ending in /chat/completions is left alone; anything else gets
-# /chat/completions appended. /v1/models is always probed at the BASE url.
+# /chat/completions appended. /v1 is appended when missing too: operators
+# habitually give the bare server address (http://host:1234), and every
+# mainstream server serves the API under /v1. A URL already ending in /v1
+# (or /v1/chat/completions) is kept as-is. /v1/models is always probed at
+# the BASE url.
 
 _local_base_url() {  # base URL (for /v1/models) from whatever was given
     local url="$1"
     url="${url%/}"
     url="${url%/chat/completions}"
+    case "$url" in
+        */v1) ;;
+        *)    url="$url/v1" ;;
+    esac
     printf '%s' "$url"
 }
 
 _local_chat_url() {  # chat-completions URL from whatever was given
     local url="$1"
-    url="${url%/}"
-    case "$url" in
-        */chat/completions) printf '%s' "$url" ;;
-        *)                  printf '%s/chat/completions' "$url" ;;
-    esac
+    url="$(_local_base_url "$url")"
+    printf '%s/chat/completions' "$url"
 }
 
 # _local_models_get <base-url> <key> — fetch GET <base>/models. On success
@@ -517,7 +522,7 @@ _local_models_get() {
 _prompt_local_url() {
     local def="$1" url
     while :; do
-        url=$(ask "Base URL of your OpenAI-compatible server (Ollama: http://localhost:11434/v1)" "$def")
+        url=$(ask "Server address as your agent will reach it (e.g. http://localhost:1234 or http://192.168.3.23:1234; /v1 is added if missing)" "$def")
         [[ -n "$url" ]] || { def=""; continue; }
         printf '%s' "$url"
         return 0
@@ -536,6 +541,16 @@ _prompt_local_key() {
     printf '\n' >/dev/tty
     key="${key//[[:space:]]/}"
     printf '%s' "$key"
+}
+
+# _local_host_url <url> — the HOST-side twin of a container-reachable URL.
+# host.docker.internal names the host from inside Docker's VM; on the host
+# itself (where this installer runs) it does not resolve, so a probe against
+# it would always fail even with the server up. Swap it for localhost when
+# probing from here. No sandbox (or a LAN address): returned unchanged.
+_local_host_url() {
+    local url="$1"
+    printf '%s' "${url//host.docker.internal/localhost}"
 }
 
 # _pick_from_list <prompt> <one-choice-per-line> [default] — numbered menu on
@@ -611,8 +626,8 @@ EOF
     # just fails later, unattended); a server that answers but exposes no
     # model list (some proxies) only warns.
     if [[ "$HAS_TTY" -eq 0 ]]; then
-        [[ -n "$url_env" ]] || die "local provider selected with no URL. Set HEADLONG_LOCAL_URL (e.g. http://localhost:11434/v1)"
-        base=$(_local_base_url "$url_env")
+        [[ -n "$url_env" ]] || die "local provider selected with no URL. Set HEADLONG_LOCAL_URL (e.g. http://localhost:11434)"
+        base=$(_local_base_url "$(_local_host_url "$url_env")")
         key="$key_env"
         if ! _local_models_get "$base" "$key"; then
             if [[ -n "$_local_models_err" && "$_local_models_err" == could\ not\ reach* ]]; then
@@ -622,13 +637,16 @@ EOF
             echo "headlong-init: continuing with the given URL — set HEADLONG_LOCAL_MODEL if the model name is not already pinned" >&2
         fi
     else
-        # A tty: default to the env/inherited value; otherwise suggest Ollama's
-        # — the common case — and let the operator correct it.
-        local def_url="${url_env:-http://localhost:11434/v1}"
+        # A tty: default to the env/inherited value; otherwise suggest a
+        # localhost LM Studio — the common case — and let the operator
+        # correct it. The probe runs on THIS host, so a host.docker.internal
+        # address (what the sandboxed agent will use) is probed through its
+        # localhost twin; the persisted URL keeps the name the agent needs.
+        local def_url="${url_env:-http://localhost:1234}"
         base=""
         while :; do
             url_env=$(_prompt_local_url "$def_url")
-            base=$(_local_base_url "$url_env")
+            base=$(_local_base_url "$(_local_host_url "$url_env")")
             key="$key_env"
             if [[ -z "$key" ]]; then
                 key=$(_prompt_local_key)
@@ -669,7 +687,24 @@ EOF
     fi
     [[ -n "$chosen" ]] || die "no model selected"
 
+    # Persist the URL the AGENT's runtime will dial. With the Docker sandbox
+    # on (or inside a container), localhost/127.0.0.1 in generated code means
+    # the container, not this machine — rewrite it to host.docker.internal
+    # (Docker Desktop: macOS/Windows; on Linux add --add-host to the sandbox
+    # or give a LAN address). A LAN IP or an explicit host.docker.internal
+    # URL passes through unchanged. Without the sandbox the host URL is the
+    # agent URL and nothing is rewritten.
     chat=$(_local_chat_url "$url_env")
+    if [[ "${SHELLM_REQUIRE_DOCKER:-0}" == "1" || "$IN_CONTAINER" -eq 1 ]]; then
+        case "$chat" in
+            *//localhost:*|*//localhost/*|*//127.0.0.1:*)
+                local host_chat="${chat//localhost/host.docker.internal}"
+                host_chat="${host_chat//127.0.0.1/host.docker.internal}"
+                echo "    Sandbox is on: the agent reaches the server at $host_chat (was $chat)."
+                chat="$host_chat"
+                ;;
+        esac
+    fi
     _env_set "$HEADLONG_HOME/.env" "LLM_PROVIDER" "openai-compatible"
     _env_set "$HEADLONG_HOME/.env" "SHELLM_API_URL" "$chat"
     if [[ -n "$key" ]]; then
@@ -689,9 +724,13 @@ EOF
     _env_set "$HEADLONG_HOME/.env" "SHELLM_MODEL" "$chosen"
 
     # Prove the whole chain with a real completion (bin/llm reads the same
-    # .env; this is the same handshake a thinker will make).
+    # .env; this is the same handshake a thinker will make). When the
+    # persisted URL is the container form (host.docker.internal), override
+    # LLM_API_URL with its localhost twin for THIS host-side check — the
+    # name only resolves inside containers, and the twin was already
+    # proven reachable by the models probe above.
     info "Checking the LLM connection (model: $chosen at $base)"
-    if _llm_ok; then
+    if LLM_API_URL="$(_local_host_url "$chat")" _llm_ok; then
         echo "    OK — $chosen answered."
         return 0
     fi


### PR DESCRIPTION
## What

Installer/setup support for local OpenAI-compatible model servers (Ollama, LM Studio, vLLM, llama.cpp, proxies). The runtime half of #65 (the generic `openai-compatible` provider) landed in #78; this adds the missing half — `headlong-init` only knew the cloud API-key flow, so a local setup had to be configured by hand after install.

## How it works

- **Explicit choice, never inferred** (per design/providers.md): a `Use a local model server? [Y/n]` prompt, `HEADLONG_PROVIDER=local|cloud`, or keep-when-healthy on re-runs.
- **Local path**: asks for the server's address as the operator knows it (`http://localhost:1234`, a LAN address, or a full URL — `/v1` and `/chat/completions` are added automatically if missing), an optional bearer key (hidden input), then **verifies by fetching `GET /v1/models`** and lets the operator **pick the model from that list** (numbered menu, free-text fallback for huge catalogs). Servers that hide `/v1/models` fall back to a typed/pinned model.
- **Sandbox-aware URL**: probes run host-side through a URL's `localhost` twin (`host.docker.internal` only resolves inside containers); with the Docker sandbox on, the persisted `SHELLM_API_URL` is rewritten `localhost`/`127.0.0.1` → `host.docker.internal` (announced), so the agent dials an address that resolves. LAN addresses and explicit container URLs pass through untouched.
- **Persisted**: `LLM_PROVIDER=openai-compatible`, `SHELLM_API_URL`, `LLM_API_KEY` (only when given — a stale key is removed so the endpoint is keyless, not mis-keyed), `SHELLM_MODEL` — then proven with a real chat completion through `bin/llm`, the same handshake a thinker makes.
- **Paths**: host installs, the long-lived Docker container, and no-tty/CI installs (`HEADLONG_PROVIDER=local` + `HEADLONG_LOCAL_URL` is all a scripted install needs). No-tty: an unreachable server is a hard stop; a reachable server without a model list only warns.
- **Install-location**: `install.sh --init` from a checkout now offers the same container / this-machine / no-sandbox menu the one-liner makes, and the container path defaults the forwarded `HEADLONG_REPO`/`HEADLONG_BRANCH` to the checkout's own origin and branch — so choice 1 installs and runs **this** code, not upstream main (an operator-exported `HEADLONG_REPO` still wins).
- **Idempotent**: a re-run keeps a working local config without re-asking; re-running with `HEADLONG_PROVIDER=local` repairs a broken one.

Headlong still never installs a server or pulls models (per the issue).

## Infrastructure consistency

The installer writes exactly the variables the existing infrastructure consumes — no new runtime names: `LLM_PROVIDER`/`SHELLM_API_URL`/`SHELLM_MODEL`/optional `LLM_API_KEY`, the tuple documented in `design/providers.md` and `docs/shellm.md` (`LLM_API_URL` stays a direct-`llm` concern and is deliberately not written). Verified by execution that `bin/llm`, `bin/shellm` (incl. the `SHELLM_API_URL`→`LLM_API_URL` re-export and sandbox/nested-run forwarding), `thinkers/_lib/common.sh`, and the dash's `llm_probe` all consume this tuple with no changes. `HEADLONG_PROVIDER`/`HEADLONG_LOCAL_URL`/`HEADLONG_LOCAL_MODEL`/`HEADLONG_LOCAL_API_KEY` are installer inputs only, like `HEADLONG_IDENTITY_*`.

## Tests

New `tests/test_local_llm_setup.sh` (34 checks, curl/llm/identity/headlong-web stubbed, no network): happy path + persistence, cloud-key non-leak, dead-endpoint hard stop, URL normalization (bare address, trailing slash, full URL), sandbox rewrite to host.docker.internal, explicit container URL passthrough, local key persistence, no-pin → first listed model, failing-completion detection, explicit cloud override, re-run idempotence. All pass; shellcheck clean.

Full `tests/run-all.sh`: all suites pass except `test_thinkers_pending.sh` ("queue-full drop logged"), which also fails on unmodified main in this environment — pre-existing timing flake, unrelated.

Proven end-to-end on a real install (Docker-container path, LM Studio server on the LAN): location menu → container cloned this branch → local offer → bare `http://<lan>:1234` accepted → 11-model picker from the live server → verified completion → identity created → mind running with no cloud key; `ada say` round-trips through the local model.

Docs: `docs/install.md` documents both interactive and non-interactive (env-var) local flows.

Closes #65 (installer half; runtime completed by #78).