### PR TITLE
macos: unread badge, incoming-message notifications, reliable jump-to-bottom

### DIFF
--- a/macos/Shellm/Makefile
+++ b/macos/Shellm/Makefile
@@ -3,9 +3,10 @@ BINARY   = $(APP)/Contents/MacOS/Shellm
 PLIST    = $(APP)/Contents/Info.plist
 SOURCES  = main.swift
 
-.PHONY: app clean sign
+.PHONY: app clean
 
 app: $(BINARY) $(PLIST)
+	@codesign --force --sign - $(APP)
 
 $(BINARY): $(SOURCES)
 	@mkdir -p $(APP)/Contents/MacOS
@@ -16,9 +17,6 @@ $(BINARY): $(SOURCES)
 $(PLIST): Info.plist
 	@mkdir -p $(APP)/Contents
 	cp Info.plist $(PLIST)
-
-sign: app
-	codesign --force --sign - $(APP)
 
 clean:
 	rm -rf $(APP)

--- a/macos/Shellm/main.swift
+++ b/macos/Shellm/main.swift
@@ -449,6 +449,7 @@ struct ChatView: View {
     @ObservedObject var model: ChatModel
     var openSettings: () -> Void
     @State private var draft = ""
+    @State private var isAtBottom = true
     @FocusState private var inputFocused: Bool
 
     var body: some View {
@@ -488,19 +489,40 @@ struct ChatView: View {
 
             // Messages
             ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 4) {
-                        ForEach(model.messages) { msg in
-                            MessageRow(msg: msg, identityName: model.identityName)
-                                .id(msg.id)
+                ZStack(alignment: .bottom) {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 4) {
+                            ForEach(model.messages) { msg in
+                                MessageRow(msg: msg, identityName: model.identityName)
+                                    .id(msg.id)
+                            }
+                            // Invisible anchor at the very bottom
+                            Color.clear.frame(height: 1).id("bottom")
+                                .onAppear { isAtBottom = true }
+                                .onDisappear { isAtBottom = false }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                    }
+                    .onChange(of: model.messages.count) {
+                        if isAtBottom, let last = model.messages.last {
+                            withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
                         }
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                }
-                .onChange(of: model.messages.count) {
-                    if let last = model.messages.last {
-                        withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+
+                    if !isAtBottom {
+                        Button {
+                            withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
+                        } label: {
+                            Image(systemName: "arrow.down.circle.fill")
+                                .font(.title2)
+                                .foregroundStyle(.primary)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(8)
+                        .background(.ultraThinMaterial, in: Circle())
+                        .padding(.bottom, 8)
+                        .transition(.opacity)
                     }
                 }
             }
@@ -570,8 +592,19 @@ struct MessageRow: View {
     }
 
     private func timeString(_ date: Date) -> String {
+        let cal = Calendar.current
+        let now = Date()
         let f = DateFormatter()
-        f.dateFormat = "HH:mm"
+
+        if cal.isDateInToday(date) {
+            f.dateFormat = "h:mm a"
+        } else if cal.isDateInYesterday(date) {
+            f.dateFormat = "'Yesterday' h:mm a"
+        } else if let daysAgo = cal.dateComponents([.day], from: date, to: now).day, daysAgo < 7 {
+            f.dateFormat = "EEEE h:mm a"  // e.g. "Tuesday 3:42 PM"
+        } else {
+            f.dateFormat = "MMM d, h:mm a"  // e.g. "Aug 14, 3:42 PM"
+        }
         return f.string(from: date)
     }
 }

--- a/macos/Shellm/main.swift
+++ b/macos/Shellm/main.swift
@@ -258,6 +258,8 @@ class ChatModel: ObservableObject {
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
 
+    private var hotkeyRetryTask: Task<Void, Never>?
+
     init() {
         startPolling()
         registerHotkey()
@@ -390,14 +392,31 @@ class ChatModel: ObservableObject {
             },
             userInfo: selfPtr
         ) else {
-            NSLog("Shellm: CGEvent tap failed — Accessibility permission not granted")
+            NSLog("Shellm: CGEvent tap failed — Accessibility not granted, will retry")
+            startHotkeyRetry()
             return
         }
 
+        hotkeyRetryTask?.cancel()
+        hotkeyRetryTask = nil
         eventTap = tap
         runLoopSource = CFMachPortCreateRunLoopSource(nil, tap, 0)
         CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
+        NSLog("Shellm: CGEvent tap registered successfully")
+    }
+
+    private func startHotkeyRetry() {
+        guard hotkeyRetryTask == nil else { return }
+        hotkeyRetryTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                if AXIsProcessTrusted() {
+                    await MainActor.run { self?.registerHotkey() }
+                    return
+                }
+            }
+        }
     }
 
     func togglePanel() {

--- a/macos/Shellm/main.swift
+++ b/macos/Shellm/main.swift
@@ -42,6 +42,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             button.action = #selector(togglePopover)
             button.target = self
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+
+            // Unread badge overlaid on the icon's bottom-right corner
+            let badge = BadgeView(frame: button.bounds)
+            badge.autoresizingMask = [.width, .height]
+            button.addSubview(badge)
+            model.badgeView = badge
         }
 
         // Popover with ChatView
@@ -51,6 +57,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         popover.contentViewController = NSHostingController(
             rootView: ChatView(model: model, openSettings: { [weak self] in self?.openSettings() })
         )
+
+        // Opening the chat marks everything read
+        NotificationCenter.default.addObserver(forName: NSPopover.didShowNotification,
+                                               object: popover, queue: .main) { [weak self] _ in
+            self?.model.markAllRead()
+        }
 
         model.statusItem = statusItem
         model.popover = popover
@@ -67,12 +79,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             DispatchQueue.main.async { self.statusItem.menu = nil }
             return
         }
-        if popover.isShown {
-            popover.performClose(nil)
-        } else {
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            popover.contentViewController?.view.window?.makeKey()
-        }
+        model.togglePanel()
     }
 
     func openSettings() {
@@ -102,6 +109,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         handler([.banner, .sound])
     }
 
