### PR TITLE
Stream responder output progressively in talk UI

### DIFF
--- a/tests/test_responder_partial_reply.sh
+++ b/tests/test_responder_partial_reply.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# tests/test_responder_partial_reply.sh -- responder exposes active stdout.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PATH="$REPO/bin:$PATH"
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ -- $2}"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/shim" "$WORK/id/run" "$WORK/id/memories" "$WORK/id/skills" \
+    "$WORK/id/kernel" "$WORK/traj/aaaaaaaa-root"
+
+TRAJ_FILE="$WORK/traj/aaaaaaaa-root/trajectory.jsonl"
+STEP_FILE="$WORK/step.json"
+READY_FILE="$WORK/llm-ready"
+REPLY_FILE="$WORK/chat-reply"
+PARTIAL_DIR="$WORK/id/run/responder-partials/trig-1"
+PARTIAL_FILE="$PARTIAL_DIR/content.txt"
+
+cat > "$STEP_FILE" <<'JSON'
+{"type":"message","step_id":"trig-1","from":"pwa-nick","to":"ada","content":"hello"}
+JSON
+
+cat > "$TRAJ_FILE" <<'JSON'
+{"type":"trajectory","step_id":"aaaaaaaa"}
+{"type":"message","step_id":"trig-1","from":"pwa-nick","to":"ada","content":"hello"}
+JSON
+
+cat > "$WORK/shim/identity" <<'SHIM'
+#!/usr/bin/env bash
+case "${1:-}" in
+    prompt) printf 'identity prompt\n' ;;
+esac
+SHIM
+
+cat > "$WORK/shim/skills" <<'SHIM'
+#!/usr/bin/env bash
+case "${1:-}" in
+    prompt) printf 'skills prompt\n' ;;
+esac
+SHIM
+
+cat > "$WORK/shim/traj" <<SHIM
+#!/usr/bin/env bash
+case "\${1:-}" in
+    exists) exit 0 ;;
+    path) printf '%s\n' "$TRAJ_FILE" ;;
+    cat) cat "$TRAJ_FILE" ;;
+    append) cat >> "$TRAJ_FILE" ;;
+esac
+SHIM
+
+cat > "$WORK/shim/llm" <<SHIM
+#!/usr/bin/env bash
+printf 'partial'
+: > "$READY_FILE"
+sleep 1
+printf ' done'
+SHIM
+
+cat > "$WORK/shim/chat" <<SHIM
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "reply" ]]; then
+    cat > "$REPLY_FILE"
+    exit 0
+fi
+exit 1
+SHIM
+
+chmod +x "$WORK/shim/identity" "$WORK/shim/skills" "$WORK/shim/traj" \
+    "$WORK/shim/llm" "$WORK/shim/chat"
+
+(
+    export PATH="$WORK/shim:$PATH"
+    export IDENTITY_DIR="$WORK/id" IDENTITY_NAME=ada
+    export TRAJ_DIR="$WORK/traj" TRAJ_ID=aaaaaaaa ROOT_TRAJ_ID=aaaaaaaa
+    export MEM_DIR="$WORK/id/memories" THINK_MODEL=test-model
+    "$REPO/thinkers/responder/step" < "$STEP_FILE"
+) > "$WORK/stdout" 2> "$WORK/stderr" &
+step_pid=$!
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -f "$READY_FILE" ]] && break
+    sleep 0.1
+done
+
+if [[ -f "$PARTIAL_FILE" ]] && grep -q 'partial' "$PARTIAL_FILE"; then
+    ok "partial reply is visible while llm is still running"
+else
+    bad "partial reply is visible while llm is still running" "missing $PARTIAL_FILE"
+fi
+
+if [[ ! -s "$REPLY_FILE" ]]; then
+    ok "final reply is not sent before generation completes"
+else
+    bad "final reply is not sent before generation completes"
+fi
+
+wait "$step_pid"
+
+if [[ "$(cat "$REPLY_FILE" 2>/dev/null)" == "partial done" ]]; then
+    ok "final reply still sends the completed content"
+else
+    bad "final reply still sends the completed content" "$(cat "$REPLY_FILE" 2>/dev/null)"
+fi
+
+if [[ ! -e "$PARTIAL_DIR" ]]; then
+    ok "partial reply file is removed after completion"
+else
+    bad "partial reply file is removed after completion" "$PARTIAL_DIR still exists"
+fi
+
+FAIL_STEP_FILE="$WORK/step-fail.json"
+FAIL_READY_FILE="$WORK/llm-fail-ready"
+FAIL_REPLY_FILE="$WORK/chat-reply-fail"
+FAIL_PARTIAL_DIR="$WORK/id/run/responder-partials/trig-fail"
+
+cat > "$FAIL_STEP_FILE" <<'JSON'
+{"type":"message","step_id":"trig-fail","from":"pwa-nick","to":"ada","content":"will this fail?"}
+JSON
+
+cat >> "$TRAJ_FILE" <<'JSON'
+{"type":"message","step_id":"trig-fail","from":"pwa-nick","to":"ada","content":"will this fail?"}
+JSON
+
+cat > "$WORK/shim/llm" <<SHIM
+#!/usr/bin/env bash
+printf 'partial'
+: > "$FAIL_READY_FILE"
+exit 1
+SHIM
+
+cat > "$WORK/shim/chat" <<SHIM
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "reply" ]]; then
+    cat > "$FAIL_REPLY_FILE"
+    exit 0
+fi
+exit 1
+SHIM
+
+chmod +x "$WORK/shim/llm" "$WORK/shim/chat"
+
+(
+    export PATH="$WORK/shim:$PATH"
+    export IDENTITY_DIR="$WORK/id" IDENTITY_NAME=ada
+    export TRAJ_DIR="$WORK/traj" TRAJ_ID=aaaaaaaa ROOT_TRAJ_ID=aaaaaaaa
+    export MEM_DIR="$WORK/id/memories" THINK_MODEL=test-model
+    "$REPO/thinkers/responder/step" < "$FAIL_STEP_FILE"
+) > "$WORK/stdout-fail" 2> "$WORK/stderr-fail"
+
+if [[ ! -e "$FAIL_REPLY_FILE" ]]; then
+    ok "partial output from failed llm is not sent"
+else
+    bad "partial output from failed llm is not sent" "$(cat "$FAIL_REPLY_FILE")"
+fi
+
+if jq -e 'select(.type == "observation" and .trigger_step == "trig-fail" and (.content | startswith("reply failed")))' "$TRAJ_FILE" >/dev/null; then
+    ok "failed llm appends reply-failed observation"
+else
+    bad "failed llm appends reply-failed observation"
+fi
+
+if [[ ! -e "$FAIL_PARTIAL_DIR" ]]; then
+    ok "partial reply file is removed after llm failure"
+else
+    bad "partial reply file is removed after llm failure" "$FAIL_PARTIAL_DIR still exists"
+fi
+
+NOREPLY_STEP_FILE="$WORK/step-fail-noreply.json"
+NOREPLY_REPLY_FILE="$WORK/chat-reply-fail-noreply"
+NOREPLY_PARTIAL_DIR="$WORK/id/run/responder-partials/trig-fail-noreply"
+
+cat > "$NOREPLY_STEP_FILE" <<'JSON'
+{"type":"message","step_id":"trig-fail-noreply","from":"pwa-nick","to":"ada","content":"maybe no reply?"}
+JSON
+
+cat >> "$TRAJ_FILE" <<'JSON'
+{"type":"message","step_id":"trig-fail-noreply","from":"pwa-nick","to":"ada","content":"maybe no reply?"}
+JSON
+
+cat > "$WORK/shim/llm" <<'SHIM'
+#!/usr/bin/env bash
+printf 'NO_REPLY'
+exit 1
+SHIM
+
+cat > "$WORK/shim/chat" <<SHIM
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "reply" ]]; then
+    cat > "$NOREPLY_REPLY_FILE"
+    exit 0
+fi
+exit 1
+SHIM
+
+chmod +x "$WORK/shim/llm" "$WORK/shim/chat"
+
+(
+    export PATH="$WORK/shim:$PATH"
+    export IDENTITY_DIR="$WORK/id" IDENTITY_NAME=ada
+    export TRAJ_DIR="$WORK/traj" TRAJ_ID=aaaaaaaa ROOT_TRAJ_ID=aaaaaaaa
+    export MEM_DIR="$WORK/id/memories" THINK_MODEL=test-model
+    "$REPO/thinkers/responder/step" < "$NOREPLY_STEP_FILE"
+) > "$WORK/stdout-fail-noreply" 2> "$WORK/stderr-fail-noreply"
+
+if [[ ! -e "$NOREPLY_REPLY_FILE" ]]; then
+    ok "NO_REPLY from failed llm is not sent"
+else
+    bad "NO_REPLY from failed llm is not sent" "$(cat "$NOREPLY_REPLY_FILE")"
+fi
+
+if jq -e 'select(.type == "observation" and .trigger_step == "trig-fail-noreply" and .decision == "no-reply")' "$TRAJ_FILE" >/dev/null; then
+    bad "NO_REPLY from failed llm is not recorded as no-reply"
+else
+    ok "NO_REPLY from failed llm is not recorded as no-reply"
+fi
+
+if jq -e 'select(.type == "observation" and .trigger_step == "trig-fail-noreply" and (.content | startswith("reply failed")))' "$TRAJ_FILE" >/dev/null; then
+    ok "NO_REPLY from failed llm appends reply-failed observation"
+else
+    bad "NO_REPLY from failed llm appends reply-failed observation"
+fi
+
+if [[ ! -e "$NOREPLY_PARTIAL_DIR" ]]; then
+    ok "partial reply file is removed after NO_REPLY llm failure"
+else
+    bad "partial reply file is removed after NO_REPLY llm failure" "$NOREPLY_PARTIAL_DIR still exists"
+fi
+
+TRAVERSAL_STEP_FILE="$WORK/step-traversal.json"
+TRAVERSAL_REPLY_FILE="$WORK/chat-reply-traversal"
+RUN_SENTINEL="$WORK/id/run/keep-me"
+
+cat > "$TRAVERSAL_STEP_FILE" <<'JSON'
+{"type":"message","step_id":"..","from":"pwa-nick","to":"ada","content":"odd id"}
+JSON
+
+cat >> "$TRAJ_FILE" <<'JSON'
+{"type":"message","step_id":"..","from":"pwa-nick","to":"ada","content":"odd id"}
+JSON
+
+printf 'sentinel' > "$RUN_SENTINEL"
+
+cat > "$WORK/shim/llm" <<'SHIM'
+#!/usr/bin/env bash
+printf 'safe reply'
+SHIM
+
+cat > "$WORK/shim/chat" <<SHIM
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "reply" ]]; then
+    cat > "$TRAVERSAL_REPLY_FILE"
+    exit 0
+fi
+exit 1
+SHIM
+
+chmod +x "$WORK/shim/llm" "$WORK/shim/chat"
+
+(
+    export PATH="$WORK/shim:$PATH"
+    export IDENTITY_DIR="$WORK/id" IDENTITY_NAME=ada
+    export TRAJ_DIR="$WORK/traj" TRAJ_ID=aaaaaaaa ROOT_TRAJ_ID=aaaaaaaa
+    export MEM_DIR="$WORK/id/memories" THINK_MODEL=test-model
+    "$REPO/thinkers/responder/step" < "$TRAVERSAL_STEP_FILE"
+) > "$WORK/stdout-traversal" 2> "$WORK/stderr-traversal"
+
+if [[ -e "$RUN_SENTINEL" ]]; then
+    ok "malformed step id cleanup keeps unrelated run files"
+else
+    bad "malformed step id cleanup keeps unrelated run files"
+fi
+
+echo
+echo "$pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/thinkers/responder/step
+++ b/thinkers/responder/step
@@ -21,6 +21,22 @@ _require_env
 THINK_MODEL="${THINK_MODEL:-${SHELLM_MODEL:-claude-opus-4-7}}"
 THINK_CONTEXT_TAIL="${THINK_CONTEXT_TAIL:-20}"
 REPLY_MODEL="${MONOLITH_REPLY_MODEL:-$THINK_MODEL}"
