### PR TITLE
Chat composer: Shift+Enter for newline, Enter to send

### DIFF
--- a/web/viewer/app/components/ui/textarea.tsx
+++ b/web/viewer/app/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "~/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input flex min-h-9 w-full resize-none overflow-y-auto rounded-md border bg-transparent px-3 py-1.5 text-base transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/web/viewer/app/hooks/use-autosize-textarea.ts
+++ b/web/viewer/app/hooks/use-autosize-textarea.ts
@@ -13,7 +13,11 @@ export function useAutosizeTextarea(value: string) {
     const el = ref.current;
     if (!el) return;
     el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
+    const styles = window.getComputedStyle(el);
+    const borderHeight =
+      (Number.parseFloat(styles.borderTopWidth) || 0) +
+      (Number.parseFloat(styles.borderBottomWidth) || 0);
+    el.style.height = `${el.scrollHeight + borderHeight}px`;
   }, [value]);
 
   return ref;

--- a/web/viewer/app/hooks/use-autosize-textarea.ts
+++ b/web/viewer/app/hooks/use-autosize-textarea.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Grows a textarea to fit its content (up to CSS max-height, where it
+ * switches to internal scrolling) by measuring scrollHeight on each change.
+ * Plain CSS `field-sizing: content` would do this alone, but isn't
+ * supported on older Safari/iOS, which the chat composers need to target.
+ */
+export function useAutosizeTextarea(value: string) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [value]);
+
+  return ref;
+}