+    // Clicking a notification opens the chat
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler handler: @escaping () -> Void) {
+        DispatchQueue.main.async { self.model.showPanel() }
+        handler()
+    }
+
     func promptAccessibilityIfNeeded() {
         // Check without prompting first
         let trusted = AXIsProcessTrusted()
@@ -110,6 +125,50 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             AXIsProcessTrustedWithOptions(
                 [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary)
         }
+    }
+}
+
+// MARK: - 1b. Unread Badge (red pill drawn over the status bar icon)
+
+final class BadgeView: NSView {
+    var count: Int = 0 {
+        didSet {
+            isHidden = count == 0
+            needsDisplay = true
+        }
+    }
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        isHidden = true
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    // Let clicks fall through to the status bar button
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard count > 0 else { return }
+        let text = count > 99 ? "99+" : "\(count)"
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 8, weight: .bold),
+            .foregroundColor: NSColor.white,
+        ]
+        let textSize = (text as NSString).size(withAttributes: attrs)
+        let h: CGFloat = 12
+        let w = max(h, textSize.width + 6)
+        let pill = NSRect(x: bounds.maxX - w - 1, y: bounds.minY + 1, width: w, height: h)
+
+        // Thin outline in the menu bar color so the pill separates from the icon
+        NSColor.windowBackgroundColor.setFill()
+        NSBezierPath(roundedRect: pill.insetBy(dx: -1, dy: -1), xRadius: h / 2 + 1, yRadius: h / 2 + 1).fill()
+        NSColor.systemRed.setFill()
+        NSBezierPath(roundedRect: pill, xRadius: h / 2, yRadius: h / 2).fill()
+
+        (text as NSString).draw(
+            at: NSPoint(x: pill.midX - textSize.width / 2, y: pill.midY - textSize.height / 2),
+            withAttributes: attrs)
     }
 }
 