+RESPONDER_PARTIALS_DIR="responder-partials"
+RESPONDER_PARTIAL_META_FILE="meta.json"
+RESPONDER_PARTIAL_CONTENT_FILE="content.txt"
+
+partial_dir=""
+partial_content_file=""
+
+_partial_key() {
+    printf '%s' "$1" | sed -E 's/[^A-Za-z0-9_-]/_/g'
+}
+
+_partial_cleanup() {
+    [[ -n "$partial_dir" && -d "$partial_dir" ]] || return 0
+    find "$partial_dir" -type f -delete 2>/dev/null || true
+    find "$partial_dir" -depth -type d -delete 2>/dev/null || true
+}
 
 # Wall-clock milliseconds, for compose_ms. Same perl path bin/traj uses for
 # its timestamps; the fallback is whole seconds, still a valid number.
@@ -112,6 +128,30 @@ jq -nc \
     '{type:"reply_claim", content:("handling reply to " + $from), source:$source}
      + (if $trigger == "" then {} else {trigger_step: $trigger} end)' \
     | traj append >/dev/null || true
+
+if [[ -n "$trigger_step_id" ]]; then
+    partial_key=$(_partial_key "$trigger_step_id")
+    partial_dir="$IDENTITY_DIR/run/$RESPONDER_PARTIALS_DIR/$partial_key"
+    partial_content_file="$partial_dir/$RESPONDER_PARTIAL_CONTENT_FILE"
+    partial_meta_file="$partial_dir/$RESPONDER_PARTIAL_META_FILE"
+    if mkdir -p "$partial_dir"; then
+        if jq -nc \
+            --arg from "$IDENTITY_NAME" \
+            --arg to "$msg_from" \
+            --arg reply_to "$trigger_step_id" \
+            '{from:$from, to:$to, reply_to:$reply_to}' \
+            > "$partial_meta_file" && : > "$partial_content_file"; then
+            trap _partial_cleanup EXIT
+        else
+            _partial_cleanup
+            partial_dir=""
+            partial_content_file=""
+        fi
+    else
+        partial_dir=""
+        partial_content_file=""
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 # Compose and send the reply
@@ -415,15 +455,32 @@ if [[ "${RESPONDER_LOG_PROMPT:-0}" == "1" && -n "${IDENTITY_DIR:-}" ]]; then
 fi
 
 printf '  replying to %s...\n' "$msg_from" >&2
