### PR TITLE
llm: fix Anthropic thinking/effort payload to match the real API

### DIFF
--- a/bin/llm
+++ b/bin/llm
@@ -156,7 +156,7 @@ Options:
   --provider NAME          Provider: anthropic, openai, gemini, openrouter,
                            opencode, opencode-go, openai-compatible, or
                            adapter (needs LLM_ADAPTER)
-  --thinking [LEVEL]       Enable thinking (Anthropic: adaptive; Gemini: minimal/low/medium/high)
+  --thinking [LEVEL]       Enable thinking (Anthropic: on/off; Gemini: minimal/low/medium/high)
   --effort LEVEL           Thinking effort/provider output effort
   --raw                    Print raw non-streaming API response JSON
   -h, --help               Show this help
@@ -180,12 +180,13 @@ Thinking & effort:
   These flags control how much reasoning the model does before answering.
   Each provider implements this differently:
 
-  Anthropic (--thinking, --effort):
-    --thinking enables extended thinking (chain-of-thought visible on stderr).
-    --effort controls output effort independent of thinking:
-      low, medium, high (default), xhigh, max
-    Both flags can be combined. Without --thinking, the model still reasons
-    internally but doesn't expose it.
+  Anthropic (--thinking):
+    --thinking enables extended thinking (chain-of-thought visible on
+    stderr), budgeted at half of --max-tokens. Without --thinking, the model
+    still reasons internally but doesn't expose it. --effort is not a real
+    Anthropic API field (the API rejects it on every current model) and is
+    always ignored here; LLM_ASSUME_THINKING=1 forces it through anyway if a
+    future model ever supports it.
 
   Gemini (--thinking LEVEL):
     Gemini models think by default. --thinking sets the depth:
@@ -474,6 +475,16 @@ supports_anthropic_thinking() {
     esac
 }
 