@@ -234,9 +293,19 @@ class ChatModel: ObservableObject {
     @Published var live = false
     @Published var identities: [IdentityListItem] = []
     @Published var error: String?
+    @Published var unreadCount = 0 {
+        didSet { badgeView?.count = unreadCount }
+    }
 
     weak var statusItem: NSStatusItem?
     weak var popover: NSPopover?
+    weak var badgeView: BadgeView?
+
+    // Step IDs already seen; lets us detect new messages even when the
+    // 200-message tail rotates (count alone misses those). Nil until the
+    // first successful fetch so history isn't reported as new.
+    private var seenStepIds: Set<String>?
+    private var seenIdentityId: String?
 
     var cfSecret: String {
         get { loadSecret() }
@@ -296,23 +365,30 @@ class ChatModel: ObservableObject {
         do {
             let resp = try await fetchChat(server: serverURL, identityId: identityId,
                 fromName: fromName, cfClientId: cfClientId, cfSecret: cfSecret)
-            let oldCount = messages.count
             if resp.messages != messages {
                 messages = resp.messages
                 outcomes = resp.outcomes
+            }
+            if resp.identity.id != seenIdentityId {
+                // Switched identity — treat its history as already read
+                seenIdentityId = resp.identity.id
+                seenStepIds = nil
             }
             identityName = resp.identity.name
             live = resp.live
             self.error = nil
 
-            // Notify on all new agent messages
-            if messages.count > oldCount {
-                for msg in messages.suffix(messages.count - oldCount) {
-                    if msg.from == identityName {
-                        notifyNewMessage(msg)
-                    }
+            // Incoming = anything not sent by us. Notify and count as unread
+            // (unless the chat is open on screen right now).
+            let fresh = messages.filter { seenStepIds?.contains($0.step_id) == false }
+            if !fresh.isEmpty {
+                let incoming = fresh.filter { $0.from != fromName }
+                for msg in incoming { notifyNewMessage(msg) }
+                if !(popover?.isShown ?? false) {
+                    unreadCount += incoming.count
                 }
             }
+            seenStepIds = Set(messages.map(\.step_id))
         } catch {
             self.error = error.localizedDescription
         }
@@ -420,14 +496,27 @@ class ChatModel: ObservableObject {
     }
 
     func togglePanel() {
-        guard let statusItem = statusItem, let button = statusItem.button else { return }
         guard let popover = popover else { return }
         if popover.isShown {
             popover.performClose(nil)
         } else {
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            popover.contentViewController?.view.window?.makeKey()
+            showPanel()
         }
+    }
+
+    func showPanel() {
+        guard let button = statusItem?.button, let popover = popover else { return }
+        if !popover.isShown {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        }
+        popover.contentViewController?.view.window?.makeKey()
+        markAllRead()
+    }
+
+    func markAllRead() {
+        unreadCount = 0
+        // Also clear delivered banners from Notification Center
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
     }
 
     // MARK: Notifications
@@ -435,8 +524,12 @@ class ChatModel: ObservableObject {
     private func notifyNewMessage(_ msg: ChatMessage) {
         let content = UNMutableNotificationContent()
         content.title = msg.from
+        if let filename = msg.filename, !filename.isEmpty {
+            content.subtitle = "📎 \(filename)"
+        }
         content.body = String(msg.content.prefix(200))
         content.sound = .default
+        content.threadIdentifier = msg.from   // group banners per sender
         let req = UNNotificationRequest(identifier: msg.id,
             content: content, trigger: nil)
         UNUserNotificationCenter.current().add(req)
@@ -450,6 +543,7 @@ struct ChatView: View {
     var openSettings: () -> Void
     @State private var draft = ""
     @State private var isAtBottom = true
+    @State private var scroller = ScrollController()
     @FocusState private var inputFocused: Bool
 
     var body: some View {
@@ -488,41 +582,37 @@ struct ChatView: View {
             Divider()
 
             // Messages
-            ScrollViewReader { proxy in
-                ZStack(alignment: .bottom) {
-                    ScrollView {
-                        LazyVStack(alignment: .leading, spacing: 4) {
-                            ForEach(model.messages) { msg in
-                                MessageRow(msg: msg, identityName: model.identityName)
-                                    .id(msg.id)
-                            }
-                            // Invisible anchor at the very bottom
-                            Color.clear.frame(height: 1).id("bottom")
-                                .onAppear { isAtBottom = true }
-                                .onDisappear { isAtBottom = false }
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                    }
-                    .onChange(of: model.messages.count) {
-                        if isAtBottom, let last = model.messages.last {
-                            withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+            ZStack(alignment: .bottom) {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 4) {
+                        ForEach(model.messages) { msg in
+                            MessageRow(msg: msg, identityName: model.identityName)
                         }
                     }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    // Tracks whether the list is scrolled to (near) the bottom, and
+                    // scrolls to the newest message whenever the popover opens
+                    .background(ScrollBottomObserver(controller: scroller) { isAtBottom = $0 })
+                }
+                .onChange(of: model.messages.count) { old, _ in
+                    // Follow new messages when at bottom; always jump on first load
+                    if isAtBottom || old == 0 {
+                        scroller.scrollToBottom(animated: old != 0)
+                    }
+                }
 
-                    if !isAtBottom {
-                        Button {
-                            withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
-                        } label: {
-                            Image(systemName: "arrow.down.circle.fill")
-                                .font(.title2)
-                                .foregroundStyle(.primary)
+                if !isAtBottom {
+                    HStack {
+                        Spacer()
+                        // AppKit button: SwiftUI buttons layered over the (NSScrollView-backed)
+                        // list never receive clicks on macOS — the scroll view wins hit-testing.
+                        JumpToBottomButton {
+                            scroller.scrollToBottom(animated: true)
                         }
-                        .buttonStyle(.plain)
-                        .padding(8)
-                        .background(.ultraThinMaterial, in: Circle())
+                        .frame(width: 32, height: 32)
+                        .padding(.trailing, 12)
                         .padding(.bottom, 8)
-                        .transition(.opacity)
                     }
                 }
             }
@@ -553,6 +643,153 @@ struct ChatView: View {
         guard !text.isEmpty else { return }
         model.send(text)
         draft = ""
+    }
+}
+
+/// Floating "jump to bottom" arrow (white on blue, half-transparent).
+struct JumpToBottomButton: NSViewRepresentable {
+    var action: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(action: action) }
+
+    func makeNSView(context: Context) -> NSButton {
+        let config = NSImage.SymbolConfiguration(pointSize: 28, weight: .regular)
+            .applying(.init(paletteColors: [.white, .systemBlue]))
+        let image = NSImage(systemSymbolName: "arrow.down.circle.fill", accessibilityDescription: "Jump to bottom")?
+            .withSymbolConfiguration(config)
+        let button = NSButton(image: image ?? NSImage(), target: context.coordinator, action: #selector(Coordinator.fire))
+        button.isBordered = false
+        button.imagePosition = .imageOnly
+        button.imageScaling = .scaleNone
+        button.focusRingType = .none
+        button.refusesFirstResponder = true
+        button.alphaValue = 0.5
+        let shadow = NSShadow()
+        shadow.shadowBlurRadius = 2
+        shadow.shadowColor = NSColor.black.withAlphaComponent(0.5)
+        button.shadow = shadow
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.action = action
+    }
+
+    final class Coordinator: NSObject {
+        var action: () -> Void
+        init(action: @escaping () -> Void) { self.action = action }
+        @objc func fire() { action() }
+    }
+}
+
+/// Handle SwiftUI uses to drive the native scroll view (see ScrollBottomObserver).
+final class ScrollController {
+    weak var view: ScrollBottomObserver.ObserverView?
+    func scrollToBottom(animated: Bool) { view?.scrollToBottom(animated: animated) }
+}
+
+/// Lives inside the ScrollView's content. Reports whether the enclosing
+/// NSScrollView is scrolled to (near) the bottom, and scrolls to the bottom
+/// natively. SwiftUI's GeometryReader/preference tricks don't update on macOS
+/// scroll and ScrollViewProxy is unreliable with LazyVStack, so use AppKit.
+struct ScrollBottomObserver: NSViewRepresentable {
+    var controller: ScrollController
+    var onChange: (Bool) -> Void
+
+    func makeNSView(context: Context) -> ObserverView {
+        let v = ObserverView()
+        v.onChange = onChange
+        controller.view = v
+        return v
+    }
+
+    func updateNSView(_ view: ObserverView, context: Context) {
+        view.onChange = onChange
+        controller.view = view
+    }
+
+    final class ObserverView: NSView {
+        var onChange: ((Bool) -> Void)?
+        private var tokens: [Any] = []
+        private var lastValue: Bool?
+        // After a scroll-to-bottom request, keep pinning to the bottom while the
+        // lazy content re-measures (its height grows as rows come on screen).
+        private var stickUntil = Date.distantPast
+
+        // Purely passive: never intercept clicks/selection meant for SwiftUI content
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            guard window != nil, let scroll = enclosingScrollView, let doc = scroll.documentView else { return }
+            if tokens.isEmpty {
+                let clip = scroll.contentView
+                clip.postsBoundsChangedNotifications = true
+                doc.postsFrameChangedNotifications = true
+                let nc = NotificationCenter.default
+                tokens.append(nc.addObserver(forName: NSView.boundsDidChangeNotification, object: clip, queue: .main) { [weak self] _ in self?.report() })
+                tokens.append(nc.addObserver(forName: NSView.frameDidChangeNotification, object: doc, queue: .main) { [weak self] _ in
+                    guard let self else { return }
+                    if Date() < self.stickUntil { self.pinToBottom() }
+                    self.report()
+                })
+            }
+            // Every time the popover opens, land on the newest message
+            scrollToBottom(animated: false)
+            report()
+        }
+
+        private func bottomOrigin(_ scroll: NSScrollView, _ doc: NSView) -> NSPoint {
+            let clip = scroll.contentView
+            return NSPoint(x: clip.bounds.origin.x,
+                           y: doc.isFlipped ? max(0, doc.frame.height - clip.bounds.height) : 0)
+        }
+
+        private func pinToBottom() {
+            guard let scroll = enclosingScrollView, let doc = scroll.documentView else { return }
+            let clip = scroll.contentView
+            let target = bottomOrigin(scroll, doc)
+            if abs(clip.bounds.origin.y - target.y) > 0.5 {
+                clip.scroll(to: target)
+                scroll.reflectScrolledClipView(clip)
+            }
+        }
+
+        func scrollToBottom(animated: Bool) {
+            guard let scroll = enclosingScrollView, let doc = scroll.documentView else { return }
+            let clip = scroll.contentView
+            let target = bottomOrigin(scroll, doc)
+            if animated {
+                NSAnimationContext.runAnimationGroup { ctx in
+                    ctx.duration = 0.25
+                    ctx.allowsImplicitAnimation = true
+                    clip.animator().setBoundsOrigin(target)
+                }
+            } else {
+                clip.scroll(to: target)
+            }
+            scroll.reflectScrolledClipView(clip)
+            // Stay pinned while lazy rows re-measure (see frameDidChange observer)
+            stickUntil = Date().addingTimeInterval(1.0)
+            DispatchQueue.main.asyncAfter(deadline: .now() + (animated ? 0.3 : 0.05)) { [weak self] in
+                self?.pinToBottom()
+            }
+        }
+
+        deinit { tokens.forEach { NotificationCenter.default.removeObserver($0) } }
+
+        private func report() {
+            guard let scroll = enclosingScrollView, let doc = scroll.documentView else { return }
+            let clip = scroll.contentView.bounds
+            let distance = doc.isFlipped
+                ? doc.frame.maxY - clip.maxY
+                : clip.minY - doc.frame.minY
+            let atBottom = distance < 40
+            guard atBottom != lastValue else { return }
+            lastValue = atBottom
+            // Defer so we never mutate SwiftUI state mid-layout
+            DispatchQueue.main.async { [weak self] in self?.onChange?(atBottom) }
+        }
     }
 }
 

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -40,13 +40,16 @@ I should reply when I see a `message` that seems directed at me or asks me a que
 
 ## Message formatting
 
-Andy reads my chat messages primarily through the Shellm.app menu-bar client (macos/Shellm/main.swift). Two rendering facts shape how I should write:
+Plain text is the only format guaranteed to render correctly in every chat client, so I default to it:
 
-1. Notifications truncate at 200 chars — `String(msg.content.prefix(200))` at line 419. Anything past ~180 chars is invisible until he opens the popover.
-2. Message body renders as plain SwiftUI `Text(msg.content)` at line 534 — no markdown parsing. Backticks, asterisks, and square-bracket links render literally.
-
-Rules I follow when sending:
-- First sentence carries the whole point in <=180 chars. Treat it as a subject line.
+- First sentence carries the whole point. Treat it as a subject line.
 - No markdown: no backticks around identifiers, no `**bold**`, no `*italics*`, no `[text](url)`. Use plain names, put single quotes around phrases if I need emphasis.
 - Long context (paths, patch names, diffs, log excerpts) goes after the lede, never in it.
-- If I've sent more than 2 messages in a burst without a reply, the next update belongs in my running note (mem edit), not another chat message. I re-raise in chat when Andy re-engages.
+- If I've sent more than 2 messages in a burst without a reply, the next update belongs in my running note (mem edit), not another chat message. I re-raise in chat when the person re-engages.
+
+### Shellm.app (macOS menu-bar client)
+
+If the person I'm talking to reads chat through Shellm.app (macos/Shellm/main.swift), two rendering facts apply on top of the rules above:
+
+1. Notifications truncate the message to 200 chars. Anything past ~180 chars is invisible until they open the popover, so keep the lede under that.
+2. The message body renders as plain SwiftUI `Text` with no markdown parsing. Backticks, asterisks, and square-bracket links render literally.

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -37,3 +37,16 @@ IMPORTANT: if I use `chat send` it sends a message to myself, so I must NEVER us
 ## When to reply
 
 I should reply when I see a `message` that seems directed at me or asks me a question. I keep my replies natural and conversational. I can also start a conversation if I have a reason to talk to the person, such as asking for help or sharing something relevant to them.
+
+## Message formatting
+
+Andy reads my chat messages primarily through the Shellm.app menu-bar client (macos/Shellm/main.swift). Two rendering facts shape how I should write:
+
+1. Notifications truncate at 200 chars — `String(msg.content.prefix(200))` at line 419. Anything past ~180 chars is invisible until he opens the popover.
+2. Message body renders as plain SwiftUI `Text(msg.content)` at line 534 — no markdown parsing. Backticks, asterisks, and square-bracket links render literally.
+
+Rules I follow when sending:
+- First sentence carries the whole point in <=180 chars. Treat it as a subject line.
+- No markdown: no backticks around identifiers, no `**bold**`, no `*italics*`, no `[text](url)`. Use plain names, put single quotes around phrases if I need emphasis.
+- Long context (paths, patch names, diffs, log excerpts) goes after the lede, never in it.
+- If I've sent more than 2 messages in a burst without a reply, the next update belongs in my running note (mem edit), not another chat message. I re-raise in chat when Andy re-engages.


### PR DESCRIPTION
## Summary

Shellm.app (menu bar client) improvements, on top of three previously unpushed `macos-client` commits (chat-skill doc, hotkey auto-retry, friendly timestamps) that were never in `main`.

### Unread badge
- Red pill with the unread count drawn over the status-bar icon (bottom-right, like Telegram/Dropbox), cleared whenever the popover opens (icon click, hotkey, or notification click).

### Notifications
- Fire for **any** incoming message (not only the selected agent); clicking a banner opens the chat; banners grouped per sender; file messages show the filename as a subtitle.
- New-message detection is now by `step_id` instead of message count. Fixes two pre-existing bugs: notifying the entire history on first launch, and missing messages once the 200-message tail rotates. Re-seeded silently on identity switch.

### Scroll / jump-to-bottom
- The per-row `onAppear`/`onDisappear` heuristic hid the arrow whenever a tall last message was partially visible. Replaced with an AppKit observer on the `NSScrollView` clip view (`GeometryReader` preferences don't update on macOS scroll).
- Popover now opens at the newest message: scroll-to-bottom is done natively on open / first load / follow-new-messages, pinning briefly while `LazyVStack` re-measures rows (`ScrollViewProxy.scrollTo` is unreliable with unrendered lazy rows on macOS).
- The arrow is now an `NSButton`: SwiftUI buttons layered over an `NSScrollView`-backed list never receive clicks on macOS (the scroll view wins hit-testing) — verified by instrumenting; the gear button fired, the arrow never did.

## Test plan
- [x] `make app` builds cleanly from this branch
- [x] Badge renders with count 3, clears on popover open (screenshot-verified in the menu bar)
- [x] Fresh open lands on newest message, no arrow
- [x] Scroll up → arrow appears; click → animates to bottom, arrow hides, text field keeps focus
- [x] No notifications fired for history on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b9XcBfmArvwbJGRu81W7C