-reply=$(llm -m "$REPLY_MODEL" -M "$convo_json" -s "$reply_system") || true
+llm_rc=0
+if [[ -n "$partial_content_file" ]]; then
+    set +e
+    llm -m "$REPLY_MODEL" -M "$convo_json" -s "$reply_system" > "$partial_content_file"
+    llm_rc=$?
+    set -e
+    reply=$(cat "$partial_content_file") || reply=""
+else
+    set +e
+    reply=$(llm -m "$REPLY_MODEL" -M "$convo_json" -s "$reply_system")
+    llm_rc=$?
+    set -e
+fi
 
 # Strip a leaked delivery command if a model echoes one.
 reply=$(printf '%s' "$reply" | sed -E '1s/^[[:space:]]*chat reply [A-Za-z0-9._-]+[[:space:]]*//')
+
+if [[ $llm_rc -ne 0 ]]; then
+    reply=""
+fi
 
 # The model may judge that no reply is needed.
 first_line=$(printf '%s' "$reply" | head -n 1 | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
 if [[ "$first_line" == "NO_REPLY" ]]; then
     printf '  model declined to reply (NO_REPLY)\n' >&2
+    _partial_cleanup
     _obs "Chose not to reply to $msg_from — their message needed no reply (already answered, or a bare acknowledgment). Their message was: $(printf '%.200s' "$trigger_content")" no-reply "$(_finish_metrics)"
     exit 0
 fi
@@ -454,7 +511,9 @@ fi
 
 reply_args=()
 [[ -n "$trigger_step_id" ]] && reply_args+=(--reply-to "$trigger_step_id")
-if [[ -n "$reply" ]] && printf '%s' "$reply" | chat reply ${reply_args[@]+"${reply_args[@]}"} "$msg_from"; then
+if [[ $llm_rc -eq 0 && -n "$reply" ]] \
+    && printf '%s' "$reply" | chat reply ${reply_args[@]+"${reply_args[@]}"} "$msg_from"; then
+    _partial_cleanup
     _extra=$(_finish_metrics)
     if [[ -n "$deferred_request" ]]; then
         _extra=$(printf '%s' "$_extra" | jq -c --arg r "$deferred_request" '. + {deferred: true, request: $r}')
@@ -469,4 +528,5 @@ fi
 
 # Reply failed — surface it so the monolith can pick it up.
 printf '  reply failed — appending failure observation\n' >&2
+_partial_cleanup
 _obs "reply failed: could not send a reply to $msg_from (empty model output or chat error — see responder log). Their message was: $(printf '%.200s' "$trigger_content")" reply-failed "$(_finish_metrics)"

--- a/web/src/headlong_web/chat.py
+++ b/web/src/headlong_web/chat.py
@@ -6,10 +6,19 @@ meant ~3.5GB of transient dicts per poll and was a main driver of the
 2026-08-13 OOM incident.
 """
 
+import json
+import time
+from pathlib import Path
 from typing import Any
 
 from headlong_web.chat_links import resolve_source_url
 from headlong_web.trajectory import CHAT_MESSAGE_TYPES as MESSAGE_TYPES
+
+PARTIAL_REPLIES_DIR = "responder-partials"
+PARTIAL_META_FILE = "meta.json"
+PARTIAL_CONTENT_FILE = "content.txt"
+PARTIAL_STEP_PREFIX = "partial:"
+PARTIAL_TTL_SECONDS = 300
 
 
 def chat_view(
@@ -17,6 +26,7 @@ def chat_view(
     identity_name: str,
     tail: int = 200,
     with_name: str | None = None,
+    partials: list[dict[str, Any]] | None = None,
 ) -> dict:
     """Messages plus per-inbound-step outcomes.
 
@@ -74,7 +84,62 @@ def chat_view(
                 "source_url": source_url,
             }
         )