+# output_config.effort is not a documented field in Anthropic's public
+# Messages API (verified against the real API on claude-sonnet-4-5, its
+# flagship model: "This model does not support the effort parameter" — the
+# same kind of ported assumption as the old thinking type:"adaptive" below).
+# No known model supports it, so this always returns 1 unless overridden.
+supports_anthropic_effort() {
+    [[ "${LLM_ASSUME_THINKING:-0}" == 1 ]] && return 0
+    return 1
+}
+
 supports_openai_reasoning() {
     [[ "${LLM_ASSUME_THINKING:-0}" == 1 ]] && return 0
     case "$LLM_MODEL" in
@@ -509,14 +520,25 @@ build_payload_anthropic() {
 
     if [[ "$LLM_THINKING" -eq 1 ]]; then
         if supports_anthropic_thinking; then
-            jq_filter="${jq_filter%\}} , thinking:{type:\"adaptive\",display:\"summarized\"}}"
+            # Anthropic requires an explicit budget_tokens with type:"enabled"
+            # (there is no "adaptive" type in the real API); half of
+            # max_tokens, floored at the API minimum of 1024, leaves the
+            # other half for the visible response.
+            local _thinking_budget=$(( LLM_MAX_TOKENS / 2 ))
+            (( _thinking_budget < 1024 )) && _thinking_budget=1024
+            jq_args+=(--argjson thinking_budget "$_thinking_budget")
+            jq_filter="${jq_filter%\}} , thinking:{type:\"enabled\",budget_tokens:\$thinking_budget}}"
         else
             echo "llm: --thinking ignored: $LLM_MODEL not in the known-thinking model list (LLM_ASSUME_THINKING=1 to send anyway)" >&2
         fi
     fi
 
     if [[ -n "$LLM_EFFORT" ]]; then
-        jq_filter="${jq_filter%\}} , output_config:{effort:\"$LLM_EFFORT\"}}"
+        if supports_anthropic_effort; then
+            jq_filter="${jq_filter%\}} , output_config:{effort:\"$LLM_EFFORT\"}}"
+        else
+            echo "llm: --effort ignored: $LLM_MODEL does not support output_config.effort (LLM_ASSUME_THINKING=1 to send anyway)" >&2
+        fi
     fi
 
     printf '%s' "$LLM_MESSAGES" | jq "${jq_args[@]}" "$jq_filter"

--- a/tests/test_llm_anthropic_thinking.sh
+++ b/tests/test_llm_anthropic_thinking.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# test_llm_anthropic_thinking.sh — Anthropic thinking/effort payload shape
+#
+# Usage: tests/test_llm_anthropic_thinking.sh
+#
+# Regression test for two bugs found live against the real Anthropic API on
+# claude-sonnet-4-5 (its flagship model):
+#
+#   - thinking:{type:"adaptive"} is not a real Anthropic API value — the API
+#     rejects it outright ("adaptive thinking is not supported on this
+#     model"). The real shape is type:"enabled" plus a required numeric
+#     budget_tokens.
+#   - output_config:{effort:...} is sent unconditionally whenever --effort is
+#     given, with no model-capability guard (unlike thinking) — the API
+#     rejects it too ("This model does not support the effort parameter").
+#     shellm always passes --effort alongside --thinking, so every shellm
+#     call to a real Claude model failed on this second bug even once the
+#     first was fixed.
+#
+# curl is stubbed: it captures the payload file bin/llm builds (passed as
+# `-d @file`, never argv — see "keep API keys out of curl arguments") and
+# answers with a minimal valid SSE stream, so this checks the exact JSON
+# bin/llm sends without touching the network.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+prev=""
+for a in "$@"; do
+    if [[ "$prev" == "-d" && "$a" == @* ]]; then
+        cp "${a#@}" "$LAST_PAYLOAD"
+    fi
+    prev="$a"
+done
+printf 'data: %s\n\n' '{"type":"message_start","message":{"usage":{"input_tokens":5}}}'
+printf 'data: %s\n\n' '{"type":"content_block_start","content_block":{"type":"text"}}'
+printf 'data: %s\n\n' '{"type":"content_block_delta","delta":{"text":"ok"}}'
+printf 'data: %s\n\n' '{"type":"content_block_stop"}'
+printf 'data: %s\n\n' '{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}'
+printf 'data: [DONE]\n\n'
+EOF
+chmod +x "$WORK/bin/curl"
+export PATH="$WORK/bin:$PATH"
+
+export ANTHROPIC_API_KEY="test-key"
+export HEADLONG_HOME="$WORK/home"
+mkdir -p "$HEADLONG_HOME"
+export LLM_RETRIES=0
+export LAST_PAYLOAD="$WORK/last_payload.json"
+unset LLM_PROVIDER LLM_API_URL LLM_MODEL LLM_ASSUME_THINKING
+
+LLM="$REPO/bin/llm"
+
+# ---------------------------------------------------------------------------
+# --thinking sends type:"enabled" with a budget under max_tokens, not "adaptive"
+# ---------------------------------------------------------------------------
+
+: > "$LAST_PAYLOAD"
+out=$(printf 'hi' | "$LLM" -m claude-sonnet-4-5 -t 4000 --thinking 2>"$WORK/stderr")
+rc=$?
+if [[ "$rc" -eq 0 && "$out" == *ok* ]]; then
+    ok "--thinking call succeeds"
+else
+    bad "--thinking call succeeds" "rc=$rc $(head -1 "$WORK/stderr")"
+fi
+
+thinking_type=$(jq -r '.thinking.type // "MISSING"' "$LAST_PAYLOAD")
+if [[ "$thinking_type" == "enabled" ]]; then
+    ok "thinking.type is \"enabled\", not \"adaptive\""
+else
+    bad "thinking.type is \"enabled\", not \"adaptive\"" "got: $thinking_type"
+fi
+
+budget=$(jq -r '.thinking.budget_tokens // "MISSING"' "$LAST_PAYLOAD")
+if [[ "$budget" == "2000" ]]; then
+    ok "budget_tokens is half of max_tokens (4000/2)"
+else
+    bad "budget_tokens is half of max_tokens (4000/2)" "got: $budget"
+fi
+if [[ "$budget" =~ ^[0-9]+$ ]] && (( budget < 4000 )); then
+    ok "budget_tokens stays under max_tokens"
+else
+    bad "budget_tokens stays under max_tokens" "budget=$budget max_tokens=4000"
+fi
+
+# A tiny max_tokens still floors at the API's 1024 minimum.
+: > "$LAST_PAYLOAD"
+printf 'hi' | "$LLM" -m claude-sonnet-4-5 -t 100 --thinking >/dev/null 2>"$WORK/stderr"
+floor_budget=$(jq -r '.thinking.budget_tokens // "MISSING"' "$LAST_PAYLOAD")
+if [[ "$floor_budget" == "1024" ]]; then
+    ok "budget_tokens floors at 1024 for a small max_tokens"
+else
+    bad "budget_tokens floors at 1024 for a small max_tokens" "got: $floor_budget"
+fi
+
+# ---------------------------------------------------------------------------
+# --effort is always ignored for Anthropic (no output_config field sent)
+# ---------------------------------------------------------------------------
+
+: > "$LAST_PAYLOAD"
+printf 'hi' | "$LLM" -m claude-sonnet-4-5 -t 4000 --thinking --effort high \
+    >/dev/null 2>"$WORK/stderr"
+has_output_config=$(jq -r 'has("output_config")' "$LAST_PAYLOAD")
+if [[ "$has_output_config" == "false" ]]; then
+    ok "--effort does not add output_config to the payload"
+else
+    bad "--effort does not add output_config to the payload" "payload had output_config"
+fi
+if grep -q -- "--effort ignored" "$WORK/stderr"; then
+    ok "--effort being dropped is reported on stderr"
+else
+    bad "--effort being dropped is reported on stderr" "$(cat "$WORK/stderr")"
+fi
+
+# thinking itself must still be sent even when effort is dropped alongside it
+# (this is the exact combination shellm always sends).
+still_has_thinking=$(jq -r 'has("thinking")' "$LAST_PAYLOAD")
+if [[ "$still_has_thinking" == "true" ]]; then
+    ok "thinking still sent when --effort is dropped alongside it"
+else
+    bad "thinking still sent when --effort is dropped alongside it"
+fi
+
+# ---------------------------------------------------------------------------
+# LLM_ASSUME_THINKING=1 is the escape hatch for both guards
+# ---------------------------------------------------------------------------
+
+: > "$LAST_PAYLOAD"
+printf 'hi' | LLM_ASSUME_THINKING=1 "$LLM" \
+    -m claude-sonnet-4-5 -t 4000 --effort high >/dev/null 2>"$WORK/stderr"
+effort_val=$(jq -r '.output_config.effort // "MISSING"' "$LAST_PAYLOAD")
+if [[ "$effort_val" == "high" ]]; then
+    ok "LLM_ASSUME_THINKING=1 forces output_config.effort through"
+else
+    bad "LLM_ASSUME_THINKING=1 forces output_config.effort through" "got: $effort_val"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Fixes #99

## What

`thinking:{type:"adaptive"}` and `output_config:{effort:...}` are not real
fields in Anthropic's public Messages API. The real API rejects both on
claude-sonnet-4-5, its flagship model. `shellm` always calls `bin/llm`
with `--thinking --effort high`, so monolith wakeup fails on any real
Anthropic Claude model. `responder` calls `bin/llm` directly, without
`--thinking`/`--effort`, so chat replies keep working and can look like
everything is fine.

## How it works

- `thinking.type` is now `"enabled"`, with a required `budget_tokens` —
  half of `max_tokens`, floored at the API's 1024 minimum, leaving the
  other half of the token budget for the visible response.
- `output_config.effort` is now gated behind a new
  `supports_anthropic_effort()` guard, mirroring the existing
  `supports_anthropic_thinking()`/`supports_openai_reasoning()`/
  `supports_gemini_thinking()` guards. It returns false for every known
  model, since none of them accept this field via the real API.
  `LLM_ASSUME_THINKING=1` is the same escape hatch already used for the
  other guards, for a future model that does support it.
- Help text (`--thinking`, the Anthropic section under "Thinking &
  effort") updated to match.

## Tests

New `tests/test_llm_anthropic_thinking.sh` (9 checks, curl stubbed to
capture the outgoing payload): `thinking.type` is `"enabled"` not
`"adaptive"`, `budget_tokens` is half of `max_tokens` and floors at 1024,
`--effort` no longer adds `output_config` and is reported on stderr,
`thinking` still sends when `--effort` is dropped alongside it (the exact
combination `shellm` always sends), and `LLM_ASSUME_THINKING=1` forces
`output_config.effort` through.

Verified against the real Anthropic API (not just the stub): both flags
together on `claude-sonnet-4-5` now succeed end to end, live on a
previously-broken identity — monolith went from 100% `rc=1` to a normal
multi-iteration run immediately after.

Full `tests/run-all.sh`: 37/38 pass; the one failure
(`test_thinkers_pending.sh`) is unrelated dispatcher-queue timing, and
fails the same way on unmodified `main` in this environment.
`shellcheck -S warning`, `bash -n`, and a bash-3.2 parse check are all
clean.