--- a/web/viewer/app/routes/chat.test.tsx
+++ b/web/viewer/app/routes/chat.test.tsx
@@ -1,0 +1,133 @@
+// Composer keyboard behavior on the chat page: Enter sends, Shift+Enter
+// does not (so it can insert a newline via native textarea behavior).
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ChatPage from "~/routes/chat";
+import type {
+  ChatLog,
+  Config,
+  IdentityActivity,
+  IdentityStatus,
+  ThinkersStatus,
+} from "~/lib/types";
+
+// jsdom ships no scrollIntoView; the message list auto-scrolls with one.
+Element.prototype.scrollIntoView ??= () => {};
+
+const sendChat = vi.fn(
+  async (_identityId: string, _content: string, from: string) => ({
+    ok: true,
+    from,
+    to: "ada",
+  })
+);
+
+vi.mock("~/lib/api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("~/lib/api")>();
+  return {
+    ...mod,
+    fetchConfig: vi.fn(
+      async (): Promise<Config> => ({
+        root: "/root",
+        version: "0",
+        controls_enabled: true,
+        self_update_enabled: false,
+        default_send_from: "you",
+        git_commit: null,
+        git_branch: null,
+      })
+    ),
+    fetchIdentityStatus: vi.fn(
+      async (): Promise<IdentityStatus> => ({
+        live: false,
+        pid_alive: false,
+        dispatcher_pid: null,
+        mindlog_mtime: null,
+        mindlog_bytes: null,
+        step_count: 0,
+      })
+    ),
+    fetchThinkers: vi.fn(
+      async (): Promise<ThinkersStatus> => ({
+        identity: { id: "ada", name: "ada" },
+        dispatcher: { running: true, pid: 1 },
+        active_thinkers: 0,
+        thinkers_total: 0,
+        thinkers_disabled: 0,
+        steps_in_flight: 0,
+        pending_total: 0,
+        thinkers: [],
+      })
+    ),
+    fetchActivity: vi.fn(
+      async (): Promise<IdentityActivity> => ({
+        state: "idle",
+        dispatcher_running: true,
+        steps_in_flight: 0,
+        pending_total: 0,
+        busy_thinkers: [],
+        last_step_ts: null,
+        last_step_age_s: null,
+        run_seconds: null,
+        stall_after_s: 60,
+        cadence_s: null,
+        queued_messages: [],
+      })
+    ),
+    fetchChat: vi.fn(
+      async (): Promise<ChatLog> => ({
+        identity: { id: "ada", name: "ada" },
+        live: false,
+        messages: [],
+        outcomes: {},
+      })
+    ),
+    sendChat: (...args: Parameters<typeof sendChat>) => sendChat(...args),
+  };
+});
+
+function renderChatPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter initialEntries={["/i/ada/chat"]}>
+      <QueryClientProvider client={client}>
+        <Routes>
+          <Route path="/i/:identityId/chat" element={<ChatPage />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  sendChat.mockClear();
+});
+afterEach(cleanup);
+
+describe("chat composer", () => {
+  it("Enter sends the draft and clears the box", async () => {
+    renderChatPage();
+    const box = await screen.findByPlaceholderText("Message ada…");
+    fireEvent.change(box, { target: { value: "hello there" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    await waitFor(() => expect(sendChat).toHaveBeenCalledTimes(1));
+    expect(sendChat).toHaveBeenCalledWith("ada", "hello there", "you");
+  });
+
+  it("Shift+Enter does not send", async () => {
+    renderChatPage();
+    const box = await screen.findByPlaceholderText("Message ada…");
+    fireEvent.change(box, { target: { value: "line one" } });
+    fireEvent.keyDown(box, { key: "Enter", shiftKey: true });
+    // give any (incorrect) submit a tick to fire before asserting it didn't
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sendChat).not.toHaveBeenCalled();
+    expect((box as HTMLTextAreaElement).value).toBe("line one");
+  });
+});

--- a/web/viewer/app/routes/chat.test.tsx
+++ b/web/viewer/app/routes/chat.test.tsx
@@ -118,6 +118,9 @@ describe("chat composer", () => {
     fireEvent.keyDown(box, { key: "Enter" });
     await waitFor(() => expect(sendChat).toHaveBeenCalledTimes(1));
     expect(sendChat).toHaveBeenCalledWith("ada", "hello there", "you");
+    await waitFor(() =>
+      expect((box as HTMLTextAreaElement).value).toBe("")
+    );
   });
 
   it("Shift+Enter does not send", async () => {
@@ -129,5 +132,15 @@ describe("chat composer", () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(sendChat).not.toHaveBeenCalled();
     expect((box as HTMLTextAreaElement).value).toBe("line one");
+  });
+
+  it("Enter does not send while an input method composition is active", async () => {
+    renderChatPage();
+    const box = await screen.findByPlaceholderText("Message ada…");
+    fireEvent.change(box, { target: { value: "unfinished" } });
+    fireEvent.keyDown(box, { key: "Enter", isComposing: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sendChat).not.toHaveBeenCalled();
+    expect((box as HTMLTextAreaElement).value).toBe("unfinished");
   });
 });

--- a/web/viewer/app/routes/chat.tsx
+++ b/web/viewer/app/routes/chat.tsx
@@ -12,6 +12,8 @@ import {
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { LoadingDots } from "~/components/ui/loading-dots";
+import { Textarea } from "~/components/ui/textarea";
+import { useAutosizeTextarea } from "~/hooks/use-autosize-textarea";
 import {
   fetchChat,
   fetchConfig,
@@ -90,6 +92,7 @@ export default function ChatPage() {
   const [draft, setDraft] = useState("");
   const [myName, setMyName] = useState(storedName);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const draftRef = useAutosizeTextarea(draft);
 
   // Seed the from-field default from the CLI (chatrc default_send_from) unless
   // the user has ever touched the name field (tracked in localStorage, so the
@@ -182,7 +185,7 @@ export default function ChatPage() {
 
       {controlsEnabled && (
         <form
-          className="mt-3 flex items-center gap-2"
+          className="mt-3 flex items-end gap-2"
           onSubmit={(event) => {
             event.preventDefault();
             const content = draft.trim();
@@ -196,14 +199,22 @@ export default function ChatPage() {
               window.localStorage.setItem(MY_NAME_KEY, event.target.value);
             }}
             title="Your name (the from field on messages)"
-            className="h-9 w-24 font-mono text-xs"
+            className="h-9 w-24 shrink-0 font-mono text-xs"
           />
-          <Input
+          <Textarea
+            ref={draftRef}
             autoFocus
+            rows={1}
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                event.currentTarget.form?.requestSubmit();
+              }
+            }}
             placeholder={`Message ${identityName}…`}
-            className="h-9 flex-1"
+            className="max-h-40 flex-1 py-2"
           />
           <Button
             type="submit"

--- a/web/viewer/app/routes/chat.tsx
+++ b/web/viewer/app/routes/chat.tsx
@@ -207,8 +207,14 @@ export default function ChatPage() {
             rows={1}
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
+            enterKeyHint="send"
             onKeyDown={(event) => {
-              if (event.key === "Enter" && !event.shiftKey) {
+              if (
+                event.key === "Enter" &&
+                !event.shiftKey &&
+                !event.nativeEvent.isComposing &&
+                event.keyCode !== 229
+              ) {
                 event.preventDefault();
                 event.currentTarget.form?.requestSubmit();
               }

--- a/web/viewer/app/routes/talk-chat.test.tsx
+++ b/web/viewer/app/routes/talk-chat.test.tsx
@@ -1,0 +1,123 @@
+// The phone composer keeps Return as a newline and uses the Send button.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ChatLog,
+  Config,
+  IdentityActivity,
+  ThinkersStatus,
+} from "~/lib/types";
+import { setPwaName } from "~/lib/pwa";
+import TalkChat from "~/routes/talk-chat";
+
+Element.prototype.scrollIntoView ??= () => {};
+
+vi.mock("~/components/push-bell", () => ({ PushBell: () => null }));
+
+const sendChat = vi.fn(
+  async (_identityId: string, _content: string, from: string) => ({
+    ok: true,
+    from,
+    to: "ada",
+  })
+);
+
+vi.mock("~/lib/api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("~/lib/api")>();
+  return {
+    ...mod,
+    fetchConfig: vi.fn(
+      async (): Promise<Config> => ({
+        root: "/root",
+        version: "0",
+        controls_enabled: true,
+        self_update_enabled: false,
+        default_send_from: "you",
+        git_commit: null,
+        git_branch: null,
+      })
+    ),
+    fetchActivity: vi.fn(
+      async (): Promise<IdentityActivity> => ({
+        state: "idle",
+        dispatcher_running: true,
+        steps_in_flight: 0,
+        pending_total: 0,
+        busy_thinkers: [],
+        last_step_ts: null,
+        last_step_age_s: null,
+        run_seconds: null,
+        stall_after_s: 60,
+        cadence_s: null,
+        queued_messages: [],
+      })
+    ),
+    fetchChat: vi.fn(
+      async (): Promise<ChatLog> => ({
+        identity: { id: "ada", name: "ada" },
+        live: false,
+        messages: [],
+        outcomes: {},
+      })
+    ),
+    fetchThinkers: vi.fn(
+      async (): Promise<ThinkersStatus> => ({
+        identity: { id: "ada", name: "ada" },
+        dispatcher: { running: true, pid: 1 },
+        active_thinkers: 0,
+        thinkers_total: 0,
+        thinkers_disabled: 0,
+        steps_in_flight: 0,
+        pending_total: 0,
+        thinkers: [],
+      })
+    ),
+    sendChat: (...args: Parameters<typeof sendChat>) => sendChat(...args),
+  };
+});
+
+function renderTalkChat() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter initialEntries={["/talk/ada"]}>
+      <QueryClientProvider client={client}>
+        <Routes>
+          <Route path="/talk/:identityId" element={<TalkChat />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  sendChat.mockClear();
+  setPwaName("nick");
+});
+afterEach(cleanup);
+
+describe("phone chat composer", () => {
+  it("leaves Return for newlines and sends multiline text with the button", async () => {
+    renderTalkChat();
+    const box = await screen.findByPlaceholderText("Message ada…");
+    fireEvent.change(box, { target: { value: "line one" } });
+
+    const allowedNativeBehavior = fireEvent.keyDown(box, { key: "Enter" });
+    expect(allowedNativeBehavior).toBe(true);
+    expect(sendChat).not.toHaveBeenCalled();
+
+    fireEvent.change(box, { target: { value: "line one\nline two" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => expect(sendChat).toHaveBeenCalledTimes(1));
+    expect(sendChat).toHaveBeenCalledWith(
+      "ada",
+      "line one\nline two",
+      "pwa-nick"
+    );
+  });
+});

--- a/web/viewer/app/routes/talk-chat.tsx
+++ b/web/viewer/app/routes/talk-chat.tsx
@@ -9,8 +9,9 @@ import { toast } from "sonner";
 import { PushBell } from "~/components/push-bell";
 import { useControlsEnabled } from "~/components/thinker-controls";
 import { Button } from "~/components/ui/button";
-import { Input } from "~/components/ui/input";
 import { LoadingDots } from "~/components/ui/loading-dots";
+import { Textarea } from "~/components/ui/textarea";
+import { useAutosizeTextarea } from "~/hooks/use-autosize-textarea";
 import { fetchActivity, fetchChat, fetchThinkers, sendChat } from "~/lib/api";
 import type { ChatMessage } from "~/lib/types";
 import { getPwaName, pwaSender, setLastIdentity } from "~/lib/pwa";
@@ -165,6 +166,7 @@ export default function TalkChat() {
   const [lastSentAt, setLastSentAt] = useState<number | null>(null);
   const [typingExpired, setTypingExpired] = useState(false);
   const pendingKey = useRef(0);
+  const draftRef = useAutosizeTextarea(draft);
   const lastSentAtRef = useRef<number | null>(null);
   lastSentAtRef.current = lastSentAt;
   const awaitingRef = useRef(false);
@@ -418,18 +420,26 @@ export default function TalkChat() {
 
       {controlsEnabled && (
         <form
-          className="flex select-none items-center gap-2 border-t px-3 pt-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)]"
+          className="flex select-none items-end gap-2 border-t px-3 pt-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)]"
           onSubmit={(event) => {
             event.preventDefault();
             const content = draft.trim();
             if (content && !sendMutation.isPending) sendMutation.mutate(content);
           }}
         >
-          <Input
+          <Textarea
+            ref={draftRef}
+            rows={1}
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                event.currentTarget.form?.requestSubmit();
+              }
+            }}
             placeholder={`Message ${identityName}…`}
-            className="h-10 flex-1 rounded-full px-4"
+            className="max-h-40 min-h-10 flex-1 rounded-3xl px-4 py-2.5"
             autoComplete="off"
           />
           <Button

--- a/web/viewer/app/routes/talk-chat.tsx
+++ b/web/viewer/app/routes/talk-chat.tsx
@@ -432,12 +432,7 @@ export default function TalkChat() {
             rows={1}
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && !event.shiftKey) {
-                event.preventDefault();
-                event.currentTarget.form?.requestSubmit();
-              }
-            }}
+            enterKeyHint="enter"
             placeholder={`Message ${identityName}…`}
             className="max-h-40 min-h-10 flex-1 rounded-3xl px-4 py-2.5"
             autoComplete="off"


### PR DESCRIPTION
## What

Both chat composers (the desktop `/chat` page and the `/talk` PWA) used a
single-line `<Input>`, so there was no way to type a multi-line message at
all. This swaps in an auto-growing `<Textarea>`: Enter still sends, and
Shift+Enter inserts a newline.

## How it works

- New `Textarea` UI primitive (`components/ui/textarea.tsx`), matching the
  existing shadcn-style `Input`/`Button` components in this dir.
- New `useAutosizeTextarea` hook (`hooks/use-autosize-textarea.ts`) that grows
  the box to fit content via `scrollHeight`, capped by `max-h-40` (then
  scrolls internally). Deliberately not CSS `field-sizing: content` — that's
  unsupported on older Safari/iOS, and `/talk` is explicitly a phone PWA.
- Both composers keep their existing submit logic; the textarea's `onKeyDown`
  calls `form.requestSubmit()` on Enter (no Shift) instead of duplicating the
  trim/pending guard.

## Tests

New `app/routes/chat.test.tsx` (2 checks): Enter sends and clears the draft;
Shift+Enter does not send and leaves the draft intact. `bun run typecheck`,
`bun run build`, and the full `vitest` suite (15 tests) all pass.