+    if partials:
+        for partial in partials:
+            reply_to = partial.get("reply_to")
+            if outcomes.get(reply_to) in {"replied", "no-reply"}:
+                continue
+            messages.append(partial)
     return {"messages": messages[-tail:], "outcomes": outcomes}
+
+
+def active_partial_replies(
+    identity_path: Path,
+    identity_name: str,
+    with_name: str | None = None,
+    now: float | None = None,
+) -> list[dict[str, Any]]:
+    root = identity_path / "run" / PARTIAL_REPLIES_DIR
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return []
+
+    now = time.time() if now is None else now
+    messages: list[dict[str, Any]] = []
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        meta_path = entry / PARTIAL_META_FILE
+        content_path = entry / PARTIAL_CONTENT_FILE
+        try:
+            stat = content_path.stat()
+            if now - stat.st_mtime > PARTIAL_TTL_SECONDS:
+                continue
+            meta = json.loads(meta_path.read_text())
+            content = content_path.read_text(errors="replace")
+        except (OSError, json.JSONDecodeError, TypeError):
+            continue
+        if not content:
+            continue
+        from_name = str(meta.get("from") or identity_name)
+        to_name = str(meta.get("to") or "")
+        reply_to = str(meta.get("reply_to") or entry.name)
+        if with_name is not None and with_name not in (from_name, to_name):
+            continue
+        messages.append(
+            {
+                "ts": None,
+                "step_id": f"{PARTIAL_STEP_PREFIX}{reply_to}",
+                "from": from_name,
+                "to": to_name,
+                "content": content,
+                "reply_to": reply_to,
+                "filename": None,
+                "partial": True,
+            }
+        )
+    return messages
 
 
 def chat_messages(

--- a/web/src/headlong_web/server.py
+++ b/web/src/headlong_web/server.py
@@ -719,7 +719,11 @@ def create_app(
             raise HTTPException(status_code=422, detail="Invalid conversation name")
         status = liveness.identity_status(identity.path, traj_dir / "trajectory.jsonl")
         view = chat.chat_view(
-            trajectory.CACHE.chat_steps(traj_dir), identity.name, tail, with_
+            trajectory.CACHE.chat_steps(traj_dir),
+            identity.name,
+            tail,
+            with_,
+            chat.active_partial_replies(identity.path, identity.name, with_),
         )
         return {
             "identity": {"id": identity.id, "name": identity.name},

--- a/web/tests/test_chat_api.py
+++ b/web/tests/test_chat_api.py
@@ -1,11 +1,13 @@
 """Chat conversation filter and PWA static-file route tests."""
 
 import json
+import os
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
+from headlong_web import chat
 from headlong_web.server import create_app
 
 ROOT_TRAJ = "ffffffff-6666-4666-8666-666666666666"
@@ -134,6 +136,150 @@ def test_chat_outcomes(client: TestClient):
     assert body["outcomes"]["m7"] == "no-reply"
     assert body["outcomes"]["m8"] == "failed"
     assert "s0" not in body["outcomes"]
+
+
+def test_chat_includes_active_partial_reply(client: TestClient, chat_identity: Path):
+    traj = chat_identity / "trajectories" / "ffffffff-root" / "trajectory.jsonl"
+    unanswered = _msg("m9", "pwa-boss", "chatty", "are you there?")
+    with traj.open("a") as stream:
+        stream.write(json.dumps(unanswered) + "\n")
+    partial = chat_identity / "run" / "responder-partials" / "m9"
+    partial.mkdir(parents=True)
+    (partial / "meta.json").write_text(
+        json.dumps({"from": "chatty", "to": "pwa-boss", "reply_to": "m9"})
+    )
+    (partial / "content.txt").write_text("partial reply")
+
+    body = client.get(
+        "/api/identities/.identities~chatty/chat", params={"with": "pwa-boss"}
+    ).json()
+
+    last = body["messages"][-1]
+    assert last == {
+        "ts": None,
+        "step_id": "partial:m9",
+        "from": "chatty",
+        "to": "pwa-boss",
+        "content": "partial reply",
+        "reply_to": "m9",
+        "filename": None,
+        "partial": True,
+    }
+
+
+def test_chat_view_omits_partial_after_final_outcome():
+    partial = {
+        "step_id": "partial:m10",
+        "from": "chatty",
+        "to": "pwa-boss",
+        "content": "ghost",
+        "reply_to": "m10",
+        "filename": None,
+        "partial": True,
+    }
+    view = chat.chat_view(
+        [
+            _msg("m10", "pwa-boss", "chatty", "question"),
+            _msg("m11", "chatty", "pwa-boss", "answer", reply_to="m10"),
+        ],
+        "chatty",
+        partials=[partial],
+    )
+
+    assert [message["step_id"] for message in view["messages"]] == ["m10", "m11"]
+
+
+def test_chat_view_keeps_partial_after_failed_outcome():
+    partial = {
+        "step_id": "partial:m10",
+        "from": "chatty",
+        "to": "pwa-boss",
+        "content": "retry draft",
+        "reply_to": "m10",
+        "filename": None,
+        "partial": True,
+    }
+    view = chat.chat_view(
+        [
+            _msg("m10", "pwa-boss", "chatty", "question"),
+            {
+                "type": "observation",
+                "step_id": "o10",
+                "content": "reply failed: transport error",
+                "trigger_step": "m10",
+            },
+        ],
+        "chatty",
+        partials=[partial],
+    )
+
+    assert [message["step_id"] for message in view["messages"]] == [
+        "m10",
+        "partial:m10",
+    ]
+
+
+def test_active_partial_replies_ignores_invalid_entries(tmp_path: Path):
+    identity = tmp_path / ".identities" / "chatty"
+    partials_root = identity / "run" / "responder-partials"
+    partials_root.mkdir(parents=True)
+    (partials_root / "not-a-dir").write_text("ignored")
+    stale = partials_root / "stale"
+    stale.mkdir()
+    (stale / "meta.json").write_text(json.dumps({"from": "chatty", "to": "pwa-boss"}))
+    stale_content = stale / "content.txt"
+    stale_content.write_text("too old")
+    os.utime(stale_content, (1, 1))
+    malformed = partials_root / "malformed"
+    malformed.mkdir()
+    (malformed / "meta.json").write_text("{")
+    (malformed / "content.txt").write_text("bad meta")
+    empty = partials_root / "empty"
+    empty.mkdir()
+    (empty / "meta.json").write_text(json.dumps({"from": "chatty", "to": "pwa-boss"}))
+    (empty / "content.txt").write_text("")
+
+    assert chat.active_partial_replies(identity, "chatty", now=400) == []
+
+
+def test_active_partial_replies_filters_and_uses_defaults(tmp_path: Path):
+    identity = tmp_path / ".identities" / "chatty"
+    current = identity / "run" / "responder-partials" / "m12"
+    current.mkdir(parents=True)
+    (current / "meta.json").write_text(json.dumps({}))
+    (current / "content.txt").write_text("draft")
+
+    assert chat.active_partial_replies(identity, "chatty", with_name="someone") == []
+    assert chat.active_partial_replies(identity, "chatty", with_name="chatty") == [
+        {
+            "ts": None,
+            "step_id": "partial:m12",
+            "from": "chatty",
+            "to": "",
+            "content": "draft",
+            "reply_to": "m12",
+            "filename": None,
+            "partial": True,
+        }
+    ]
+
+
+def test_active_partial_replies_tolerates_partial_utf8_write(tmp_path: Path):
+    identity = tmp_path / ".identities" / "chatty"
+    current = identity / "run" / "responder-partials" / "m13"
+    current.mkdir(parents=True)
+    (current / "meta.json").write_text(
+        json.dumps({"from": "chatty", "to": "pwa-boss", "reply_to": "m13"})
+    )
+    (current / "content.txt").write_bytes(b"hello \xe2")
+
+    [partial] = chat.active_partial_replies(identity, "chatty", with_name="pwa-boss")
+
+    assert partial["content"] == "hello \ufffd"
+
+
+def test_active_partial_replies_missing_root_returns_empty(tmp_path: Path):
+    assert chat.active_partial_replies(tmp_path / ".identities" / "chatty", "chatty") == []
 
 
 def test_chat_with_rejects_bad_name(client: TestClient):

--- a/web/viewer/app/lib/types.ts
+++ b/web/viewer/app/lib/types.ts
@@ -131,6 +131,7 @@ export interface ChatMessage {
   reply_to: string | null;
   filename: string | null;
   source_url: string | null;
+  partial?: boolean;
 }
 
 export interface ChatLog {

--- a/web/viewer/app/routes/talk-chat.test.tsx
+++ b/web/viewer/app/routes/talk-chat.test.tsx
@@ -11,6 +11,7 @@ import type {
   IdentityActivity,
   ThinkersStatus,
 } from "~/lib/types";
+import { fetchChat } from "~/lib/api";
 import { setPwaName } from "~/lib/pwa";
 import TalkChat from "~/routes/talk-chat";
 
@@ -119,5 +120,47 @@ describe("phone chat composer", () => {
       "line one\nline two",
       "pwa-nick"
     );
+  });
+});
+
+const EMPTY_CHAT: ChatLog = {
+  identity: { id: "ada", name: "ada" },
+  live: false,
+  messages: [],
+  outcomes: {},
+};
+const FINAL_REPLY_TEXT = "here is the finished reply";
+
+describe("completed reply settles the waiting state", () => {
+  afterEach(() => {
+    vi.mocked(fetchChat).mockResolvedValue(EMPTY_CHAT);
+  });
+
+  it("renders a non-partial incoming reply and clears the pending-send state", async () => {
+    // A final (partial: false) message from the other side must take the
+    // `!lastMessage.partial` branch that resets lastSentAt, unlike a partial
+    // bubble which keeps the fast-poll/typing affordances alive.
+    vi.mocked(fetchChat).mockResolvedValue({
+      ...EMPTY_CHAT,
+      messages: [
+        {
+          ts: "2026-01-01T00:00:00Z",
+          step_id: "s1",
+          from: "ada",
+          to: "pwa-nick",
+          content: FINAL_REPLY_TEXT,
+          reply_to: null,
+          filename: null,
+          source_url: null,
+          partial: false,
+        },
+      ],
+    });
+
+    renderTalkChat();
+
+    expect(await screen.findByText(FINAL_REPLY_TEXT)).toBeTruthy();
+    // No typing dots once the completed reply has arrived.
+    expect(document.querySelectorAll(".typing-dot").length).toBe(0);
   });
 });

--- a/web/viewer/app/routes/talk-chat.tsx
+++ b/web/viewer/app/routes/talk-chat.tsx
@@ -169,6 +169,7 @@ export default function TalkChat() {
   const draftRef = useAutosizeTextarea(draft);
   const lastSentAtRef = useRef<number | null>(null);
   lastSentAtRef.current = lastSentAt;
+  const hasActivePartialRef = useRef(false);
   const awaitingRef = useRef(false);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -187,6 +188,7 @@ export default function TalkChat() {
     queryFn: () => fetchChat(identityId, 200, myName),
     refetchInterval: () => {
       const sent = lastSentAtRef.current;
+      if (hasActivePartialRef.current) return FAST_POLL_MS;
       const awaiting =
         awaitingRef.current && sent && Date.now() - sent < FAST_POLL_WINDOW_MS;
       return awaiting ? FAST_POLL_MS : IDLE_POLL_MS;
@@ -216,10 +218,16 @@ export default function TalkChat() {
   const messages = useMemo(() => chat?.messages ?? [], [chat]);
   const outcomes = chat?.outcomes ?? {};
 
-  // A reply arriving ends the "waiting" state (fast poll + typing dots).
+  const hasActivePartial = messages.some((message) => message.partial);
+  hasActivePartialRef.current = hasActivePartial;
+
+  // A final reply arriving ends the waiting state; an active partial keeps
+  // fast polling so the bubble can keep growing.
   const lastMessage = messages[messages.length - 1];
   useEffect(() => {
-    if (lastMessage && lastMessage.from !== myName) setLastSentAt(null);
+    if (lastMessage && lastMessage.from !== myName && !lastMessage.partial) {
+      setLastSentAt(null);
+    }
   }, [lastMessage, myName]);
 
   // Optimistic bubbles disappear once the server echoes the real message.
@@ -255,7 +263,8 @@ export default function TalkChat() {
   const waitingForReply =
     lastSentAt !== null &&
     lastOutcome === undefined &&
-    (visiblePending.some((p) => !p.failed) ||
+    (hasActivePartial ||
+      visiblePending.some((p) => !p.failed) ||
       (lastMessage ? lastMessage.from === myName : false));
 
   // Dots only when the agent is verifiably on it: dispatcher up AND a
@@ -264,7 +273,11 @@ export default function TalkChat() {
     (t) => t.steps_in_flight > 0 || t.pending.includes("message")
   );
   const showTyping =
-    waitingForReply && dispatcherRunning && thinkerBusy && !typingExpired;
+    waitingForReply &&
+    !hasActivePartial &&
+    dispatcherRunning &&
+    thinkerBusy &&
+    !typingExpired;
   const showDeclinedNote =
     lastSentAt !== null &&
     lastOutcome === "no-reply" &&
@@ -274,7 +287,11 @@ export default function TalkChat() {
     lastOutcome === "failed" &&
     (lastMessage ? lastMessage.from === myName : false);
   const showNoReplyNote =
-    waitingForReply && typingExpired && !showDeclinedNote && !showFailedNote;
+    waitingForReply &&
+    typingExpired &&
+    !hasActivePartial &&
+    !showDeclinedNote &&
+    !showFailedNote;
   awaitingRef.current = waitingForReply;
 
   // Follow new messages only when already reading the latest ones.


### PR DESCRIPTION
## Summary

- Stream responder LLM stdout into an ephemeral per-trigger partial file under the identity run directory.
- Expose active partial replies through the chat API without persisting them to trajectory history.
- Render partial replies in the talk UI as the existing incoming bubble, keep fast polling while partials are active, and suppress duplicate typing/timeout affordances.
- Treat nonzero LLM exits as reply failures even if stdout contains partial text or `NO_REPLY`.

Fixes #75

## RED / GREEN proof

RED on upstream `origin/main` with the new responder regression:

```text
FAIL partial reply is visible while llm is still running -- missing /tmp/tmp.6xu3gVi946/id/run/responder-partials/trig-1/content.txt
3 passed, 1 failed
```

RED on upstream `origin/main` with the new chat API regression:

```text
FAILED web/tests/test_chat_api.py::test_chat_includes_active_partial_reply
1 failed in 0.98s
```

GREEN on this branch:

```text
test_responder_partial_reply.sh: 12 passed, 0 failed
web/tests/test_chat_api.py: 18 passed
```

## Validation

```text
full local validation suite baseline on origin/main: pass
full local validation suite final on 05d283b: pass
bash suite: passed 40, failed 0
web pytest: 178 passed, 2 skipped
python diff coverage: 44/44 added lines covered
viewer test: 13 passed
viewer typecheck: pass
viewer build: pass
```

Browser/API proof against a served production build:

```text
partial_text=partial reply in progress
chat_request_count=2
typing_dot_count=0
timeout_note_count=0
```

## Review notes

Independent review found and this branch covers these edge cases:

- partial stdout from a failed LLM call is never sent as the final reply
- failed `NO_REPLY` output records `reply-failed`, not permanent `no-reply`
- retry partials remain visible after a prior `reply failed` outcome
- partial files tolerate incomplete UTF-8 writes during polling
- malformed step IDs cannot make partial cleanup delete unrelated `run/` files
