### PR TITLE
llm/shellm: add OpenAI Responses completion protocol

### DIFF
--- a/.agents/skills/operating-headlong
+++ b/.agents/skills/operating-headlong
@@ -1,0 +1,1 @@
+../../skills/operating-headlong

--- a/.agents/skills/operating-headlong-responses
+++ b/.agents/skills/operating-headlong-responses
@@ -1,0 +1,1 @@
+../../skills/operating-headlong-responses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
         # image; uuidgen (uuid-runtime) is installed explicitly so a nested
         # shellm run never depends on the image's package set.
         run: sudo apt-get install -y -qq uuid-runtime >/dev/null
+      - uses: astral-sh/setup-uv@v7
+        # tools/responses-ws is a uv script (websockets); its test skips
+        # without uv, which would leave the WebSocket transport unexercised.
       - name: Run tests/test_*.sh
         run: tests/run-all.sh
 
@@ -171,6 +174,7 @@ jobs:
         run: |
           brew list coreutils >/dev/null 2>&1 || brew install -q coreutils
           brew list jq >/dev/null 2>&1 || brew install -q jq
+          brew list uv >/dev/null 2>&1 || brew install -q uv
       - name: Make Apple's /bin/bash the `bash` on PATH
         # The image also has Homebrew bash 5 on PATH, which would hide every
         # 3.2 problem. A shim dir ahead of everything else makes `bash` and
@@ -274,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LOC_LIMIT: 11500
+      LOC_LIMIT: 12000
     steps:
       - uses: actions/checkout@v5
       - name: Install cloc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
         # shellm run never depends on the image's package set.
         run: sudo apt-get install -y -qq uuid-runtime >/dev/null
       - uses: astral-sh/setup-uv@v7
-        # tools/responses-ws is a uv script (websockets); its test skips
-        # without uv, which would leave the WebSocket transport unexercised.
+        # tools/responses-ws is a uv script (websockets); its test requires
+        # uv so the WebSocket transport cannot silently remain unexercised.
       - name: Run tests/test_*.sh
         run: tests/run-all.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@
 #   gitleaks       gitleaks git (full history)  secrets; allowlist in .gitleaks.toml
 #   loc            cloc bin/ thinkers/          the harness stays under
 #                                               LOC_LIMIT code lines (the
-#                                               README's "about 10K lines"
+#                                               README's "about 11K lines"
 #                                               claim; was 10K at the launch
 #                                               blog post, week of 2026-08-24)
 #   alert-main     Slack post                    after each push to main: red
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LOC_LIMIT: 11000
+      LOC_LIMIT: 11500
     steps:
       - uses: actions/checkout@v5
       - name: Install cloc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LOC_LIMIT: 11500
+      LOC_LIMIT: 11600
     steps:
       - uses: actions/checkout@v5
       - name: Install cloc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LOC_LIMIT: 11000
+      LOC_LIMIT: 11500
     steps:
       - uses: actions/checkout@v5
       - name: Install cloc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@
 #   gitleaks       gitleaks git (full history)  secrets; allowlist in .gitleaks.toml
 #   loc            cloc bin/ thinkers/          the harness stays under
 #                                               LOC_LIMIT code lines (the
-#                                               README's "about 11K lines"
+#                                               README's "about 10K lines"
 #                                               claim; was 10K at the launch
 #                                               blog post, week of 2026-08-24)
 #   alert-main     Slack post                    after each push to main: red
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LOC_LIMIT: 11600
+      LOC_LIMIT: 11000
     steps:
       - uses: actions/checkout@v5
       - name: Install cloc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,24 @@ Replies take 15 to 45 seconds while the monolith thinker wakes.
 - Responses mode (`SHELLM_API_FORMAT=responses`) keeps its continuation
   state per process: response ids and the replay chain live in the run's
   temp dir and vanish with it, and a `--resume` starts a fresh chain from
-  the trajectory. Only `SHELLM_RESPONSES_CONVERSATION` is durable across
-  runs (the id is written to the `shellm-run` header row). The knobs and
-  their interplay are in the Responses sections of
-  [docs/shellm.md](docs/shellm.md); the contracts are
-  design/responses-api.md and design/responses-lifecycle.md.
+  the trajectory. Conversation mode instead persists its id in the run
+  header and private sent-step acknowledgements under the trajectory
+  directory's `.responses-conversations/`. A whole-run local lock prevents
+  competing writers; ambiguous, missing, mismatched checkpoints or stale
+  locks fail closed. Do not delete a lock and blindly retry. Responses
+  CREATE is never automatically retried; preserve `outcome_unknown` and
+  recovery handles rather than assuming nothing happened.
+
+## Operating guides and skills
+
+- [Operating Headlong](docs/operating-headlong.md): core identity, thinker,
+  chat, memory, trajectory, context, and skill workflows and safety boundaries.
+- [Using Responses](docs/responses-guide.md): choosing a completion worker,
+  background recovery, sessions, transport, compaction, and executable examples.
+- [shellm reference](docs/shellm.md): the execution loop and its configuration.
+- Agent skills: `operating-headlong` and `operating-headlong-responses` in
+  `skills/`, also discoverable through `.agents/skills/` symlinks. The legacy
+  `shellm` skill now routes to the correct engine/framework documentation.
+- Protocol contracts: `design/responses-api.md` and
+  `design/responses-lifecycle.md`. Synthetic protocol tests do not certify
+  live-provider behavior; paid verification requires an approved spend scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,11 @@ Replies take 15 to 45 seconds while the monolith thinker wakes.
 - The dashboard binds localhost by default and `0.0.0.0` in a container.
   A failed dashboard does not fail the install; check `dash.status` in
   `status.json` and `<state-home>/logs/web.log`.
+- Responses mode (`SHELLM_API_FORMAT=responses`) keeps its continuation
+  state per process: response ids and the replay chain live in the run's
+  temp dir and vanish with it, and a `--resume` starts a fresh chain from
+  the trajectory. Only `SHELLM_RESPONSES_CONVERSATION` is durable across
+  runs (the id is written to the `shellm-run` header row). The knobs and
+  their interplay are in the Responses sections of
+  [docs/shellm.md](docs/shellm.md); the contracts are
+  design/responses-api.md and design/responses-lifecycle.md.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![CI](https://github.com/laude-institute/headlong/actions/workflows/ci.yml/badge.svg)](https://github.com/laude-institute/headlong/actions/workflows/ci.yml)
 
 **Headlong** is an open source agent microharness, a complete agent harness
-with a core of about 11K lines of Bash.
+with a core of about 12K lines of Bash.
 
 [Launch post](https://www.laude.org/updates/headlong-a-microharness-for-persistent-agents) |
 [Announcement](https://x.com/andykonwinski/status/2091990178638496195)
@@ -158,7 +158,7 @@ Headlong also gives an agent a few convenience tools, such as a way to
 distill and codify its experience (`mem`) and a way to save and reuse
 procedures for specialized tasks (`skills`). The core is the tools the
 running mind executes, the executables in `bin/` plus the thought
-processes in `thinkers/`, and it comes to about 11.5K lines by cloc's count (capped at 12K). A
+processes in `thinkers/`, and it comes to about 11.9K lines by cloc's count (capped at 12K). A
 harness this small can be read end to end, and it is easy to modify and
 experiment with.
 
@@ -287,6 +287,13 @@ in [design/providers.md](design/providers.md).
 
 ## Learn more
 
+- [Operating Headlong](docs/operating-headlong.md) — choose a runtime and
+  operate identities, thinkers, chat, memory, trajectories, and skills safely
+- [Using Responses](docs/responses-guide.md) — completion workers, background
+  recovery, resumable sessions, WebSocket transport, compaction, and examples
+- [Agent operating skills](skills/README.md) — procedural guidance for core
+  Headlong and Responses, installed with the framework and discoverable by
+  coding agents in this checkout
 - [philosophy.md](philosophy.md) — the case for applying Ken Thompson's
   philosophy to agent microharnesses, and the full design story
 - [docs/shellm.md](docs/shellm.md) — the shellm engine reference: the

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ in [docs/install.md](docs/install.md).
   stream also means no hard walls between people: assume anything you
   tell the agent is shared with everyone who talks to it.
 - **Built around Ken Thompson's philosophy.** The core tooling is a
-  handful of small Bash executables (`shellm`, `traj`, `llm`, `context`,
-  `mem`, `skills`, ...), each doing one thing well and composing through
+  handful of small Bash executables (`shellm`, `traj`, `llm`, `responses`,
+  `context`, `mem`, `skills`, ...), each doing one thing well and composing through
   pipes, files, and environment variables. The model writes shell
   commands, so `curl` is the HTTP client and `jq` is the JSON processor.
 - **An agent's trajectory is a DAG of jsonl files** with fork and merge.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Headlong also gives an agent a few convenience tools, such as a way to
 distill and codify its experience (`mem`) and a way to save and reuse
 procedures for specialized tasks (`skills`). The core is the tools the
 running mind executes, the executables in `bin/` plus the thought
-processes in `thinkers/`, and it comes to about 11K lines by cloc's count (capped at 11.5K). A
+processes in `thinkers/`, and it comes to about 11.5K lines by cloc's count (capped at 12K). A
 harness this small can be read end to end, and it is easy to modify and
 experiment with.
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -6,6 +6,6 @@ and the smaller tools around them. The table in the root
 [README](../README.md) says what each one does, and
 [docs/shellm.md](../docs/shellm.md) is the engine reference.
 
-Code in `bin/` and `thinkers/` counts against the under-11.5K-lines core
+Code in `bin/` and `thinkers/` counts against the under-10K-lines core
 (`cloc bin/ thinkers/`), so keep additions small. Tooling that runs
 around the mind rather than inside it belongs in [tools/](../tools/).

--- a/bin/README.md
+++ b/bin/README.md
@@ -6,6 +6,6 @@ and the smaller tools around them. The table in the root
 [README](../README.md) says what each one does, and
 [docs/shellm.md](../docs/shellm.md) is the engine reference.
 
-Code in `bin/` and `thinkers/` counts against the under-10K-lines core
+Code in `bin/` and `thinkers/` counts against the under-11.5K-lines core
 (`cloc bin/ thinkers/`), so keep additions small. Tooling that runs
 around the mind rather than inside it belongs in [tools/](../tools/).

--- a/bin/context
+++ b/bin/context
@@ -15,6 +15,8 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 
 CTX_HEAD="${CTX_HEAD:-1}"
+CTX_IDS=0
+CTX_MERGE=1
 CTX_TAIL="${CTX_TAIL:-50}"
 CTX_TAIL_BLOCK="${CTX_TAIL_BLOCK:-1}"
 CTX_PROMPT_LIMIT="${SHELLM_STDOUT_PROMPT_LIMIT:-2048}"
@@ -58,6 +60,12 @@ Step selection:
                         changes once per B appended rows instead of on every
                         call (keeps provider prompt caches warm). Default: 1.
   --pin <step_id>       Always include this step. Repeatable.
+  --ids                 Tag each message with step_ids: the rows it renders
+                        ([] for an elision marker). For callers that must
+                        tell new rows from re-rendered ones.
+  --no-merge            Keep consecutive same-role messages separate (the
+                        default merges them for APIs that require
+                        alternation). One row, one message.
   --run RUN_ID          Keep only steps whose run_id is RUN_ID (pins always
                         stay). Steps of other runs never render and never
                         count as elided; a gap inside the run renders as
@@ -105,6 +113,8 @@ while [[ $# -gt 0 ]]; do
         --tail)             CTX_TAIL="${2:?--tail requires N}"; shift 2 ;;
         --tail-block)       CTX_TAIL_BLOCK="${2:?--tail-block requires B}"; shift 2 ;;
         --pin)              CTX_PINS+=("${2:?--pin requires step_id}"); shift 2 ;;
+        --ids)              CTX_IDS=1; shift ;;
+        --no-merge)         CTX_MERGE=0; shift ;;
         --prompt-limit)     CTX_PROMPT_LIMIT="${2:?--prompt-limit requires BYTES}"; shift 2 ;;
         --block-limit)      CTX_BLOCK_LIMIT="${2:?--block-limit requires BYTES}"; shift 2 ;;
         --whole-blocks)     CTX_WHOLE_BLOCKS="${2:?--whole-blocks requires W}"; shift 2 ;;
@@ -353,22 +363,25 @@ def render_step($limit0; $blobs; $full):
 def build_messages($kept; $limit; $blobs; $elision; $total; $skip; $full; $run):
   def gap_between($a; $b):
     ($b - $a - 1) - ([$skip[] | select(. > $a and . < $b)] | length);
+  # --ids: a rendered row carries its step_id; a marker carries none.
+  def tag($m; $sids): if $ids == 1 then $m + {step_ids: $sids} else $m end;
   def marker($gap; $first):
-    if $run == "" then [{role: "user", content: "[\($gap) steps elided]"}]
+    if $run == "" then [tag({role: "user", content: "[\($gap) steps elided]"}; [])]
     elif $first then []
-    else [{role: "user", content: "[earlier steps elided]"}] end;
+    else [tag({role: "user", content: "[earlier steps elided]"}; [])] end;
   reduce $kept[] as $it ({msgs: [], last: -1};
       gap_between(.last; $it.i) as $gap |
       (if $elision != "none" and $gap > 0
        then .msgs + marker($gap; .last == -1)
        else .msgs end) as $m |
       ($it.row | render_step(row_limit($it.i; $total; $limit; $blocklimit); $blobs; $full) | rtrim) as $c |
-      {msgs: (if $c == "" then $m else $m + [{role: $it.role, content: $c}] end),
+      {msgs: (if $c == "" then $m
+              else $m + [tag({role: $it.role, content: $c}; [($it.row.step_id | tostring)])] end),
        last: $it.i}
   ) |
   (gap_between(.last; $total) as $gap |
    if $elision != "none" and $gap > 0 and $run == ""
-   then .msgs + [{role: "user", content: "[\($gap) steps elided]"}]
+   then .msgs + [tag({role: "user", content: "[\($gap) steps elided]"}; [])]
    else .msgs end);
 
 # Merge consecutive same-role messages (Anthropic API requires alternation).
@@ -376,6 +389,9 @@ def merge_roles:
   reduce .[] as $msg ([];
       if (length > 0) and (.[-1].role == $msg.role) then
           .[-1].content += ("\n---\n" + $msg.content)
+          | if ($msg | has("step_ids"))
+            then .[-1].step_ids = ((.[-1].step_ids // []) + $msg.step_ids)
+            else . end
       else . + [$msg]
       end
   );
@@ -412,7 +428,8 @@ if $mode == "refs" then
     ] | unique | .[]
 else
     $N,
-    (build_messages($kept; $limit; $blobs; $elision; $total; $skip; $FULL; $run) | merge_roles)
+    (build_messages($kept; $limit; $blobs; $elision; $total; $skip; $FULL; $run)
+     | if $merge == 1 then merge_roles else . end)
 end
 JQEOF
 )
@@ -481,6 +498,8 @@ _ctx_jq() {
         --argjson limit "$2" \
         --argjson blocklimit "${4:-$2}" \
         --argjson pins "$PINS_JSON" \
+        --argjson ids "$CTX_IDS" \
+        --argjson merge "$CTX_MERGE" \
         --arg astr "$CTX_ASSISTANT_TYPES" \
         --arg ustr "$CTX_USER_TYPES" \
         --arg estr "$CTX_EXCLUDE_TYPES" \

--- a/bin/llm
+++ b/bin/llm
@@ -94,9 +94,8 @@ LLM_RESPONSE_FILE="${LLM_RESPONSE_FILE:-}"
 # caller. Best-effort: fields the provider doesn't report are omitted, and no
 # failure here can break the call.
 LLM_USAGE_FILE="${LLM_USAGE_FILE:-}"
-# Transient-failure retries (provider errors, 429/5xx, network). Retries
-# only happen when NOTHING has been emitted yet — a retry after partial
-# streamed output would duplicate text. LLM_RETRIES=0 disables.
+# Chat retries only before output; Responses never retries a create because
+# silence does not prove non-dispatch. LLM_RETRIES=0 disables chat retries.
 LLM_RETRIES="${LLM_RETRIES:-2}"
 LLM_RETRY_BACKOFF="${LLM_RETRY_BACKOFF:-1}"   # seconds; grows linearly per attempt
 
@@ -361,8 +360,8 @@ Environment:
                            precedence, and a value that disagrees with the
                            name warns on stderr
   LLM_MAX_TOKENS           Override the per-model default output cap (same as -t)
-  LLM_RETRIES              Retries for transient API failures (default: 2;
-                           0 disables). Never retries after partial output.
+  LLM_RETRIES              Chat retries before output (default: 2; 0 disables).
+                           Responses CREATE is never automatically retried
   LLM_RETRY_BACKOFF        Backoff base seconds between retries (default: 1)
   LLM_CONNECT_TIMEOUT      Seconds to establish the connection (default: 10;
                            0 disables)
@@ -1106,8 +1105,28 @@ check_response_responses() {
     jq -r '
         if .error != null then .error.message // "unknown error"
         elif .status == "failed" then .error.message // "response failed"
+        elif .status == "cancelled" then "response cancelled"
         else empty end
     ' 2>/dev/null
+}
+
+# Only a valid terminal object is a successful Responses completion. An empty
+# text field can be legitimate (tools, refusals), but an empty/error envelope
+# cannot. Keep this contract identical for SSE and buffered responses.
+valid_response_terminal() {
+    jq -e 'type == "object" and .error == null
+        and (.id | type == "string" and length > 0)
+        and (.output | type == "array")
+        and (.status == "completed" or .status == "incomplete")' >/dev/null 2>&1
+}
+
+responses_outcome_unknown() {
+    local reason="$1" id="${2:-}"
+    jq -nc --arg message "$reason" --arg id "$id" \
+        '{error:{code:"outcome_unknown",message:$message}}
+         + (if $id == "" then {} else {id:$id} end)' | write_response_file
+    _llm_note error "" "outcome_unknown: $reason"
+    die "Responses outcome_unknown: $reason${id:+ (response $id)}; do not automatically recreate"
 }
 
 check_response_gemini() {
@@ -1399,7 +1418,7 @@ stream_openai() {
 }
 
 stream_responses() {
-    local _saw_data=0 _err_buf="" _chunk="" _event="" _response=""
+    local _saw_data=0 _err_buf="" _chunk="" _event="" _response="" _bg_id="" _rid=""
     local _text_emitted=0 _reasoning_emitted=0 _terminal=0
     while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
         local line="${raw_line%$'\r'}"
@@ -1408,6 +1427,14 @@ stream_responses() {
             local json="${line#data: }"
             [[ "$json" == "[DONE]" ]] && continue
             _event=$(printf '%s' "$json" | jq -r '.type // empty' 2>/dev/null) || _event=""
+            _rid=$(printf '%s' "$json" | jq -r '.response.id // empty' 2>/dev/null) || _rid=""
+            if [[ -n "$_rid" ]]; then
+                [[ "$_rid" =~ ^[A-Za-z0-9_-]+$ ]] \
+                    || responses_outcome_unknown "invalid stream response identity" "$_bg_id"
+                [[ -z "$_bg_id" || "$_bg_id" == "$_rid" ]] \
+                    || responses_outcome_unknown "stream changed response identity" "$_bg_id"
+                _bg_id="$_rid"
+            fi
             case "$_event" in
                 response.output_text.delta|response.refusal.delta)
                     # Preserve newline-only deltas; see stream_openai.
@@ -1435,6 +1462,8 @@ stream_responses() {
                     ;;
                 response.completed|response.incomplete)
                     _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
+                    printf '%s' "$_response" | valid_response_terminal \
+                        || responses_outcome_unknown "invalid terminal response" "$_bg_id"
                     if [[ -n "$_response" ]] \
                         && printf '%s' "$_response" | jq -e --arg status "${_event#response.}" \
                             '.status == $status' >/dev/null 2>&1; then
@@ -1472,19 +1501,22 @@ stream_responses() {
                                 warn_incomplete_response "$_reason"
                             fi
                         fi
+                    else
+                        responses_outcome_unknown "terminal event and response status disagree" "$_bg_id"
                     fi
                     mark_emitted
+                    ;;
+                response.cancelled)
+                    _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
+                    [[ -n "$_response" ]] && printf '%s' "$_response" | write_response_file
+                    die_permanent "API stream error: response cancelled"
                     ;;
                 response.failed)
                     _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
                     [[ -n "$_response" ]] && printf '%s' "$_response" | write_response_file
                     local _failed_msg=""
                     _failed_msg=$(printf '%s' "$json" | jq -r '.response.error.message // .error.message // "response failed"' 2>/dev/null) || _failed_msg="response failed"
-                    if [[ -e "$LLM_DATA_MARKER" ]]; then
-                        die "API stream error: $_failed_msg"
-                    else
-                        die_retryable "API stream error: $_failed_msg"
-                    fi
+                    die_permanent "API stream error: $_failed_msg"
                     ;;
                 error)
                     printf '%s' "$json" | write_response_file
@@ -1510,10 +1542,7 @@ stream_responses() {
     # event never arrives, so there is no sidecar and usage is estimated.
     [[ -n "${LLM_STOP_MARKER:-}" && -e "$LLM_STOP_MARKER" ]] && return 0
     if [[ "$_terminal" -ne 1 ]]; then
-        if [[ -e "$LLM_DATA_MARKER" ]]; then
-            die "API stream error: Responses stream ended without a terminal response"
-        fi
-        die_retryable "API stream error: Responses stream ended without a terminal response"
+        responses_outcome_unknown "Responses stream ended without a terminal response" "$_bg_id"
     fi
 }
 
@@ -1780,7 +1809,7 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         # Anthropic overloaded_error arrives as an in-stream error event and
         # exits 1, not 75), with one exception: a handler that exited 76
         # (die_permanent) saw an error a replay cannot fix.
-        if [[ "$_emitted" -eq 0 && "$_rc" -ne 76 \
+        if [[ "$LLM_API_FORMAT" != responses && "$_emitted" -eq 0 && "$_rc" -ne 76 \
             && "$_attempt" -lt "$_max_attempts" ]]; then
             echo "llm: transient API failure (attempt $_attempt/$_max_attempts): ${_retry_msg:-${_ce:-exit $_rc}} — retrying" >&2
             sleep $(( LLM_RETRY_BACKOFF * _attempt ))
@@ -1803,7 +1832,7 @@ else
             "${headers[@]}" -d @"$payload_file" "$url" 2>/dev/null) || http_code="000"
 
         # Transient: network failure, timeout, rate limit, server error
-        if [[ "$http_code" =~ ^(000|408|429|5[0-9][0-9])$ && "$_attempt" -lt "$_max_attempts" ]]; then
+        if [[ "$LLM_API_FORMAT" != responses && "$http_code" =~ ^(000|408|429|5[0-9][0-9])$ && "$_attempt" -lt "$_max_attempts" ]]; then
             echo "llm: transient API failure (attempt $_attempt/$_max_attempts): HTTP $http_code — retrying" >&2
             rm -f "$local_resp"
             sleep $(( LLM_RETRY_BACKOFF * _attempt ))
@@ -1815,7 +1844,7 @@ else
         if [[ "$http_code" != "000" && "$http_code" -lt 400 ]]; then
             if grep -q '[^[:space:]]' "$local_resp"; then
                 if [[ "$LLM_API_FORMAT" == responses ]]; then
-                    embedded_err=$(check_response_responses < "$local_resp")
+                    embedded_err=$(check_response_responses < "$local_resp" || true)
                 else
                     embedded_err=$("check_response_${LLM_PROVIDER}" < "$local_resp")
                 fi
@@ -1825,12 +1854,14 @@ else
                 # parse-fail to empty on it, which used to read as success
                 # with no output.
                 embedded_err="whitespace-only response body"
+                [[ "$LLM_API_FORMAT" != responses ]] \
+                    || responses_outcome_unknown "$embedded_err"
             fi
             if [[ -n "$embedded_err" ]]; then
-                if [[ "$LLM_API_FORMAT" == responses ]] \
-                    && jq -e '.status == "failed"' "$local_resp" >/dev/null 2>&1; then
+                if [[ "$LLM_API_FORMAT" == responses ]]; then
                     write_response_file < "$local_resp"
                     rm -f "$local_resp"
+                    _llm_note error "" "$embedded_err"
                     die "API error: $embedded_err"
                 fi
                 if [[ "$_attempt" -lt "$_max_attempts" ]]; then
@@ -1849,9 +1880,18 @@ else
         break
     done
 
+    _response_id=""
+    if [[ "$LLM_API_FORMAT" == responses ]]; then
+        _response_id=$(jq -r '.id? | strings' "$local_resp" 2>/dev/null || true)
+    fi
     if [[ "$http_code" -ge 400 || "$http_code" == "000" ]]; then
         error_msg=$(jq -r '.error.message // .message // empty' "$local_resp" 2>/dev/null || true)
         if [[ "$LLM_API_FORMAT" == responses ]]; then
+            if [[ "$http_code" =~ ^(000|408|5[0-9][0-9])$ ]]; then
+                rm -f "$local_resp"
+                _llm_note error "$http_code" "create outcome unknown"
+                responses_outcome_unknown "create failed with HTTP $http_code; provider acceptance is unknown" "$_response_id"
+            fi
             if [[ -s "$local_resp" ]] && jq -e . "$local_resp" >/dev/null 2>&1; then
                 write_response_file < "$local_resp"
             else
@@ -1867,6 +1907,12 @@ else
             die "API error (HTTP $http_code): $error_msg"
         fi
         die "API error (HTTP $http_code)"
+    fi
+    if [[ "$LLM_API_FORMAT" == responses ]]; then
+        if ! valid_response_terminal < "$local_resp"; then
+            rm -f "$local_resp"
+            responses_outcome_unknown "invalid or nonterminal response body" "$_response_id"
+        fi
     fi
     _llm_note ok
 

--- a/bin/llm
+++ b/bin/llm
@@ -85,6 +85,13 @@ LLM_API_FORMAT="${LLM_API_FORMAT:-chat}"
 LLM_RESPONSES_BODY_FILE="${LLM_RESPONSES_BODY_FILE:-}"
 LLM_PREVIOUS_RESPONSE_ID="${LLM_PREVIOUS_RESPONSE_ID:-}"
 LLM_RESPONSE_FILE="${LLM_RESPONSE_FILE:-}"
+# Background Responses (design/responses-lifecycle.md): the create returns at
+# once and the model keeps working server-side. llm then polls, or streams and
+# resumes the stream from its last sequence number when it drops, and cancels
+# the job when it is killed or runs out of time. LLM_RESPONSES_BACKGROUND=1
+# turns it on, 0 forces foreground over a body file that asks for it, unset
+# leaves the body file's say.
+LLM_RESPONSES_POLL_INTERVAL="${LLM_RESPONSES_POLL_INTERVAL:-2}"
 # Token usage is captured on every call. A caller that wants this call's
 # numbers sets LLM_USAGE_FILE and gets a one-line JSON record
 # ({in_tok, out_tok, think_tok}) written there after the call (bin/shellm
@@ -354,6 +361,15 @@ Environment:
   LLM_PREVIOUS_RESPONSE_ID Continue a stored Responses chain from this response
   LLM_RESPONSE_FILE        Atomically write the full terminal Response object,
                            or a provider error envelope, to this mode-0600 file
+  LLM_RESPONSES_BACKGROUND 1 runs the Responses create in the background: llm
+                           polls the response by id (--no-stream), or streams
+                           it and resumes a dropped stream from its last
+                           sequence number, and cancels the job when killed,
+                           out of time, or out of resumes. 0 forces foreground
+                           over a body file that asks for background
+  LLM_RESPONSES_POLL_INTERVAL
+                           Seconds between background polls (default 2,
+                           doubling to 10). LLM_MAX_TIME bounds the whole wait
   LLM_ADAPTER              Path to an adapter executable; required with
                            --provider adapter (contract: design/providers.md)
   LLM_PROVIDER             Provider to use when the model name implies none
@@ -493,20 +509,27 @@ if [[ -z "$LLM_PROVIDER" ]]; then
 fi
 
 case "$LLM_API_FORMAT" in
-    chat) ;;
+    chat)
+        if [[ -n "${LLM_RESPONSES_BACKGROUND:-}" ]]; then
+            echo "llm: note: LLM_RESPONSES_BACKGROUND ignored with LLM_API_FORMAT=chat" >&2
+        fi
+        ;;
     responses)
         case "$LLM_PROVIDER" in
             openai|openrouter|openai-compatible) ;;
             *) die "Responses format is not supported for provider $LLM_PROVIDER (use openai, openrouter, or openai-compatible)" ;;
         esac
+        case "${LLM_RESPONSES_BACKGROUND:-}" in
+            ""|0|1) ;;
+            *) die "Invalid LLM_RESPONSES_BACKGROUND '$LLM_RESPONSES_BACKGROUND' (expected 0 or 1)" ;;
+        esac
+        [[ "$LLM_RESPONSES_POLL_INTERVAL" =~ ^[0-9]+$ ]] \
+            || die "Invalid LLM_RESPONSES_POLL_INTERVAL '$LLM_RESPONSES_POLL_INTERVAL' (expected whole seconds)"
         if [[ -n "$LLM_RESPONSES_BODY_FILE" ]]; then
             [[ -f "$LLM_RESPONSES_BODY_FILE" ]] \
                 || die "Responses body file not found: $LLM_RESPONSES_BODY_FILE"
             jq -e 'type == "object"' "$LLM_RESPONSES_BODY_FILE" >/dev/null 2>&1 \
                 || die "Responses body file must contain a JSON object: $LLM_RESPONSES_BODY_FILE"
-            if [[ "$(jq -r '.background // false' "$LLM_RESPONSES_BODY_FILE")" == true ]]; then
-                die "background responses require lifecycle operations; use foreground Responses completion for now"
-            fi
             if jq -e 'has("conversation")' "$LLM_RESPONSES_BODY_FILE" >/dev/null 2>&1; then
                 die "conversation state cannot be combined with llm's previous_response_id continuation; omit conversation"
             fi
@@ -815,6 +838,7 @@ _build_payload_responses() {
         --arg system "$LLM_SYSTEM"
         --arg previous "$LLM_PREVIOUS_RESPONSE_ID"
         --arg effort "$reasoning_effort"
+        --arg background "${LLM_RESPONSES_BACKGROUND:-}"
         --argjson max_tokens "$LLM_MAX_TOKENS"
         --argjson stream "$( [[ "$LLM_STREAM" -eq 1 ]] && echo true || echo false )"
     )
@@ -846,6 +870,9 @@ _build_payload_responses() {
           else .instructions = $system end
         | if $previous == "" then del(.previous_response_id)
           else .previous_response_id = $previous end
+        | if $background == "1" then .background = true
+          elif $background == "0" then del(.background)
+          else . end
         | if $effort == "" then .
           else .reasoning = ((.reasoning // {}) + {effort: $effort, summary: "auto"}) end
         | .include = ((.include // [])
@@ -1400,14 +1427,26 @@ stream_openai() {
 
 stream_responses() {
     local _saw_data=0 _err_buf="" _chunk="" _event="" _response=""
-    local _text_emitted=0 _reasoning_emitted=0 _terminal=0
+    # A resumed background stream starts where the dropped one left off, so
+    # text already printed is not printed again from the terminal object.
+    local _text_emitted="${LLM_BG_RESUME_TEXT:-0}" _reasoning_emitted="${LLM_BG_RESUME_REASONING:-0}" _terminal=0
+    # Background mode keeps the response id and the last sequence number in
+    # LLM_BG_STATE: the retry loop resumes a dropped stream from there, and
+    # the cancel path uses the id when llm is killed.
+    local _bg_id="${LLM_BG_RESUME_ID:-}" _bg_seq="${LLM_BG_RESUME_SEQ:-}" _seq="" _rid=""
     while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
         local line="${raw_line%$'\r'}"
         if [[ "$line" == data:\ * ]]; then
             _saw_data=1
             local json="${line#data: }"
             [[ "$json" == "[DONE]" ]] && continue
-            _event=$(printf '%s' "$json" | jq -r '.type // empty' 2>/dev/null) || _event=""
+            _event=""; _seq=""; _rid=""
+            IFS=$'\t' read -r _event _seq _rid < <(printf '%s' "$json" \
+                | jq -r '[(.type // ""), ((.sequence_number // "") | tostring), (.response.id // "")] | @tsv' 2>/dev/null) || true
+            if [[ -n "${LLM_BG_STATE:-}" ]]; then
+                [[ -z "$_bg_id" && -n "$_rid" ]] && _bg_id="$_rid"
+                [[ -n "$_seq" ]] && _bg_seq="$_seq"
+            fi
             case "$_event" in
                 response.output_text.delta|response.refusal.delta)
                     # Preserve newline-only deltas; see stream_openai.
@@ -1475,6 +1514,14 @@ stream_responses() {
                     fi
                     mark_emitted
                     ;;
+                response.cancelled)
+                    # Someone else cancelled the background job (or a previous
+                    # llm did on its way out); nothing to retry or resume.
+                    _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
+                    [[ -n "$_response" ]] && printf '%s' "$_response" | write_response_file
+                    echo "llm: warning: response cancelled" >&2
+                    die "API stream error: response cancelled"
+                    ;;
                 response.failed)
                     _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
                     [[ -n "$_response" ]] && printf '%s' "$_response" | write_response_file
@@ -1499,6 +1546,12 @@ stream_responses() {
                     fi
                     ;;
             esac
+            # Recorded after the event is handled, so a drop right here
+            # resumes after this event and knows whether its text is out.
+            if [[ -n "${LLM_BG_STATE:-}" ]]; then
+                printf '%s\t%s\t%s\t%s\n' "$_bg_id" "$_bg_seq" "$_text_emitted" "$_reasoning_emitted" \
+                    > "$LLM_BG_STATE" 2>/dev/null || true
+            fi
         elif [[ "$_saw_data" -eq 0 ]]; then
             _err_buf="${_err_buf}${line}
 "
@@ -1510,6 +1563,14 @@ stream_responses() {
     # event never arrives, so there is no sidecar and usage is estimated.
     [[ -n "${LLM_STOP_MARKER:-}" && -e "$LLM_STOP_MARKER" ]] && return 0
     if [[ "$_terminal" -ne 1 ]]; then
+        # A background response outlives its stream: with the id known, the
+        # retry loop resumes from the last sequence number instead of
+        # creating a second response. Exit 77 is that signal.
+        if [[ -n "${LLM_BG_STATE:-}" && -n "$_bg_id" ]]; then
+            printf '%s\t%s\t%s\t%s\n' "$_bg_id" "$_bg_seq" "$_text_emitted" "$_reasoning_emitted" \
+                > "$LLM_BG_STATE" 2>/dev/null || true
+            exit 77
+        fi
         if [[ -e "$LLM_DATA_MARKER" ]]; then
             die "API stream error: Responses stream ended without a terminal response"
         fi
@@ -1587,6 +1648,7 @@ if [[ -z "$LLM_USAGE_FILE" ]]; then
 fi
 _llm_cleanup() {
     rm -f "$payload_file"
+    if [[ -n "${LLM_BG_STATE:-}" ]]; then rm -f "$LLM_BG_STATE"; fi
     if [[ -n "${_llm_auth_file:-}" ]]; then rm -f "$_llm_auth_file"; fi
     if [[ -n "${_adapter_dir:-}" ]]; then rm -rf "$_adapter_dir"; fi
     if [[ "$_llm_usage_own" -eq 1 ]]; then rm -f "$LLM_USAGE_FILE"; fi
@@ -1714,6 +1776,98 @@ get_url_headers
 [[ "$LLM_RETRIES" =~ ^[0-9]+$ ]] || LLM_RETRIES=0
 _max_attempts=$(( LLM_RETRIES + 1 ))
 
+# --- background Responses ---------------------------------------------------
+# The create URL ends in /responses; retrieve and cancel hang off the same
+# base (design/responses-lifecycle.md), so LLM_API_URL and the provider
+# defaults both work.
+_responses_base_url() {
+    local u="${url%%\?*}"
+    printf '%s' "${u%/responses}"
+}
+# Best-effort cancel of the background response llm is abandoning, so a
+# killed or timed-out call does not leave a billable job running with no one
+# to read it. The id comes from the polling loop or the stream state file.
+_llm_bg_cancel() {
+    local why="$1" id="${_bg_id:-}"
+    if [[ -z "$id" && -n "${LLM_BG_STATE:-}" && -s "$LLM_BG_STATE" ]]; then
+        IFS=$'\t' read -r id _ < "$LLM_BG_STATE" || true
+    fi
+    [[ -n "$id" ]] || return 0
+    # Nothing of this reaches the caller's stdout: it is not model output.
+    curl -sS -X POST --max-time 5 "${headers[@]}" -o /dev/null \
+        "$(_responses_base_url)/responses/$id/cancel" >/dev/null 2>&1 || true
+    echo "llm: cancelled background response $id ($why)" >&2
+}
+_llm_bg_signal() {
+    trap - INT TERM
+    if [[ -n "${_bg_job:-}" ]]; then kill "$_bg_job" 2>/dev/null || true; fi
+    _llm_bg_cancel "SIG$1"
+    _llm_note error "" "cancelled on SIG$1"
+    exit 1
+}
+# Poll a background response until it reaches a terminal status, leaving the
+# final object in local_resp for the ordinary buffered handling. LLM_MAX_TIME
+# bounds the whole wait; the interval doubles up to 10s; transient poll
+# errors get LLM_RETRIES consecutive tries before the job is cancelled.
+_llm_bg_poll() {
+    _bg_id=$(jq -r '.id // empty' "$local_resp" 2>/dev/null)
+    [[ -n "$_bg_id" ]] || die "background response has no id to poll"
+    local interval="$LLM_RESPONSES_POLL_INTERVAL" deadline=0 now code failures=0 status
+    [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]] \
+        && deadline=$(( $(date +%s) + LLM_MAX_TIME ))
+    while :; do
+        now=$(date +%s)
+        if [[ "$deadline" -gt 0 && "$now" -ge "$deadline" ]]; then
+            _llm_bg_cancel "LLM_MAX_TIME=${LLM_MAX_TIME}s reached"
+            _llm_note error "" "background response timed out"
+            die "background response $_bg_id did not finish within LLM_MAX_TIME=${LLM_MAX_TIME}s; cancelled"
+        fi
+        # Sleep as a job and wait for it, so a signal reaches the cancel trap
+        # at once rather than when the sleep ends.
+        sleep "$interval" &
+        _bg_job=$!
+        wait "$_bg_job" || true
+        _bg_job=""
+        if [[ "$interval" -lt 10 ]]; then
+            interval=$(( interval * 2 ))
+            [[ "$interval" -gt 10 ]] && interval=10
+        fi
+        code=$(curl -sS -o "$local_resp" -w '%{http_code}' ${_net_args[@]+"${_net_args[@]}"} \
+            "${headers[@]}" "$(_responses_base_url)/responses/$_bg_id" 2>/dev/null) || code="000"
+        if [[ "$code" =~ ^(000|408|429|5[0-9][0-9])$ ]]; then
+            failures=$(( failures + 1 ))
+            if [[ "$failures" -gt "$LLM_RETRIES" ]]; then
+                _llm_bg_cancel "polling failed"
+                _llm_note error "$code" "background poll failed"
+                die "API error (HTTP $code) while polling background response $_bg_id"
+            fi
+            continue
+        fi
+        failures=0
+        if [[ "$code" -ge 400 ]]; then
+            error_msg=$(jq -r '.error.message // .message // empty' "$local_resp" 2>/dev/null || true)
+            write_response_file < "$local_resp"
+            _llm_note error "$code" "${error_msg:-HTTP $code}"
+            die "API error (HTTP $code) while polling background response $_bg_id: ${error_msg:-HTTP $code}"
+        fi
+        status=$(jq -r '.status // empty' "$local_resp" 2>/dev/null || true)
+        case "$status" in
+            queued|in_progress) continue ;;
+            *) break ;;
+        esac
+    done
+}
+_bg_active=0
+_bg_job=""
+if [[ "$LLM_API_FORMAT" == responses ]] \
+   && jq -e '.background == true' "$payload_file" >/dev/null 2>&1; then
+    _bg_active=1
+    LLM_BG_STATE=$(mktemp)
+    export LLM_BG_STATE
+    trap '_llm_bg_signal INT' INT
+    trap '_llm_bg_signal TERM' TERM
+fi
+
 # Network guard flags for curl (see the LLM_CONNECT_TIMEOUT block above).
 _net_args=()
 [[ "$LLM_CONNECT_TIMEOUT" =~ ^[0-9]+$ && "$LLM_CONNECT_TIMEOUT" -gt 0 ]] \
@@ -1732,6 +1886,8 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
     # die still prints its message and we propagate its exit. Retries only
     # fire while the emission marker doesn't exist.
     _attempt=0
+    _bg_resume=0
+    _bg_resumes=0
     while :; do
         _attempt=$(( _attempt + 1 ))
         _block=""
@@ -1742,7 +1898,28 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         _rc=0
         _stream_handler="stream_${LLM_PROVIDER}"
         [[ "$LLM_API_FORMAT" == responses ]] && _stream_handler=stream_responses
-        ( "$_stream_handler" < <(curl -sS -N ${_net_args[@]+"${_net_args[@]}"} "${headers[@]}" -d @"$payload_file" "$url" 2>"$_curl_err") ) || _rc=$?
+        # The create posts the payload. A resume of a dropped background
+        # stream GETs the same response from its last sequence number instead,
+        # carrying what the dropped stream had already emitted.
+        _stream_curl=(curl -sS -N ${_net_args[@]+"${_net_args[@]}"} "${headers[@]}")
+        if [[ "$_bg_resume" -eq 1 ]]; then
+            IFS=$'\t' read -r LLM_BG_RESUME_ID LLM_BG_RESUME_SEQ LLM_BG_RESUME_TEXT LLM_BG_RESUME_REASONING \
+                < "$LLM_BG_STATE" || true
+            export LLM_BG_RESUME_ID LLM_BG_RESUME_SEQ LLM_BG_RESUME_TEXT LLM_BG_RESUME_REASONING
+            _stream_curl+=("$(_responses_base_url)/responses/${LLM_BG_RESUME_ID}?stream=true&starting_after=${LLM_BG_RESUME_SEQ:-0}")
+        else
+            _stream_curl+=(-d @"$payload_file" "$url")
+        fi
+        if [[ "$_bg_active" -eq 1 ]]; then
+            # As a job, so a signal reaches the cancel trap at once instead of
+            # after the stream ends.
+            ( "$_stream_handler" < <("${_stream_curl[@]}" 2>"$_curl_err") ) &
+            _bg_job=$!
+            wait "$_bg_job" || _rc=$?
+            _bg_job=""
+        else
+            ( "$_stream_handler" < <("${_stream_curl[@]}" 2>"$_curl_err") ) || _rc=$?
+        fi
 
         _emitted=0
         [[ -e "$LLM_DATA_MARKER" ]] && _emitted=1
@@ -1757,7 +1934,25 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         [[ -s "$LLM_RETRY_ERR" ]] && _retry_msg=$(cat "$LLM_RETRY_ERR")
         rm -f "$_curl_err" "$LLM_RETRY_ERR" "$LLM_DATA_MARKER" "$LLM_STOP_MARKER"
 
+        if [[ "$_rc" -eq 77 ]]; then
+            # The background stream dropped with the response id known. This
+            # is not a retry of the create, so emitted output does not forbid
+            # it; the budget is LLM_RETRIES resumes, then the job is cancelled.
+            if [[ "$_bg_resumes" -lt "$LLM_RETRIES" ]]; then
+                _bg_resumes=$(( _bg_resumes + 1 ))
+                IFS=$'\t' read -r _bg_id_now _bg_seq_now _ < "$LLM_BG_STATE" || true
+                echo "llm: background stream dropped (resume $_bg_resumes/$LLM_RETRIES): resuming $_bg_id_now after sequence ${_bg_seq_now:-0}${_ce:+ ($_ce)}" >&2
+                sleep $(( LLM_RETRY_BACKOFF * _bg_resumes ))
+                _bg_resume=1
+                continue
+            fi
+            _llm_bg_cancel "resume budget exhausted"
+            _llm_note error "" "background stream dropped"
+            die "API stream error: background response stream dropped and its LLM_RETRIES=$LLM_RETRIES resumes are used up"
+        fi
         if [[ -n "$_stopped" && "$_rc" -eq 0 && "$_emitted" -eq 1 ]]; then
+            # The cut leaves a background model generating for nobody.
+            [[ "$_bg_active" -eq 1 ]] && _llm_bg_cancel "stopped after the first code block"
             [[ "$_stopped" =~ ^[0-9]+$ ]] && write_usage "" "$(( (_stopped + 3) / 4 ))" "" "" estimated
             _llm_note ok
             _llm_ledger_append
@@ -1775,6 +1970,14 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
             # empty answer as success.
             _retry_msg="empty response: stream ended without emitting anything"
             _rc=1
+        fi
+        if [[ "$_bg_resume" -eq 1 ]]; then
+            # A failed resume is final: the response exists server-side, so
+            # re-creating it would run the model twice.
+            _llm_bg_cancel "resume failed"
+            [[ -n "$_retry_msg" ]] && { _llm_note error "" "$_retry_msg"; die "$_retry_msg"; }
+            [[ -n "$_ce" ]] && { _llm_note error "" "curl error: $_ce"; die "curl error: $_ce"; }
+            exit 1
         fi
         # Anything that failed before output was emitted is retried (an
         # Anthropic overloaded_error arrives as an in-stream error event and
@@ -1867,6 +2070,31 @@ else
             die "API error (HTTP $http_code): $error_msg"
         fi
         die "API error (HTTP $http_code)"
+    fi
+    # A background create answers with a queued or in-progress object; poll
+    # until it is terminal, then treat that object like any buffered reply.
+    # Only the polled object can be failed or cancelled here: a failed
+    # foreground create was caught as an embedded error above.
+    if [[ "$_bg_active" -eq 1 ]] \
+       && jq -e '.status == "queued" or .status == "in_progress"' "$local_resp" >/dev/null 2>&1; then
+        _llm_bg_poll
+        _final_status=$(jq -r '.status // empty' "$local_resp" 2>/dev/null || true)
+        case "$_final_status" in
+            failed)
+                write_response_file < "$local_resp"
+                _final_err=$(check_response_responses < "$local_resp")
+                rm -f "$local_resp"
+                _llm_note error "" "${_final_err:-response failed}"
+                die "API error: ${_final_err:-response failed}"
+                ;;
+            cancelled)
+                write_response_file < "$local_resp"
+                rm -f "$local_resp"
+                _llm_note error "" "response cancelled"
+                echo "llm: warning: response cancelled" >&2
+                die "API error: response cancelled"
+                ;;
+        esac
     fi
     _llm_note ok
 

--- a/bin/llm
+++ b/bin/llm
@@ -110,9 +110,9 @@ LLM_RESPONSES_COMPACT_THRESHOLD="${LLM_RESPONSES_COMPACT_THRESHOLD:-}"
 # caller. Best-effort: fields the provider doesn't report are omitted, and no
 # failure here can break the call.
 LLM_USAGE_FILE="${LLM_USAGE_FILE:-}"
-# Transient-failure retries (provider errors, 429/5xx, network). Retries
-# only happen when NOTHING has been emitted yet — a retry after partial
-# streamed output would duplicate text. LLM_RETRIES=0 disables.
+# Chat retries only before output; Responses never retries a create because
+# silence does not prove non-dispatch. In background Responses this budget
+# instead bounds retrieval retries and stream resumes. 0 disables retries.
 LLM_RETRIES="${LLM_RETRIES:-2}"
 LLM_RETRY_BACKOFF="${LLM_RETRY_BACKOFF:-1}"   # seconds; grows linearly per attempt
 
@@ -396,13 +396,14 @@ Environment:
                            precedence, and a value that disagrees with the
                            name warns on stderr
   LLM_MAX_TOKENS           Override the per-model default output cap (same as -t)
-  LLM_RETRIES              Retries for transient API failures (default: 2;
-                           0 disables). Never retries after partial output.
+  LLM_RETRIES              Chat retries before output; Responses retrieve/resume
+                           retries only, never create (default: 2; 0 disables)
   LLM_RETRY_BACKOFF        Backoff base seconds between retries (default: 1)
   LLM_CONNECT_TIMEOUT      Seconds to establish the connection (default: 10;
                            0 disables)
-  LLM_MAX_TIME             Hard ceiling on one HTTP attempt, seconds
-                           (default: 600; 0 disables)
+  LLM_MAX_TIME             Seconds per chat attempt or whole Responses operation
+                           (default: 600; 0 disables). Background cancellation
+                           gets up to 5 additional seconds; it is best effort
   LLM_SPEED_LIMIT          Abort a transfer slower than this many bytes/s...
   LLM_SPEED_TIME           ...for this many consecutive seconds (defaults:
                            100 bytes/s over 60s; 0 on either disables)
@@ -1175,8 +1176,28 @@ check_response_responses() {
     jq -r '
         if .error != null then .error.message // "unknown error"
         elif .status == "failed" then .error.message // "response failed"
+        elif .status == "cancelled" then "response cancelled"
         else empty end
     ' 2>/dev/null
+}
+
+# Only a valid terminal object is a successful Responses completion. An empty
+# text field can be legitimate (tools, refusals), but an empty/error envelope
+# cannot. Keep this contract identical for SSE and buffered responses.
+valid_response_terminal() {
+    jq -e 'type == "object" and .error == null
+        and (.id | type == "string" and length > 0)
+        and (.output | type == "array")
+        and (.status == "completed" or .status == "incomplete")' >/dev/null 2>&1
+}
+
+responses_outcome_unknown() {
+    local reason="$1" id="${2:-}"
+    jq -nc --arg message "$reason" --arg id "$id" \
+        '{error:{code:"outcome_unknown",message:$message}}
+         + (if $id == "" then {} else {id:$id} end)' | write_response_file
+    _llm_note error "" "outcome_unknown: $reason"
+    die "Responses outcome_unknown: $reason${id:+ (response $id)}; do not automatically recreate"
 }
 
 check_response_gemini() {
@@ -1484,9 +1505,22 @@ stream_responses() {
             [[ "$json" == "[DONE]" ]] && continue
             _event=""; _seq=""; _rid=""
             IFS=$'\t' read -r _event _seq _rid < <(printf '%s' "$json" \
-                | jq -r '[(.type // ""), ((.sequence_number // "") | tostring), (.response.id // "")] | @tsv' 2>/dev/null) || true
+                | jq -r '[(.type // "-"), ((.sequence_number // "-") | tostring), (.response.id // "-")] | @tsv' 2>/dev/null) || true
+            [[ "$_rid" == - ]] && _rid=""
+            [[ "$_seq" == - ]] && _seq=""
+            if [[ -n "$_rid" ]]; then
+                [[ "$_rid" =~ ^[A-Za-z0-9_-]+$ ]] \
+                    || responses_outcome_unknown "invalid stream response identity" "$_bg_id"
+                [[ -z "$_bg_id" || "$_bg_id" == "$_rid" ]] \
+                    || responses_outcome_unknown "stream changed response identity" "$_bg_id"
+                _bg_id="$_rid"
+            fi
             if [[ -n "${LLM_BG_STATE:-}" ]]; then
-                [[ -z "$_bg_id" && -n "$_rid" ]] && _bg_id="$_rid"
+                [[ -z "$_seq" || "$_seq" =~ ^[0-9]+$ ]] \
+                    || responses_outcome_unknown "invalid stream sequence number" "$_bg_id"
+                if [[ -n "$_seq" && -n "${LLM_BG_RESUME_SEQ:-}" && "$_seq" -le "$LLM_BG_RESUME_SEQ" ]]; then
+                    continue
+                fi
                 [[ -n "$_seq" ]] && _bg_seq="$_seq"
             fi
             case "$_event" in
@@ -1516,6 +1550,8 @@ stream_responses() {
                     ;;
                 response.completed|response.incomplete)
                     _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
+                    printf '%s' "$_response" | valid_response_terminal \
+                        || responses_outcome_unknown "invalid terminal response" "$_bg_id"
                     if [[ -n "$_response" ]] \
                         && printf '%s' "$_response" | jq -e --arg status "${_event#response.}" \
                             '.status == $status' >/dev/null 2>&1; then
@@ -1553,8 +1589,11 @@ stream_responses() {
                                 warn_incomplete_response "$_reason"
                             fi
                         fi
+                    else
+                        responses_outcome_unknown "terminal event and response status disagree" "$_bg_id"
                     fi
                     mark_emitted
+                    return 0
                     ;;
                 response.cancelled)
                     # Someone else cancelled the background job (or a previous
@@ -1562,18 +1601,14 @@ stream_responses() {
                     _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
                     [[ -n "$_response" ]] && printf '%s' "$_response" | write_response_file
                     echo "llm: warning: response cancelled" >&2
-                    die "API stream error: response cancelled"
+                    die_permanent "API stream error: response cancelled"
                     ;;
                 response.failed)
                     _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
                     [[ -n "$_response" ]] && printf '%s' "$_response" | write_response_file
                     local _failed_msg=""
                     _failed_msg=$(printf '%s' "$json" | jq -r '.response.error.message // .error.message // "response failed"' 2>/dev/null) || _failed_msg="response failed"
-                    if [[ -e "$LLM_DATA_MARKER" ]]; then
-                        die "API stream error: $_failed_msg"
-                    else
-                        die_retryable "API stream error: $_failed_msg"
-                    fi
+                    die_permanent "API stream error: $_failed_msg"
                     ;;
                 error)
                     printf '%s' "$json" | write_response_file
@@ -1613,10 +1648,7 @@ stream_responses() {
                 > "$LLM_BG_STATE" 2>/dev/null || true
             exit 77
         fi
-        if [[ -e "$LLM_DATA_MARKER" ]]; then
-            die "API stream error: Responses stream ended without a terminal response"
-        fi
-        die_retryable "API stream error: Responses stream ended without a terminal response"
+        responses_outcome_unknown "Responses stream ended without a terminal response" "$_bg_id"
     fi
 }
 
@@ -1680,7 +1712,8 @@ stream_opencode() { stream_anthropic; }
 # carries the whole prompt, and `-d "$payload"` dies with "Argument list too
 # long" on a large one (Linux caps a single argument at 128 KiB, macOS caps
 # total argv at 1 MiB). The file is reused across retries and removed on exit.
-payload_file=$(mktemp "${TMPDIR:-/tmp}/llm-payload.XXXXXX")
+_llm_work=$(mktemp -d "${TMPDIR:-/tmp}/llm-call.XXXXXX")
+payload_file="$_llm_work/payload"
 # No caller-provided usage file: a private one stands in (the ledger still
 # gets the record) and goes away with the payload file.
 _llm_usage_own=0
@@ -1689,7 +1722,7 @@ if [[ -z "$LLM_USAGE_FILE" ]]; then
     _llm_usage_own=1
 fi
 _llm_cleanup() {
-    rm -f "$payload_file"
+    rm -rf "$_llm_work"
     if [[ -n "${LLM_BG_STATE:-}" ]]; then rm -f "$LLM_BG_STATE"; fi
     if [[ -n "${_llm_auth_file:-}" ]]; then rm -f "$_llm_auth_file"; fi
     if [[ -n "${_adapter_dir:-}" ]]; then rm -rf "$_adapter_dir"; fi
@@ -1842,22 +1875,86 @@ _responses_base_url() {
 # killed or timed-out call does not leave a billable job running with no one
 # to read it. The id comes from the polling loop or the stream state file.
 _llm_bg_cancel() {
-    local why="$1" id="${_bg_id:-}"
+    local why="$1" id="${_bg_id:-}" code status
     if [[ -z "$id" && -n "${LLM_BG_STATE:-}" && -s "$LLM_BG_STATE" ]]; then
         IFS=$'\t' read -r id _ < "$LLM_BG_STATE" || true
     fi
-    [[ -n "$id" ]] || return 0
-    # Nothing of this reaches the caller's stdout: it is not model output.
-    curl -sS -X POST --max-time 5 "${headers[@]}" -o /dev/null \
-        "$(_responses_base_url)/responses/$id/cancel" >/dev/null 2>&1 || true
-    echo "llm: cancelled background response $id ($why)" >&2
+    if [[ ! "$id" =~ ^[A-Za-z0-9_-]+$ ]]; then
+        jq -nc --arg message "$why; no response handle available for cancellation" \
+            '{error:{code:"outcome_unknown",message:$message}}' | write_response_file
+        echo "llm: background outcome unknown; no safe response handle to cancel ($why)" >&2
+        return 0
+    fi
+    code=$(curl -sS --globoff -X POST --connect-timeout 5 --max-time 5 "${headers[@]}" \
+        -o "$_llm_work/cancel" -w '%{http_code}' \
+        "$(_responses_base_url)/responses/$id/cancel" 2>/dev/null) || code=000
+    status=$(jq -r --arg id "$id" 'select(.id == $id) | .status // empty' "$_llm_work/cancel" 2>/dev/null || true)
+    if [[ "$code" =~ ^2[0-9][0-9]$ && "$status" =~ ^(cancelled|completed|incomplete|failed)$ ]]; then
+        write_response_file < "$_llm_work/cancel"
+        echo "llm: background response $id confirmed $status ($why)" >&2
+    else
+        jq -nc --arg id "$id" --arg code "$code" --arg why "$why" \
+            '{id:$id,error:{code:"outcome_unknown",message:"cancellation not confirmed"},
+              cancellation:{requested:true,http_code:$code,reason:$why}}' | write_response_file
+        echo "llm: cancellation not confirmed for background response $id (HTTP $code; $why); reconcile with responses get $id" >&2
+    fi
 }
 _llm_bg_signal() {
-    trap - INT TERM
-    if [[ -n "${_bg_job:-}" ]]; then kill "$_bg_job" 2>/dev/null || true; fi
-    _llm_bg_cancel "SIG$1"
-    _llm_note error "" "cancelled on SIG$1"
+    trap '' INT TERM
+    local p
+    for p in "${_bg_job:-}" "${_llm_curl_pid:-}"; do
+        [[ -n "$p" ]] || continue
+        kill "$p" 2>/dev/null || true
+        wait "$p" 2>/dev/null || true
+    done
+    [[ "$_bg_active" -eq 1 ]] && _llm_bg_cancel "SIG$1"
+    _llm_note error "" "interrupted on SIG$1; provider outcome may be unknown"
     exit 1
+}
+
+# One elapsed-time budget begins before create; never refresh it for a poll,
+# reconnect, or backoff. Cancellation gets a separate, bounded 5s grace.
+_llm_deadline=0
+if [[ "$LLM_API_FORMAT" == responses && "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]]; then
+    _llm_deadline=$(( SECONDS + LLM_MAX_TIME ))
+fi
+_llm_check_deadline() {
+    if [[ "$_llm_deadline" -gt 0 && "$SECONDS" -ge "$_llm_deadline" ]]; then
+        [[ "$_bg_active" -eq 1 ]] && _llm_bg_cancel "LLM_MAX_TIME=${LLM_MAX_TIME}s reached"
+        _llm_note error "" "LLM_MAX_TIME deadline exceeded"
+        die "LLM_MAX_TIME=${LLM_MAX_TIME}s exceeded; completion was not accepted within the deadline"
+    fi
+}
+_llm_pause() {
+    local duration="$1" remaining
+    _llm_check_deadline
+    if [[ "$_llm_deadline" -gt 0 ]]; then
+        remaining=$(( _llm_deadline - SECONDS ))
+        [[ "$duration" -le "$remaining" ]] || duration="$remaining"
+    fi
+    sleep "$duration" &
+    _bg_job=$!
+    wait "$_bg_job" || true
+    _bg_job=""
+    _llm_check_deadline
+}
+_llm_transfer_budget() {
+    _llm_check_deadline
+    _transfer_args=("${_net_args[@]+"${_net_args[@]}"}")
+    if [[ "$_llm_deadline" -gt 0 ]]; then
+        _transfer_args+=(--max-time "$(( _llm_deadline - SECONDS ))")
+    fi
+}
+# Track curl in the parent, including buffered polling: a signal must not
+# leave a credential-bearing child running after command cleanup.
+_llm_fetch() {
+    _llm_transfer_budget
+    curl -sS --globoff "${_transfer_args[@]+"${_transfer_args[@]}"}" "${headers[@]}" \
+        -w '%{http_code}' "$@" > "$_llm_work/http-code" 2>/dev/null &
+    _llm_curl_pid=$!
+    http_code=000
+    if wait "$_llm_curl_pid"; then http_code=$(cat "$_llm_work/http-code"); fi
+    _llm_curl_pid=""
 }
 # Poll a background response until it reaches a terminal status, leaving the
 # final object in local_resp for the ordinary buffered handling. LLM_MAX_TIME
@@ -1865,29 +1962,18 @@ _llm_bg_signal() {
 # errors get LLM_RETRIES consecutive tries before the job is cancelled.
 _llm_bg_poll() {
     _bg_id=$(jq -r '.id // empty' "$local_resp" 2>/dev/null)
-    [[ -n "$_bg_id" ]] || die "background response has no id to poll"
-    local interval="$LLM_RESPONSES_POLL_INTERVAL" deadline=0 now code failures=0 status
-    [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]] \
-        && deadline=$(( $(date +%s) + LLM_MAX_TIME ))
+    [[ "$_bg_id" =~ ^[A-Za-z0-9_-]+$ ]] || responses_outcome_unknown "background response has no safe id to poll"
+    write_response_file < "$local_resp"
+    local interval="$LLM_RESPONSES_POLL_INTERVAL" code failures=0 status
     while :; do
-        now=$(date +%s)
-        if [[ "$deadline" -gt 0 && "$now" -ge "$deadline" ]]; then
-            _llm_bg_cancel "LLM_MAX_TIME=${LLM_MAX_TIME}s reached"
-            _llm_note error "" "background response timed out"
-            die "background response $_bg_id did not finish within LLM_MAX_TIME=${LLM_MAX_TIME}s; cancelled"
-        fi
-        # Sleep as a job and wait for it, so a signal reaches the cancel trap
-        # at once rather than when the sleep ends.
-        sleep "$interval" &
-        _bg_job=$!
-        wait "$_bg_job" || true
-        _bg_job=""
+        _llm_pause "$interval"
         if [[ "$interval" -lt 10 ]]; then
             interval=$(( interval * 2 ))
             [[ "$interval" -gt 10 ]] && interval=10
         fi
-        code=$(curl -sS -o "$local_resp" -w '%{http_code}' ${_net_args[@]+"${_net_args[@]}"} \
-            "${headers[@]}" "$(_responses_base_url)/responses/$_bg_id" 2>/dev/null) || code="000"
+        _llm_fetch -o "$local_resp" "$(_responses_base_url)/responses/$_bg_id"
+        code="$http_code"
+        _llm_check_deadline
         if [[ "$code" =~ ^(000|408|429|5[0-9][0-9])$ ]]; then
             failures=$(( failures + 1 ))
             if [[ "$failures" -gt "$LLM_RETRIES" ]]; then
@@ -1900,11 +1986,15 @@ _llm_bg_poll() {
         failures=0
         if [[ "$code" -ge 400 ]]; then
             error_msg=$(jq -r '.error.message // .message // empty' "$local_resp" 2>/dev/null || true)
-            write_response_file < "$local_resp"
+            _llm_bg_cancel "polling failed with HTTP $code"
             _llm_note error "$code" "${error_msg:-HTTP $code}"
             die "API error (HTTP $code) while polling background response $_bg_id: ${error_msg:-HTTP $code}"
         fi
         status=$(jq -r '.status // empty' "$local_resp" 2>/dev/null || true)
+        jq -e --arg id "$_bg_id" '.id == $id and (.error == null or .status == "failed")' "$local_resp" >/dev/null 2>&1 || {
+            _llm_bg_cancel "invalid poll response"
+            die "invalid poll response for $_bg_id"
+        }
         case "$status" in
             queued|in_progress) continue ;;
             *) break ;;
@@ -1913,13 +2003,15 @@ _llm_bg_poll() {
 }
 _bg_active=0
 _bg_job=""
+if [[ "$LLM_API_FORMAT" == responses ]]; then
+    trap '_llm_bg_signal INT' INT
+    trap '_llm_bg_signal TERM' TERM
+fi
 if [[ "$LLM_API_FORMAT" == responses ]] \
    && jq -e '.background == true' "$payload_file" >/dev/null 2>&1; then
     _bg_active=1
-    LLM_BG_STATE=$(mktemp)
+    LLM_BG_STATE="$_llm_work/background"
     export LLM_BG_STATE
-    trap '_llm_bg_signal INT' INT
-    trap '_llm_bg_signal TERM' TERM
 fi
 
 # Network guard flags for curl (see the LLM_CONNECT_TIMEOUT block above).
@@ -1945,8 +2037,8 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
     while :; do
         _attempt=$(( _attempt + 1 ))
         _block=""
-        _curl_err=$(mktemp)
-        LLM_RETRY_ERR=$(mktemp)
+        _curl_err="$_llm_work/curl-error"
+        LLM_RETRY_ERR="$_llm_work/retry-error"
         LLM_DATA_MARKER="${LLM_RETRY_ERR}.emitted"
         LLM_STOP_MARKER="${LLM_RETRY_ERR}.stopped"
         _rc=0
@@ -1955,7 +2047,8 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         # The create posts the payload. A resume of a dropped background
         # stream GETs the same response from its last sequence number instead,
         # carrying what the dropped stream had already emitted.
-        _stream_curl=(curl -sS -N ${_net_args[@]+"${_net_args[@]}"} "${headers[@]}")
+        _llm_transfer_budget
+        _stream_curl=(curl -sS --globoff -N "${_transfer_args[@]+"${_transfer_args[@]}"}" "${headers[@]}")
         if [[ "$_bg_resume" -eq 1 ]]; then
             IFS=$'\t' read -r LLM_BG_RESUME_ID LLM_BG_RESUME_SEQ LLM_BG_RESUME_TEXT LLM_BG_RESUME_REASONING \
                 < "$LLM_BG_STATE" || true
@@ -1964,21 +2057,22 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         else
             _stream_curl+=(-d @"$payload_file" "$url")
         fi
-        if [[ "$_bg_active" -eq 1 ]]; then
-            # As a job, so a signal reaches the cancel trap at once instead of
-            # after the stream ends. The `|| exit` keeps the handler in the
-            # same errexit-ignored context the foreground form below gives it:
-            # a bare `( ... ) &` would run it with set -e live, and one
-            # transiently failing write (stderr to a busy pipe, say) would end
-            # the stream with a silent exit 1 instead of the handler's own
-            # verdict.
-            ( "$_stream_handler" < <("${_stream_curl[@]}" 2>"$_curl_err") || exit "$?" ) &
+        if [[ "$LLM_API_FORMAT" == responses ]]; then
+            mkfifo "$_llm_work/stream"
+            "${_stream_curl[@]}" > "$_llm_work/stream" 2>"$_curl_err" &
+            _llm_curl_pid=$!
+            ( "$_stream_handler" < "$_llm_work/stream" || exit "$?" ) &
             _bg_job=$!
             wait "$_bg_job" || _rc=$?
             _bg_job=""
+            kill "$_llm_curl_pid" 2>/dev/null || true
+            wait "$_llm_curl_pid" 2>/dev/null || true
+            _llm_curl_pid=""
+            rm -f "$_llm_work/stream"
         else
             ( "$_stream_handler" < <("${_stream_curl[@]}" 2>"$_curl_err") ) || _rc=$?
         fi
+        _llm_check_deadline
 
         _emitted=0
         [[ -e "$LLM_DATA_MARKER" ]] && _emitted=1
@@ -2001,7 +2095,7 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
                 _bg_resumes=$(( _bg_resumes + 1 ))
                 IFS=$'\t' read -r _bg_id_now _bg_seq_now _ < "$LLM_BG_STATE" || true
                 echo "llm: background stream dropped (resume $_bg_resumes/$LLM_RETRIES): resuming $_bg_id_now after sequence ${_bg_seq_now:-0}${_ce:+ ($_ce)}" >&2
-                sleep $(( LLM_RETRY_BACKOFF * _bg_resumes ))
+                _llm_pause $(( LLM_RETRY_BACKOFF * _bg_resumes ))
                 _bg_resume=1
                 continue
             fi
@@ -2030,7 +2124,7 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
             _retry_msg="empty response: stream ended without emitting anything"
             _rc=1
         fi
-        if [[ "$_bg_resume" -eq 1 ]]; then
+        if [[ "$_bg_resume" -eq 1 && "$_rc" -ne 76 ]]; then
             # A failed resume is final: the response exists server-side, so
             # re-creating it would run the model twice.
             _llm_bg_cancel "resume failed"
@@ -2042,7 +2136,7 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         # Anthropic overloaded_error arrives as an in-stream error event and
         # exits 1, not 75), with one exception: a handler that exited 76
         # (die_permanent) saw an error a replay cannot fix.
-        if [[ "$_emitted" -eq 0 && "$_rc" -ne 76 \
+        if [[ "$LLM_API_FORMAT" != responses && "$_emitted" -eq 0 && "$_rc" -ne 76 \
             && "$_attempt" -lt "$_max_attempts" ]]; then
             echo "llm: transient API failure (attempt $_attempt/$_max_attempts): ${_retry_msg:-${_ce:-exit $_rc}} — retrying" >&2
             sleep $(( LLM_RETRY_BACKOFF * _attempt ))
@@ -2059,13 +2153,15 @@ else
     _attempt=0
     while :; do
         _attempt=$(( _attempt + 1 ))
-        local_resp=$(mktemp)
-        http_code=$(curl -sS -o "$local_resp" -w '%{http_code}' \
-            ${_net_args[@]+"${_net_args[@]}"} \
-            "${headers[@]}" -d @"$payload_file" "$url" 2>/dev/null) || http_code="000"
+        local_resp="$_llm_work/response"
+        _llm_fetch -o "$local_resp" -d @"$payload_file" "$url"
+        if [[ "$_bg_active" -eq 1 ]]; then
+            _bg_id=$(jq -r '.id // empty' "$local_resp" 2>/dev/null || true)
+        fi
+        _llm_check_deadline
 
         # Transient: network failure, timeout, rate limit, server error
-        if [[ "$http_code" =~ ^(000|408|429|5[0-9][0-9])$ && "$_attempt" -lt "$_max_attempts" ]]; then
+        if [[ "$LLM_API_FORMAT" != responses && "$http_code" =~ ^(000|408|429|5[0-9][0-9])$ && "$_attempt" -lt "$_max_attempts" ]]; then
             echo "llm: transient API failure (attempt $_attempt/$_max_attempts): HTTP $http_code — retrying" >&2
             rm -f "$local_resp"
             sleep $(( LLM_RETRY_BACKOFF * _attempt ))
@@ -2077,7 +2173,7 @@ else
         if [[ "$http_code" != "000" && "$http_code" -lt 400 ]]; then
             if grep -q '[^[:space:]]' "$local_resp"; then
                 if [[ "$LLM_API_FORMAT" == responses ]]; then
-                    embedded_err=$(check_response_responses < "$local_resp")
+                    embedded_err=$(check_response_responses < "$local_resp" || true)
                 else
                     embedded_err=$("check_response_${LLM_PROVIDER}" < "$local_resp")
                 fi
@@ -2087,12 +2183,14 @@ else
                 # parse-fail to empty on it, which used to read as success
                 # with no output.
                 embedded_err="whitespace-only response body"
+                [[ "$LLM_API_FORMAT" != responses ]] \
+                    || responses_outcome_unknown "$embedded_err"
             fi
             if [[ -n "$embedded_err" ]]; then
-                if [[ "$LLM_API_FORMAT" == responses ]] \
-                    && jq -e '.status == "failed"' "$local_resp" >/dev/null 2>&1; then
+                if [[ "$LLM_API_FORMAT" == responses ]]; then
                     write_response_file < "$local_resp"
                     rm -f "$local_resp"
+                    _llm_note error "" "$embedded_err"
                     die "API error: $embedded_err"
                 fi
                 if [[ "$_attempt" -lt "$_max_attempts" ]]; then
@@ -2111,9 +2209,18 @@ else
         break
     done
 
+    _response_id=""
+    if [[ "$LLM_API_FORMAT" == responses ]]; then
+        _response_id=$(jq -r '.id? | strings' "$local_resp" 2>/dev/null || true)
+    fi
     if [[ "$http_code" -ge 400 || "$http_code" == "000" ]]; then
         error_msg=$(jq -r '.error.message // .message // empty' "$local_resp" 2>/dev/null || true)
         if [[ "$LLM_API_FORMAT" == responses ]]; then
+            if [[ "$http_code" =~ ^(000|408|5[0-9][0-9])$ ]]; then
+                rm -f "$local_resp"
+                _llm_note error "$http_code" "create outcome unknown"
+                responses_outcome_unknown "create failed with HTTP $http_code; provider acceptance is unknown" "$_response_id"
+            fi
             if [[ -s "$local_resp" ]] && jq -e . "$local_resp" >/dev/null 2>&1; then
                 write_response_file < "$local_resp"
             else
@@ -2137,23 +2244,16 @@ else
     if [[ "$_bg_active" -eq 1 ]] \
        && jq -e '.status == "queued" or .status == "in_progress"' "$local_resp" >/dev/null 2>&1; then
         _llm_bg_poll
-        _final_status=$(jq -r '.status // empty' "$local_resp" 2>/dev/null || true)
-        case "$_final_status" in
-            failed)
-                write_response_file < "$local_resp"
-                _final_err=$(check_response_responses < "$local_resp")
-                rm -f "$local_resp"
-                _llm_note error "" "${_final_err:-response failed}"
-                die "API error: ${_final_err:-response failed}"
-                ;;
-            cancelled)
-                write_response_file < "$local_resp"
-                rm -f "$local_resp"
-                _llm_note error "" "response cancelled"
-                echo "llm: warning: response cancelled" >&2
-                die "API error: response cancelled"
-                ;;
-        esac
+    fi
+    if [[ "$LLM_API_FORMAT" == responses ]]; then
+        _final_err=$(check_response_responses < "$local_resp" || true)
+        if [[ -n "$_final_err" ]]; then
+            write_response_file < "$local_resp"
+            _llm_note error "" "$_final_err"
+            die "API error: $_final_err"
+        fi
+        valid_response_terminal < "$local_resp" \
+            || responses_outcome_unknown "invalid or nonterminal response body" "${_bg_id:-$_response_id}"
     fi
     _llm_note ok
 

--- a/bin/llm
+++ b/bin/llm
@@ -497,7 +497,12 @@ case "$LLM_API_FORMAT" in
     responses)
         case "$LLM_PROVIDER" in
             openai|openrouter|openai-compatible) ;;
-            *) die "Responses format is not supported for provider $LLM_PROVIDER (use openai, openrouter, or openai-compatible)" ;;
+            # An adapter speaks whatever its own transport speaks, so llm only
+            # tells it which protocol the stdin payload is (--api-format below)
+            # and hands over the Responses environment. tools/responses-ws is
+            # the adapter this exists for; see design/responses-lifecycle.md.
+            adapter) ;;
+            *) die "Responses format is not supported for provider $LLM_PROVIDER (use openai, openrouter, openai-compatible, or adapter)" ;;
         esac
         if [[ -n "$LLM_RESPONSES_BODY_FILE" ]]; then
             [[ -f "$LLM_RESPONSES_BODY_FILE" ]] \
@@ -1608,6 +1613,10 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
         [[ -n "$LLM_THINKING_LEVEL" ]] && _adapter_args+=("$LLM_THINKING_LEVEL")
     fi
     [[ "$LLM_STREAM" -eq 0 ]] && _adapter_args+=(--no-stream)
+    # Chat adapters predate this flag and must not see it, so it is added only
+    # in Responses mode, where stdin is typed input items rather than a chat
+    # messages array and the adapter owes the caller a terminal sidecar.
+    [[ "$LLM_API_FORMAT" == responses ]] && _adapter_args+=(--api-format responses)
     # Private 0700 sidecar directory for the system prompt and the deadline
     # marker files. Derived names next to a visible /tmp file would be
     # symlink-attackable by other local users; mktemp -d gives an
@@ -1623,6 +1632,14 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
     # kill it). The payload tempfile and its cleanup are reused.
     printf '%s' "$LLM_MESSAGES" > "$payload_file"
     export LLM_USAGE_FILE
+    # In Responses mode the adapter owns the whole protocol, so it needs the
+    # same three inputs the curl path reads. Exporting them here means an
+    # operator can set them without knowing whether the value has to be
+    # exported to reach a child process.
+    if [[ "$LLM_API_FORMAT" == responses ]]; then
+        export LLM_API_FORMAT LLM_RESPONSE_FILE LLM_PREVIOUS_RESPONSE_ID \
+            LLM_RESPONSES_BODY_FILE
+    fi
     _adapter_rc=0
     if [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]]; then
         # The adapter runs in its own process group (set -m) so the

--- a/bin/llm
+++ b/bin/llm
@@ -92,6 +92,11 @@ LLM_RESPONSE_FILE="${LLM_RESPONSE_FILE:-}"
 # turns it on, 0 forces foreground over a body file that asks for it, unset
 # leaves the body file's say.
 LLM_RESPONSES_POLL_INTERVAL="${LLM_RESPONSES_POLL_INTERVAL:-2}"
+# Server-side compaction (design/responses-lifecycle.md): once the rendered
+# input crosses this many tokens the server rewrites the window into an opaque
+# compaction item inside the ordinary turn. Set here it owns the request field;
+# left unset, whatever context_management the body file carries stands.
+LLM_RESPONSES_COMPACT_THRESHOLD="${LLM_RESPONSES_COMPACT_THRESHOLD:-}"
 # Token usage is captured on every call. A caller that wants this call's
 # numbers sets LLM_USAGE_FILE and gets a one-line JSON record
 # ({in_tok, out_tok, think_tok}) written there after the call (bin/shellm
@@ -370,6 +375,11 @@ Environment:
   LLM_RESPONSES_POLL_INTERVAL
                            Seconds between background polls (default 2,
                            doubling to 10). LLM_MAX_TIME bounds the whole wait
+  LLM_RESPONSES_COMPACT_THRESHOLD
+                           Token count at which the server compacts the window
+                           inside the turn, sent as context_management. When
+                           set it replaces any context_management from the body
+                           file; unset, the body file's value stands
   LLM_ADAPTER              Path to an adapter executable; required with
                            --provider adapter (contract: design/providers.md)
   LLM_PROVIDER             Provider to use when the model name implies none
@@ -513,6 +523,9 @@ case "$LLM_API_FORMAT" in
         if [[ -n "${LLM_RESPONSES_BACKGROUND:-}" ]]; then
             echo "llm: note: LLM_RESPONSES_BACKGROUND ignored with LLM_API_FORMAT=chat" >&2
         fi
+        if [[ -n "$LLM_RESPONSES_COMPACT_THRESHOLD" ]]; then
+            echo "llm: note: LLM_RESPONSES_COMPACT_THRESHOLD ignored with LLM_API_FORMAT=chat" >&2
+        fi
         ;;
     responses)
         case "$LLM_PROVIDER" in
@@ -530,6 +543,10 @@ case "$LLM_API_FORMAT" in
         esac
         [[ "$LLM_RESPONSES_POLL_INTERVAL" =~ ^[0-9]+$ ]] \
             || die "Invalid LLM_RESPONSES_POLL_INTERVAL '$LLM_RESPONSES_POLL_INTERVAL' (expected whole seconds)"
+        if [[ -n "$LLM_RESPONSES_COMPACT_THRESHOLD" ]]; then
+            [[ "$LLM_RESPONSES_COMPACT_THRESHOLD" =~ ^[1-9][0-9]*$ ]] \
+                || die "Invalid LLM_RESPONSES_COMPACT_THRESHOLD '$LLM_RESPONSES_COMPACT_THRESHOLD' (expected a positive integer)"
+        fi
         if [[ -n "$LLM_RESPONSES_BODY_FILE" ]]; then
             [[ -f "$LLM_RESPONSES_BODY_FILE" ]] \
                 || die "Responses body file not found: $LLM_RESPONSES_BODY_FILE"
@@ -844,6 +861,7 @@ _build_payload_responses() {
         --arg previous "$LLM_PREVIOUS_RESPONSE_ID"
         --arg effort "$reasoning_effort"
         --arg background "${LLM_RESPONSES_BACKGROUND:-}"
+        --arg compact_threshold "$LLM_RESPONSES_COMPACT_THRESHOLD"
         --argjson max_tokens "$LLM_MAX_TOKENS"
         --argjson stream "$( [[ "$LLM_STREAM" -eq 1 ]] && echo true || echo false )"
     )
@@ -878,6 +896,9 @@ _build_payload_responses() {
         | if $background == "1" then .background = true
           elif $background == "0" then del(.background)
           else . end
+        | if $compact_threshold == "" then .
+          else .context_management =
+            [{type: "compaction", compact_threshold: ($compact_threshold | tonumber)}] end
         | if $effort == "" then .
           else .reasoning = ((.reasoning // {}) + {effort: $effort, summary: "auto"}) end
         | .include = ((.include // [])

--- a/bin/llm
+++ b/bin/llm
@@ -1185,10 +1185,10 @@ check_response_responses() {
 # text field can be legitimate (tools, refusals), but an empty/error envelope
 # cannot. Keep this contract identical for SSE and buffered responses.
 valid_response_terminal() {
-    jq -e 'type == "object" and .error == null
+    jq -es 'length == 1 and (.[0] | type == "object" and .error == null
         and (.id | type == "string" and length > 0)
         and (.output | type == "array")
-        and (.status == "completed" or .status == "incomplete")' >/dev/null 2>&1
+        and (.status == "completed" or .status == "incomplete"))' >/dev/null 2>&1
 }
 
 responses_outcome_unknown() {
@@ -1496,7 +1496,7 @@ stream_responses() {
     # Background mode keeps the response id and the last sequence number in
     # LLM_BG_STATE: the retry loop resumes a dropped stream from there, and
     # the cancel path uses the id when llm is killed.
-    local _bg_id="${LLM_BG_RESUME_ID:-}" _bg_seq="${LLM_BG_RESUME_SEQ:-}" _seq="" _rid=""
+    local _bg_id="${LLM_BG_RESUME_ID:-}" _bg_seq="${LLM_BG_RESUME_SEQ:-}" _seq="" _rid="" _fields=""
     while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
         local line="${raw_line%$'\r'}"
         if [[ "$line" == data:\ * ]]; then
@@ -1504,8 +1504,26 @@ stream_responses() {
             local json="${line#data: }"
             [[ "$json" == "[DONE]" ]] && continue
             _event=""; _seq=""; _rid=""
-            IFS=$'\t' read -r _event _seq _rid < <(printf '%s' "$json" \
-                | jq -r '[(.type // "-"), ((.sequence_number // "-") | tostring), (.response.id // "-")] | @tsv' 2>/dev/null) || true
+            _fields=$(printf '%s' "$json" | jq -ers '
+                if length == 1 then .[0] else error("one event required") end
+                | if type == "object" and (.type | type == "string" and length > 0)
+                    and (if has("response") then
+                        (.response | type == "object")
+                        and (.response.id | type == "string" and test("^[A-Za-z0-9_-]+$"))
+                        else true end)
+                    and (if has("response_id") then
+                        (.response_id | type == "string" and test("^[A-Za-z0-9_-]+$"))
+                        and (if has("response") then .response_id == .response.id else true end)
+                        else true end)
+                    and (if has("sequence_number") then
+                        (.sequence_number | type == "number"
+                            and . >= 0 and . <= 9007199254740991 and floor == .)
+                        else true end)
+                    then [.type, ((.sequence_number // "-") | tostring),
+                          (.response.id // .response_id // "-")] | @tsv
+                    else error("invalid event identity") end' 2>/dev/null) \
+                || responses_outcome_unknown "invalid stream event or response identity" "$_bg_id"
+            IFS=$'\t' read -r _event _seq _rid <<<"$_fields"
             [[ "$_rid" == - ]] && _rid=""
             [[ "$_seq" == - ]] && _seq=""
             if [[ -n "$_rid" ]]; then
@@ -1515,14 +1533,12 @@ stream_responses() {
                     || responses_outcome_unknown "stream changed response identity" "$_bg_id"
                 _bg_id="$_rid"
             fi
-            if [[ -n "${LLM_BG_STATE:-}" ]]; then
-                [[ -z "$_seq" || "$_seq" =~ ^[0-9]+$ ]] \
-                    || responses_outcome_unknown "invalid stream sequence number" "$_bg_id"
-                if [[ -n "$_seq" && -n "${LLM_BG_RESUME_SEQ:-}" && "$_seq" -le "$LLM_BG_RESUME_SEQ" ]]; then
-                    continue
-                fi
-                [[ -n "$_seq" ]] && _bg_seq="$_seq"
+            # Every stream has one high-water mark. Background mode also
+            # persists it, but foreground output must not replay stale deltas.
+            if [[ -n "$_seq" && -n "$_bg_seq" && "$_seq" -le "$_bg_seq" ]]; then
+                continue
             fi
+            [[ -n "$_seq" ]] && _bg_seq="$_seq"
             case "$_event" in
                 response.output_text.delta|response.refusal.delta)
                     # Preserve newline-only deltas; see stream_openai.
@@ -1556,6 +1572,7 @@ stream_responses() {
                         && printf '%s' "$_response" | jq -e --arg status "${_event#response.}" \
                             '.status == $status' >/dev/null 2>&1; then
                         _terminal=1
+                        : > "$_llm_work/responses-terminal"
                         # A failed sidecar write is the call's failure, not a
                         # message on stderr: errexit is off inside the handler
                         # and the pipeline's die only leaves its own subshell.
@@ -1595,19 +1612,23 @@ stream_responses() {
                     mark_emitted
                     return 0
                     ;;
-                response.cancelled)
-                    # Someone else cancelled the background job (or a previous
-                    # llm did on its way out); nothing to retry or resume.
+                response.cancelled|response.failed)
+                    # Both terminals settle the same response. Keep their
+                    # diagnostics distinct after shared validation/publication.
+                    local _status="${_event#response.}" _failed_msg
                     _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
-                    [[ -n "$_response" ]] && printf '%s' "$_response" | write_response_file
-                    echo "llm: warning: response cancelled" >&2
-                    die_permanent "API stream error: response cancelled"
-                    ;;
-                response.failed)
-                    _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
-                    [[ -n "$_response" ]] && printf '%s' "$_response" | write_response_file
-                    local _failed_msg=""
-                    _failed_msg=$(printf '%s' "$json" | jq -r '.response.error.message // .error.message // "response failed"' 2>/dev/null) || _failed_msg="response failed"
+                    printf '%s' "$_response" | jq -es --arg status "$_status" 'length == 1
+                        and (.[0] | type == "object" and .status == $status
+                            and (.output | type == "array"))' >/dev/null 2>&1 \
+                        || responses_outcome_unknown "invalid $_status terminal response" "$_bg_id"
+                    : > "$_llm_work/responses-terminal"
+                    printf '%s' "$_response" | write_response_file || exit 1
+                    if [[ "$_status" == cancelled ]]; then
+                        echo "llm: warning: response cancelled" >&2
+                        _failed_msg="response cancelled"
+                    else
+                        _failed_msg=$(printf '%s' "$json" | jq -r '.response.error.message // .error.message // "response failed"' 2>/dev/null) || _failed_msg="response failed"
+                    fi
                     die_permanent "API stream error: $_failed_msg"
                     ;;
                 error)
@@ -1875,6 +1896,8 @@ _responses_base_url() {
 # killed or timed-out call does not leave a billable job running with no one
 # to read it. The id comes from the polling loop or the stream state file.
 _llm_bg_cancel() {
+    # A validated terminal already ended the job, even if its sidecar failed.
+    [[ ! -e "$_llm_work/responses-terminal" ]] || return 0
     local why="$1" id="${_bg_id:-}" code status
     if [[ -z "$id" && -n "${LLM_BG_STATE:-}" && -s "$LLM_BG_STATE" ]]; then
         IFS=$'\t' read -r id _ < "$LLM_BG_STATE" || true
@@ -2124,13 +2147,13 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
             _retry_msg="empty response: stream ended without emitting anything"
             _rc=1
         fi
-        if [[ "$_bg_resume" -eq 1 && "$_rc" -ne 76 ]]; then
-            # A failed resume is final: the response exists server-side, so
-            # re-creating it would run the model twice.
-            _llm_bg_cancel "resume failed"
-            [[ -n "$_retry_msg" ]] && { _llm_note error "" "$_retry_msg"; die "$_retry_msg"; }
-            [[ -n "$_ce" ]] && { _llm_note error "" "curl error: $_ce"; die "curl error: $_ce"; }
-            exit 1
+        if [[ "$_bg_active" -eq 1 && ! -e "$_llm_work/responses-terminal" ]]; then
+            # Initial-stream failures abandon a known job just like failed
+            # resumes. An error event is not a terminal response receipt.
+            _llm_bg_cancel "background stream failed"
+            # Responses never enters the retry branch below. Use the common
+            # final diagnostics after normalizing this abandonment to failure.
+            _rc=1
         fi
         # Anything that failed before output was emitted is retried (an
         # Anthropic overloaded_error arrives as an in-stream error event and

--- a/bin/llm
+++ b/bin/llm
@@ -84,6 +84,10 @@ _llm_or_env="$LLM_OR_ONLY$LLM_OR_DATA_COLLECTION$LLM_OR_ZDR"
 LLM_API_FORMAT="${LLM_API_FORMAT:-chat}"
 LLM_RESPONSES_BODY_FILE="${LLM_RESPONSES_BODY_FILE:-}"
 LLM_PREVIOUS_RESPONSE_ID="${LLM_PREVIOUS_RESPONSE_ID:-}"
+# A Conversation is the other way to carry state: the server keeps the items
+# and this call names the container instead of its predecessor. The two are
+# alternatives, so the pair is refused here rather than at the provider.
+LLM_RESPONSES_CONVERSATION="${LLM_RESPONSES_CONVERSATION:-}"
 LLM_RESPONSE_FILE="${LLM_RESPONSE_FILE:-}"
 # Background Responses (design/responses-lifecycle.md): the create returns at
 # once and the model keeps working server-side. llm then polls, or streams and
@@ -359,6 +363,11 @@ Environment:
                            previous_response_id, max_output_tokens, stream, and
                            command-line reasoning settings
   LLM_PREVIOUS_RESPONSE_ID Continue a stored Responses chain from this response
+  LLM_RESPONSES_CONVERSATION
+                           Send this call into a stored Conversation (conv_...)
+                           instead of chaining response ids. Owns the body
+                           file's conversation field, and cannot be combined
+                           with LLM_PREVIOUS_RESPONSE_ID
   LLM_RESPONSE_FILE        Atomically write the full terminal Response object,
                            or a provider error envelope, to this mode-0600 file
   LLM_RESPONSES_BACKGROUND 1 runs the Responses create in the background: llm
@@ -535,9 +544,13 @@ case "$LLM_API_FORMAT" in
                 || die "Responses body file not found: $LLM_RESPONSES_BODY_FILE"
             jq -e 'type == "object"' "$LLM_RESPONSES_BODY_FILE" >/dev/null 2>&1 \
                 || die "Responses body file must contain a JSON object: $LLM_RESPONSES_BODY_FILE"
-            if jq -e 'has("conversation")' "$LLM_RESPONSES_BODY_FILE" >/dev/null 2>&1; then
-                die "conversation state cannot be combined with llm's previous_response_id continuation; omit conversation"
+            if jq -e '.conversation != null' "$LLM_RESPONSES_BODY_FILE" >/dev/null 2>&1; then
+                _body_conversation=1
             fi
+        fi
+        if [[ -n "$LLM_PREVIOUS_RESPONSE_ID" ]] \
+            && [[ -n "$LLM_RESPONSES_CONVERSATION" || "${_body_conversation:-0}" -eq 1 ]]; then
+            die "conversation and previous_response_id cannot both be set (LLM_RESPONSES_CONVERSATION or the body file's conversation, against LLM_PREVIOUS_RESPONSE_ID); pick one"
         fi
         # A sidecar the caller asked for must be writable before any tokens
         # are spent: the streaming handler cannot fail the call cleanly for a
@@ -842,6 +855,7 @@ _build_payload_responses() {
         --arg model "$LLM_MODEL"
         --arg system "$LLM_SYSTEM"
         --arg previous "$LLM_PREVIOUS_RESPONSE_ID"
+        --arg conversation "$LLM_RESPONSES_CONVERSATION"
         --arg effort "$reasoning_effort"
         --arg background "${LLM_RESPONSES_BACKGROUND:-}"
         --argjson max_tokens "$LLM_MAX_TOKENS"
@@ -875,6 +889,8 @@ _build_payload_responses() {
           else .instructions = $system end
         | if $previous == "" then del(.previous_response_id)
           else .previous_response_id = $previous end
+        | if $conversation == "" then .
+          else .conversation = $conversation end
         | if $background == "1" then .background = true
           elif $background == "0" then del(.background)
           else . end
@@ -1700,7 +1716,7 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
     # exported to reach a child process.
     if [[ "$LLM_API_FORMAT" == responses ]]; then
         export LLM_API_FORMAT LLM_RESPONSE_FILE LLM_PREVIOUS_RESPONSE_ID \
-            LLM_RESPONSES_BODY_FILE
+            LLM_RESPONSES_BODY_FILE LLM_RESPONSES_CONVERSATION
     fi
     _adapter_rc=0
     if [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]]; then

--- a/bin/llm
+++ b/bin/llm
@@ -1966,8 +1966,13 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         fi
         if [[ "$_bg_active" -eq 1 ]]; then
             # As a job, so a signal reaches the cancel trap at once instead of
-            # after the stream ends.
-            ( "$_stream_handler" < <("${_stream_curl[@]}" 2>"$_curl_err") ) &
+            # after the stream ends. The `|| exit` keeps the handler in the
+            # same errexit-ignored context the foreground form below gives it:
+            # a bare `( ... ) &` would run it with set -e live, and one
+            # transiently failing write (stderr to a busy pipe, say) would end
+            # the stream with a silent exit 1 instead of the handler's own
+            # verdict.
+            ( "$_stream_handler" < <("${_stream_curl[@]}" 2>"$_curl_err") || exit "$?" ) &
             _bg_job=$!
             wait "$_bg_job" || _rc=$?
             _bg_job=""

--- a/bin/llm
+++ b/bin/llm
@@ -1773,7 +1773,17 @@ if [[ "$LLM_PROVIDER" == "adapter" ]]; then
             LLM_RESPONSES_BODY_FILE LLM_RESPONSES_CONVERSATION
     fi
     _adapter_rc=0
-    if [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]]; then
+    if [[ -n "${HEADLONG_JOB_EXECUTION_ID:-}" ]]; then
+        [[ -n "${HEADLONG_JOB_ID:-}" && -n "${HEADLONG_JOB_ATTEMPT_ID:-}" && -x "${HEADLONG_JOB_CONTROL_TOOL:-}" ]] \
+            || die "Job adapters must run through the admitted Headlong attempt wrapper"
+        _adapter_deadline=0
+        [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ ]] && _adapter_deadline="$LLM_MAX_TIME"
+        # The attempt controller reserves and records this exact subgroup.
+        # Its deadline is phase-local; its guardian also sweeps on job death.
+        "$HEADLONG_JOB_CONTROL_TOOL" adapter-run --deadline "$_adapter_deadline" -- \
+            "$LLM_ADAPTER" "${_adapter_args[@]}" < "$payload_file" || _adapter_rc=$?
+        if [[ "$_adapter_rc" -eq 124 ]]; then : > "$_adapter_dir/deadline"; fi
+    elif [[ "$LLM_MAX_TIME" =~ ^[0-9]+$ && "$LLM_MAX_TIME" -gt 0 ]]; then
         # The adapter runs in its own process group (set -m) so the
         # deadline can kill its whole tree: a shell adapter's provider
         # child would otherwise survive a PID-targeted kill and hold the

--- a/bin/llm
+++ b/bin/llm
@@ -169,6 +169,14 @@ die_retryable() {
     { [[ -n "${LLM_RETRY_ERR:-}" ]] && printf '%s' "$*" > "$LLM_RETRY_ERR" 2>/dev/null; } || true
     exit 75
 }
+# A failure seen before anything was emitted that a retry cannot fix (a
+# rejected previous_response_id in Responses mode): the stream retry loop
+# stops at once instead of replaying a deterministic error. Exit 76 is the
+# loop's private signal; the caller sees exit 1 like any other error.
+die_permanent() {
+    { [[ -n "${LLM_RETRY_ERR:-}" ]] && printf '%s' "$*" > "$LLM_RETRY_ERR" 2>/dev/null; } || true
+    exit 76
+}
 
 # Called by stream handlers the moment anything is emitted (stdout text or
 # thinking on stderr) — from that point on, failures must not retry.
@@ -371,7 +379,10 @@ Environment:
                            first block and drop the rest: a model that keeps
                            writing after its command no longer costs tokens
                            or wall time. Usage is then estimated
-                           (out_tok from bytes, estimated:true).
+                           (out_tok from bytes, estimated:true). Under
+                           LLM_API_FORMAT=responses the cut also skips the
+                           terminal event, so LLM_RESPONSE_FILE is not
+                           written for that call.
 
 Examples:
   llm -m claude-sonnet-4-5-20250929 "explain quicksort"
@@ -1224,9 +1235,12 @@ _responses_prev_id_error() {
 _die_if_no_stream_data() {
     [[ "$_saw_data" -eq 0 && -n "$_err_buf" ]] || return 0
     local _err _continuation_error=0
-    if [[ "$LLM_API_FORMAT" == responses && -n "$LLM_RESPONSE_FILE" ]]; then
+    if [[ "$LLM_API_FORMAT" == responses ]]; then
         if printf '%s' "$_err_buf" | jq -e . >/dev/null 2>&1; then
             printf '%s' "$_err_buf" | write_response_file
+            # Judged on the error body alone, sidecar or not: a rejected
+            # previous_response_id is deterministic, and replaying it only
+            # delays the caller's fallback to its exact replay chain.
             printf '%s' "$_err_buf" | _responses_prev_id_error && _continuation_error=1
         else
             jq -nc --arg message "$_err_buf" '{error:{message:$message}}' \
@@ -1235,7 +1249,7 @@ _die_if_no_stream_data() {
     fi
     _err=$(printf '%s' "$_err_buf" | jq -r '.error.message // .message // empty' 2>/dev/null || true)
     if [[ "$_continuation_error" -eq 1 ]]; then
-        die "API error: ${_err:-previous_response_id was rejected}"
+        die_permanent "API error: ${_err:-previous_response_id was rejected}"
     fi
     [[ -n "$_err" ]] && die_retryable "API error: $_err"
     die_retryable "API error: $_err_buf"
@@ -1371,7 +1385,7 @@ stream_responses() {
                     if [[ -n "$_chunk" ]]; then
                         mark_emitted
                         _text_emitted=1
-                        printf '%s' "$_chunk"
+                        _emit_text "$_chunk" || break
                     fi
                     ;;
                 response.reasoning_summary_text.delta)
@@ -1442,8 +1456,10 @@ stream_responses() {
                     printf '%s' "$json" | write_response_file
                     local _error_msg=""
                     _error_msg=$(printf '%s' "$json" | jq -r '.error.message // .message // "unknown error"' 2>/dev/null) || _error_msg="unknown error"
-                    if [[ -e "$LLM_DATA_MARKER" ]] || printf '%s' "$json" | _responses_prev_id_error; then
+                    if [[ -e "$LLM_DATA_MARKER" ]]; then
                         die "API stream error: $_error_msg"
+                    elif printf '%s' "$json" | _responses_prev_id_error; then
+                        die_permanent "API stream error: $_error_msg"
                     else
                         die_retryable "API stream error: $_error_msg"
                     fi
@@ -1455,6 +1471,10 @@ stream_responses() {
         fi
     done
     _die_if_no_stream_data
+    # Cut on purpose after the first code block (LLM_STOP_AFTER_CODE_BLOCK):
+    # the retry loop reads the stop marker as a clean finish. The terminal
+    # event never arrives, so there is no sidecar and usage is estimated.
+    [[ -n "${LLM_STOP_MARKER:-}" && -e "$LLM_STOP_MARKER" ]] && return 0
     if [[ "$_terminal" -ne 1 ]]; then
         if [[ -e "$LLM_DATA_MARKER" ]]; then
             die "API stream error: Responses stream ended without a terminal response"
@@ -1722,10 +1742,11 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
             _retry_msg="empty response: stream ended without emitting anything"
             _rc=1
         fi
-        _retryable=0
-        [[ "$_rc" -eq 75 || -n "$_ce" ]] && _retryable=1
-        [[ "$_retry_msg" == empty\ response:* ]] && _retryable=1
-        if [[ "$_emitted" -eq 0 && "$_retryable" -eq 1 \
+        # Anything that failed before output was emitted is retried (an
+        # Anthropic overloaded_error arrives as an in-stream error event and
+        # exits 1, not 75), with one exception: a handler that exited 76
+        # (die_permanent) saw an error a replay cannot fix.
+        if [[ "$_emitted" -eq 0 && "$_rc" -ne 76 \
             && "$_attempt" -lt "$_max_attempts" ]]; then
             echo "llm: transient API failure (attempt $_attempt/$_max_attempts): ${_retry_msg:-${_ce:-exit $_rc}} — retrying" >&2
             sleep $(( LLM_RETRY_BACKOFF * _attempt ))
@@ -1734,6 +1755,7 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         # Exhausted or output already emitted: fail like before
         [[ -n "$_retry_msg" ]] && { _llm_note error "" "$_retry_msg"; die "$_retry_msg"; }
         [[ -n "$_ce" ]] && { _llm_note error "" "curl error: $_ce"; die "curl error: $_ce"; }
+        [[ "$_rc" -eq 76 ]] && exit 1
         exit "$_rc"   # mid-stream die already printed its message
     done
 else
@@ -1784,7 +1806,7 @@ else
                     continue
                 fi
                 if [[ "$LLM_API_FORMAT" == responses ]]; then
-                    printf '%s' "$(cat "$local_resp")" | write_response_file
+                    write_response_file < "$local_resp"
                 fi
                 rm -f "$local_resp"
                 die "API error: $embedded_err"

--- a/bin/llm
+++ b/bin/llm
@@ -511,6 +511,12 @@ case "$LLM_API_FORMAT" in
                 die "conversation state cannot be combined with llm's previous_response_id continuation; omit conversation"
             fi
         fi
+        # A sidecar the caller asked for must be writable before any tokens
+        # are spent: the streaming handler cannot fail the call cleanly for a
+        # missing directory once the reply is on its way.
+        if [[ -n "$LLM_RESPONSE_FILE" && ! -d "$(dirname "$LLM_RESPONSE_FILE")" ]]; then
+            die "Response file directory does not exist: $(dirname "$LLM_RESPONSE_FILE")"
+        fi
         ;;
     *) die "Unknown LLM_API_FORMAT '$LLM_API_FORMAT' (expected chat or responses)" ;;
 esac
@@ -788,6 +794,13 @@ build_payload_openai() {
 # The optional extra body owns the broad protocol surface while llm overwrites
 # the fields coupled to its existing CLI contract.
 build_payload_responses() {
+    if [[ "$LLM_PROVIDER" == openrouter && -n "$LLM_OR_ONLY$LLM_OR_DATA_COLLECTION$LLM_OR_ZDR" ]]; then
+        _build_payload_responses | _apply_or_provider
+    else
+        _build_payload_responses
+    fi
+}
+_build_payload_responses() {
     local reasoning_effort="${LLM_THINKING_LEVEL:-${LLM_EFFORT:-}}"
     local -a jq_args=(
         --arg model "$LLM_MODEL"
@@ -870,18 +883,26 @@ build_payload_openrouter() {
         build_payload_openai
         return
     fi
-    # Values are already normalised above, so this only assembles them. The sum
-    # is bound with `as $p` rather than written inline as the object's value:
-    # jq 1.7 (what ubuntu-latest, and therefore CI, runs) rejects a `+` chain of
-    # parenthesised ifs in that position, and only 1.8 relaxed the grammar.
-    build_payload_openai | jq -c \
+    build_payload_openai | _apply_or_provider
+}
+
+# Add the OpenRouter provider object to a payload on stdin. Shared by the chat
+# and Responses builders: a pinned route or a ZDR/no-training constraint is a
+# statement about where the prompt may go, so it applies to every wire format
+# that reaches OpenRouter, and a caller's own provider object is merged, not
+# replaced. Values are already normalised above, so this only assembles them.
+# The sum is bound with `as $p` rather than written inline as the object's
+# value: jq 1.7 (what ubuntu-latest, and therefore CI, runs) rejects a `+`
+# chain of parenthesised ifs in that position, and only 1.8 relaxed the grammar.
+_apply_or_provider() {
+    jq -c \
         --arg only "$LLM_OR_ONLY" \
         --arg dc "$LLM_OR_DATA_COLLECTION" \
         --arg zdr "$LLM_OR_ZDR" \
         '((if $only != "" then {only: ($only | split(","))} else {} end)
           + (if $dc != "" then {data_collection: $dc} else {} end)
           + (if $zdr != "" then {zdr: true} else {} end)) as $p
-         | . + {provider: $p}'
+         | .provider = ((.provider // {}) + $p)'
 }
 
 # Generic openai-compatible endpoint (Ollama, vLLM, LM Studio, proxies):
@@ -1408,7 +1429,10 @@ stream_responses() {
                         && printf '%s' "$_response" | jq -e --arg status "${_event#response.}" \
                             '.status == $status' >/dev/null 2>&1; then
                         _terminal=1
-                        printf '%s' "$_response" | write_response_file
+                        # A failed sidecar write is the call's failure, not a
+                        # message on stderr: errexit is off inside the handler
+                        # and the pipeline's die only leaves its own subshell.
+                        printf '%s' "$_response" | write_response_file || exit 1
                         if [[ "$_reasoning_emitted" -eq 0 ]]; then
                             printf '%s' "$_response" | extract_reasoning_responses >&2
                         fi

--- a/bin/llm
+++ b/bin/llm
@@ -1355,7 +1355,7 @@ stream_openai() {
 
 stream_responses() {
     local _saw_data=0 _err_buf="" _chunk="" _event="" _response=""
-    local _text_emitted=0 _reasoning_emitted=0
+    local _text_emitted=0 _reasoning_emitted=0 _terminal=0
     while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
         local line="${raw_line%$'\r'}"
         if [[ "$line" == data:\ * ]]; then
@@ -1390,7 +1390,10 @@ stream_responses() {
                     ;;
                 response.completed|response.incomplete)
                     _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
-                    if [[ -n "$_response" ]]; then
+                    if [[ -n "$_response" ]] \
+                        && printf '%s' "$_response" | jq -e --arg status "${_event#response.}" \
+                            '.status == $status' >/dev/null 2>&1; then
+                        _terminal=1
                         printf '%s' "$_response" | write_response_file
                         if [[ "$_reasoning_emitted" -eq 0 ]]; then
                             printf '%s' "$_response" | extract_reasoning_responses >&2
@@ -1452,6 +1455,12 @@ stream_responses() {
         fi
     done
     _die_if_no_stream_data
+    if [[ "$_terminal" -ne 1 ]]; then
+        if [[ -e "$LLM_DATA_MARKER" ]]; then
+            die "API stream error: Responses stream ended without a terminal response"
+        fi
+        die_retryable "API stream error: Responses stream ended without a terminal response"
+    fi
 }
 
 stream_gemini() {

--- a/bin/llm
+++ b/bin/llm
@@ -514,8 +514,16 @@ case "$LLM_API_FORMAT" in
         # A sidecar the caller asked for must be writable before any tokens
         # are spent: the streaming handler cannot fail the call cleanly for a
         # missing directory once the reply is on its way.
-        if [[ -n "$LLM_RESPONSE_FILE" && ! -d "$(dirname "$LLM_RESPONSE_FILE")" ]]; then
-            die "Response file directory does not exist: $(dirname "$LLM_RESPONSE_FILE")"
+        if [[ -n "$LLM_RESPONSE_FILE" ]]; then
+            _response_dir=$(dirname "$LLM_RESPONSE_FILE")
+            [[ -d "$_response_dir" ]] \
+                || die "Response file directory does not exist: $_response_dir"
+            [[ -w "$_response_dir" ]] \
+                || die "Response file directory is not writable: $_response_dir"
+            # mv into an existing directory would "succeed" by dropping the
+            # temp file inside it, leaving no file at the path the caller reads.
+            [[ -d "$LLM_RESPONSE_FILE" ]] \
+                && die "Response file is a directory: $LLM_RESPONSE_FILE"
         fi
         ;;
     *) die "Unknown LLM_API_FORMAT '$LLM_API_FORMAT' (expected chat or responses)" ;;
@@ -1178,6 +1186,8 @@ write_response_file() {
         || die "Cannot create temporary Response file in: $response_dir"
     if ( umask 077; cat > "$response_tmp" ); then
         chmod 600 "$response_tmp" 2>/dev/null || true
+        [[ -d "$LLM_RESPONSE_FILE" ]] \
+            && { rm -f "$response_tmp"; die "Response file is a directory: $LLM_RESPONSE_FILE"; }
         mv -f "$response_tmp" "$LLM_RESPONSE_FILE" \
             || { rm -f "$response_tmp"; die "Cannot write Response file: $LLM_RESPONSE_FILE"; }
     else

--- a/bin/llm
+++ b/bin/llm
@@ -77,6 +77,14 @@ LLM_OR_ZDR="${LLM_OR_ZDR:-}"
 # routing constraint nobody typed on this command line still changes where the
 # prompt may go, so it is announced once rather than applied invisibly.
 _llm_or_env="$LLM_OR_ONLY$LLM_OR_DATA_COLLECTION$LLM_OR_ZDR"
+# Completion wire protocol. "chat" preserves the existing API and output
+# contract; "responses" selects OpenAI's Responses create/stream protocol.
+# Lifecycle operations (retrieve/cancel/delete, conversations, compaction)
+# belong in a follow-on surface rather than overloading this completion CLI.
+LLM_API_FORMAT="${LLM_API_FORMAT:-chat}"
+LLM_RESPONSES_BODY_FILE="${LLM_RESPONSES_BODY_FILE:-}"
+LLM_PREVIOUS_RESPONSE_ID="${LLM_PREVIOUS_RESPONSE_ID:-}"
+LLM_RESPONSE_FILE="${LLM_RESPONSE_FILE:-}"
 # Token usage is captured on every call. A caller that wants this call's
 # numbers sets LLM_USAGE_FILE and gets a one-line JSON record
 # ({in_tok, out_tok, think_tok}) written there after the call (bin/shellm
@@ -326,6 +334,18 @@ Environment:
   LLM_API_KEY              Optional key for openai-compatible, sent as
                            Authorization: Bearer when set (local servers
                            like Ollama need none)
+  LLM_API_FORMAT           Completion protocol: chat (default) or responses.
+                           Responses is supported by openai, openrouter, and
+                           openai-compatible providers
+  LLM_RESPONSES_BODY_FILE  Optional JSON object merged into a Responses create
+                           request. Supports tools, include, store, text format,
+                           metadata, truncation, service tier, and other create
+                           fields. llm owns model, input, instructions,
+                           previous_response_id, max_output_tokens, stream, and
+                           command-line reasoning settings
+  LLM_PREVIOUS_RESPONSE_ID Continue a stored Responses chain from this response
+  LLM_RESPONSE_FILE        Atomically write the full terminal Response object,
+                           or a provider error envelope, to this mode-0600 file
   LLM_ADAPTER              Path to an adapter executable; required with
                            --provider adapter (contract: design/providers.md)
   LLM_PROVIDER             Provider to use when the model name implies none
@@ -361,6 +381,8 @@ Examples:
   llm -m z-ai/glm-5.2 "explain quicksort"
   LLM_API_URL=http://localhost:11434/v1/chat/completions \
     llm --provider openai-compatible -m qwen3:8b "explain quicksort"
+  LLM_API_FORMAT=responses LLM_RESPONSE_FILE=/tmp/response.json \
+    llm --provider openai -m gpt-5.5 --thinking high "solve carefully"
 EOF
     exit "${1:-0}"
 }
@@ -458,6 +480,26 @@ detect_provider() {
 if [[ -z "$LLM_PROVIDER" ]]; then
     LLM_PROVIDER=$(detect_provider "$LLM_MODEL")
 fi
+
+case "$LLM_API_FORMAT" in
+    chat) ;;
+    responses)
+        case "$LLM_PROVIDER" in
+            openai|openrouter|openai-compatible) ;;
+            *) die "Responses format is not supported for provider $LLM_PROVIDER (use openai, openrouter, or openai-compatible)" ;;
+        esac
+        if [[ -n "$LLM_RESPONSES_BODY_FILE" ]]; then
+            [[ -f "$LLM_RESPONSES_BODY_FILE" ]] \
+                || die "Responses body file not found: $LLM_RESPONSES_BODY_FILE"
+            jq -e 'type == "object"' "$LLM_RESPONSES_BODY_FILE" >/dev/null 2>&1 \
+                || die "Responses body file must contain a JSON object: $LLM_RESPONSES_BODY_FILE"
+            if [[ "$(jq -r '.background // false' "$LLM_RESPONSES_BODY_FILE")" == true ]]; then
+                die "background responses require lifecycle operations; use foreground Responses completion for now"
+            fi
+        fi
+        ;;
+    *) die "Unknown LLM_API_FORMAT '$LLM_API_FORMAT' (expected chat or responses)" ;;
+esac
 
 # An environment-supplied provider reroutes every call in the process tree,
 # so it must never do it silently: when it disagrees with what the model
@@ -726,6 +768,54 @@ build_payload_openai() {
     printf '%s' "$msgs" | jq "${jq_args[@]}" "$jq_filter"
 }
 
+# OpenAI Responses create request. Input stays as the typed JSON supplied by
+# --messages/--messages-file: message items, images/files, prior reasoning
+# items, tool calls, and tool outputs must not be flattened into chat strings.
+# The optional extra body owns the broad protocol surface while llm overwrites
+# the fields coupled to its existing CLI contract.
+build_payload_responses() {
+    local reasoning_effort="${LLM_THINKING_LEVEL:-${LLM_EFFORT:-}}"
+    local -a jq_args=(
+        --arg model "$LLM_MODEL"
+        --arg system "$LLM_SYSTEM"
+        --arg previous "$LLM_PREVIOUS_RESPONSE_ID"
+        --arg effort "$reasoning_effort"
+        --argjson max_tokens "$LLM_MAX_TOKENS"
+        --argjson stream "$( [[ "$LLM_STREAM" -eq 1 ]] && echo true || echo false )"
+    )
+
+    if [[ -n "$LLM_RESPONSES_BODY_FILE" ]]; then
+        jq_args+=(--slurpfile extra "$LLM_RESPONSES_BODY_FILE")
+    else
+        # Match --slurpfile's array shape without putting any caller content
+        # on argv.
+        jq_args+=(--argjson extra '[{}]')
+    fi
+
+    if [[ -n "$reasoning_effort" && "$LLM_PROVIDER" == openai ]] \
+       && ! supports_openai_reasoning; then
+        echo "llm: --thinking/--effort ignored: $LLM_MODEL not in the known-reasoning model list (LLM_ASSUME_THINKING=1 to send anyway)" >&2
+        reasoning_effort=""
+        # Replace the earlier jq value; the final duplicate option wins.
+        jq_args+=(--arg effort "")
+    fi
+
+    printf '%s' "$LLM_MESSAGES" | jq "${jq_args[@]}" '
+        ($extra[0] // {}) + {
+            model: $model,
+            input: .,
+            max_output_tokens: $max_tokens,
+            stream: $stream
+        }
+        | if $system == "" then del(.instructions)
+          else .instructions = $system end
+        | if $previous == "" then del(.previous_response_id)
+          else .previous_response_id = $previous end
+        | if $effort == "" then .
+          else .reasoning = ((.reasoning // {}) + {effort: $effort, summary: "auto"}) end
+    '
+}
+
 build_payload_gemini() {
     # Convert messages to Gemini format: {contents:[{role,parts:[{text}]}]}
     local contents
@@ -753,10 +843,9 @@ build_payload_gemini() {
     printf '%s' "$contents" | jq "${jq_args[@]}" "$jq_filter"
 }
 
-# OpenRouter is OpenAI-compatible (chat/completions wire format)
-# OpenRouter is OpenAI-compatible (chat/completions wire format), plus an
-# optional "provider" object carrying the routing preferences above. Without
-# that object OpenRouter is free to pick any host serving the model.
+# OpenRouter is OpenAI-compatible (chat/completions or Responses wire format),
+# plus an optional "provider" object carrying the routing preferences above.
+# Without that object OpenRouter is free to pick any host serving the model.
 build_payload_openrouter() {
     # Unpinned callers pay nothing: no extra jq pass, byte-identical to before.
     if [[ -z "$LLM_OR_ONLY$LLM_OR_DATA_COLLECTION$LLM_OR_ZDR" ]]; then
@@ -839,13 +928,21 @@ get_url_headers() {
             ;;
         openai)
             [[ -z "${OPENAI_API_KEY:-}" ]] && die "OPENAI_API_KEY is not set"
-            url="${LLM_API_URL:-https://api.openai.com/v1/chat/completions}"
+            if [[ "$LLM_API_FORMAT" == responses ]]; then
+                url="${LLM_API_URL:-https://api.openai.com/v1/responses}"
+            else
+                url="${LLM_API_URL:-https://api.openai.com/v1/chat/completions}"
+            fi
             headers=(-H "Content-Type: application/json")
             add_auth_header "Authorization: Bearer $OPENAI_API_KEY"
             ;;
         openrouter)
             [[ -z "${OPENROUTER_API_KEY:-}" ]] && die "OPENROUTER_API_KEY is not set"
-            url="${LLM_API_URL:-https://openrouter.ai/api/v1/chat/completions}"
+            if [[ "$LLM_API_FORMAT" == responses ]]; then
+                url="${LLM_API_URL:-https://openrouter.ai/api/v1/responses}"
+            else
+                url="${LLM_API_URL:-https://openrouter.ai/api/v1/chat/completions}"
+            fi
             headers=(-H "Content-Type: application/json")
             add_auth_header "Authorization: Bearer $OPENROUTER_API_KEY"
             ;;
@@ -901,6 +998,27 @@ extract_text_openai() {
     jq -r '.choices[0].message.content // empty' 2>/dev/null
 }
 
+extract_text_responses() {
+    jq -j '
+        .output[]?
+        | select(.type == "message")
+        | .content[]?
+        | if .type == "output_text" then .text
+          elif .type == "refusal" then .refusal
+          else empty end
+    ' 2>/dev/null
+}
+
+extract_reasoning_responses() {
+    jq -j '
+        .output[]?
+        | select(.type == "reasoning")
+        | .summary[]?
+        | select(.type == "summary_text")
+        | .text
+    ' 2>/dev/null
+}
+
 extract_text_gemini() {
     jq -r '.candidates[0].content.parts[0].text // empty' 2>/dev/null
 }
@@ -937,6 +1055,14 @@ check_response_openai() {
       ] | .[0] // empty' 2>/dev/null
 }
 
+check_response_responses() {
+    jq -r '
+        if .error != null then .error.message // "unknown error"
+        elif .status == "failed" then .error.message // "response failed"
+        else empty end
+    ' 2>/dev/null
+}
+
 check_response_gemini() {
     jq -r '.error.message // empty' 2>/dev/null
 }
@@ -962,6 +1088,22 @@ check_truncated_openai() {
     jq -r 'if (.choices[0].finish_reason // "") == "length" then "y" else empty end' 2>/dev/null
 }
 
+check_truncated_responses() {
+    jq -r '
+        if .status == "incomplete"
+           and (.incomplete_details.reason // "") == "max_output_tokens"
+        then "y" else empty end
+    ' 2>/dev/null
+}
+
+check_incomplete_responses() {
+    jq -r '
+        if .status == "incomplete"
+        then .incomplete_details.reason // "unknown reason"
+        else empty end
+    ' 2>/dev/null
+}
+
 check_truncated_gemini() {
     jq -r 'if (.candidates[0].finishReason // "") == "MAX_TOKENS" then "y" else empty end' 2>/dev/null
 }
@@ -976,6 +1118,33 @@ check_truncated_opencode() { check_truncated_anthropic; }
 # straight through the handler subshell, so this works from either).
 warn_truncated() {
     echo "llm: warning: output truncated at max_tokens=$LLM_MAX_TOKENS (reasoning tokens count against it) — raise with -t" >&2
+}
+
+warn_incomplete_response() {
+    local reason="$1"
+    [[ -z "$reason" || "$reason" == max_output_tokens ]] && return 0
+    echo "llm: warning: response incomplete: $reason" >&2
+}
+
+# Write the full terminal Responses object (or an API error envelope) for
+# machine callers. A same-directory temporary plus rename makes each write
+# atomic, and mode 0600 keeps prompts, outputs, and reasoning private.
+write_response_file() {
+    [[ -n "$LLM_RESPONSE_FILE" ]] || return 0
+    local response_dir response_tmp
+    response_dir=$(dirname "$LLM_RESPONSE_FILE")
+    [[ -d "$response_dir" ]] \
+        || die "Response file directory does not exist: $response_dir"
+    response_tmp=$(mktemp "$response_dir/.llm-response.XXXXXX") \
+        || die "Cannot create temporary Response file in: $response_dir"
+    if ( umask 077; cat > "$response_tmp" ); then
+        chmod 600 "$response_tmp" 2>/dev/null || true
+        mv -f "$response_tmp" "$LLM_RESPONSE_FILE" \
+            || { rm -f "$response_tmp"; die "Cannot write Response file: $LLM_RESPONSE_FILE"; }
+    else
+        rm -f "$response_tmp"
+        die "Cannot write Response file: $LLM_RESPONSE_FILE"
+    fi
 }
 
 # Write the LLM_USAGE_FILE record. Args: input tokens, output tokens,
@@ -1040,8 +1209,26 @@ _llm_ledger_append() {
 # error body. Reads the caller's _saw_data/_err_buf via dynamic scoping.
 _die_if_no_stream_data() {
     [[ "$_saw_data" -eq 0 && -n "$_err_buf" ]] || return 0
-    local _err
+    local _err _continuation_error=0
+    if [[ "$LLM_API_FORMAT" == responses && -n "$LLM_RESPONSE_FILE" ]]; then
+        if printf '%s' "$_err_buf" | jq -e . >/dev/null 2>&1; then
+            printf '%s' "$_err_buf" | write_response_file
+            if printf '%s' "$_err_buf" | jq -e '
+                [(.error.param? // ""), (.error.code? // ""), (.error.message? // "")]
+                | map(tostring | ascii_downcase) | join(" ")
+                | test("previous[ _]response[ _]id|previous response")
+            ' >/dev/null 2>&1; then
+                _continuation_error=1
+            fi
+        else
+            jq -nc --arg message "$_err_buf" '{error:{message:$message}}' \
+                | write_response_file
+        fi
+    fi
     _err=$(printf '%s' "$_err_buf" | jq -r '.error.message // empty' 2>/dev/null || true)
+    if [[ "$_continuation_error" -eq 1 ]]; then
+        die "API error: ${_err:-previous_response_id was rejected}"
+    fi
     [[ -n "$_err" ]] && die_retryable "API error: $_err"
     die_retryable "API error: $_err_buf"
 }
@@ -1150,6 +1337,113 @@ stream_openai() {
                     write_usage "$_u_in" "$_u_out" "$_u_think" "$_u_cache"
                 fi
             fi
+        elif [[ "$_saw_data" -eq 0 ]]; then
+            _err_buf="${_err_buf}${line}
+"
+        fi
+    done
+    _die_if_no_stream_data
+}
+
+stream_responses() {
+    local _saw_data=0 _err_buf="" _chunk="" _event="" _response=""
+    local _text_emitted=0 _reasoning_emitted=0
+    while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+        local line="${raw_line%$'\r'}"
+        if [[ "$line" == data:\ * ]]; then
+            _saw_data=1
+            local json="${line#data: }"
+            [[ "$json" == "[DONE]" ]] && continue
+            _event=$(printf '%s' "$json" | jq -r '.type // empty' 2>/dev/null) || _event=""
+            case "$_event" in
+                response.output_text.delta|response.refusal.delta)
+                    # Preserve newline-only deltas; see stream_openai.
+                    _chunk=$(printf '%s' "$json" | jq -j '.delta // empty'; printf X)
+                    _chunk="${_chunk%X}"
+                    if [[ -n "$_chunk" ]]; then
+                        mark_emitted
+                        _text_emitted=1
+                        printf '%s' "$_chunk"
+                    fi
+                    ;;
+                response.reasoning_summary_text.delta)
+                    _chunk=$(printf '%s' "$json" | jq -j '.delta // empty'; printf X)
+                    _chunk="${_chunk%X}"
+                    if [[ -n "$_chunk" ]]; then
+                        mark_emitted
+                        _reasoning_emitted=1
+                        printf '%s' "$_chunk" >&2
+                    fi
+                    ;;
+                response.output_item.done)
+                    # A function call or other typed item is valid protocol
+                    # output even when there is no visible assistant text.
+                    mark_emitted
+                    ;;
+                response.completed|response.incomplete)
+                    _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
+                    if [[ -n "$_response" ]]; then
+                        printf '%s' "$_response" | write_response_file
+                        if [[ "$_reasoning_emitted" -eq 0 ]]; then
+                            printf '%s' "$_response" | extract_reasoning_responses >&2
+                        fi
+                        if [[ "$_text_emitted" -eq 0 ]]; then
+                            printf '%s' "$_response" | extract_text_responses
+                        fi
+
+                        local _u=""
+                        _u=$(printf '%s' "$_response" | jq -r '[
+                                (.usage.input_tokens // ""),
+                                (.usage.output_tokens // ""),
+                                (.usage.output_tokens_details.reasoning_tokens // ""),
+                                (.usage.input_tokens_details.cached_tokens // "")
+                            ] | @tsv' 2>/dev/null) || _u=""
+                        if [[ -n "$_u" ]]; then
+                            local _u_in _u_out _u_think _u_cache
+                            IFS=$'\t' read -r _u_in _u_out _u_think _u_cache <<<"$_u"
+                            write_usage "$_u_in" "$_u_out" "$_u_think" "$_u_cache"
+                        fi
+
+                        if [[ "$_event" == response.incomplete ]]; then
+                            local _reason=""
+                            _reason=$(printf '%s' "$_response" | check_incomplete_responses)
+                            if [[ "$_reason" == max_output_tokens ]]; then
+                                warn_truncated
+                            else
+                                warn_incomplete_response "$_reason"
+                            fi
+                        fi
+                    fi
+                    mark_emitted
+                    ;;
+                response.failed)
+                    _response=$(printf '%s' "$json" | jq -c '.response // empty' 2>/dev/null) || _response=""
+                    [[ -n "$_response" ]] && printf '%s' "$_response" | write_response_file
+                    local _failed_msg=""
+                    _failed_msg=$(printf '%s' "$json" | jq -r '.response.error.message // .error.message // "response failed"' 2>/dev/null) || _failed_msg="response failed"
+                    if [[ -e "$LLM_DATA_MARKER" ]]; then
+                        die "API stream error: $_failed_msg"
+                    else
+                        die_retryable "API stream error: $_failed_msg"
+                    fi
+                    ;;
+                error)
+                    printf '%s' "$json" | write_response_file
+                    local _error_msg=""
+                    _error_msg=$(printf '%s' "$json" | jq -r '.error.message // .message // "unknown error"' 2>/dev/null) || _error_msg="unknown error"
+                    if [[ -e "$LLM_DATA_MARKER" ]]; then
+                        die "API stream error: $_error_msg"
+                    elif printf '%s' "$json" | jq -e '
+                        [(.error.param? // ""), (.error.code? // ""), (.error.message? // "")]
+                        | map(tostring | ascii_downcase) | join(" ")
+                        | test("previous[ _]response[ _]id|previous response")
+                    ' >/dev/null 2>&1; then
+                        die "API stream error: $_error_msg"
+                    else
+                        die_retryable "API stream error: $_error_msg"
+                    fi
+                    ;;
+            esac
         elif [[ "$_saw_data" -eq 0 ]]; then
             _err_buf="${_err_buf}${line}
 "
@@ -1339,9 +1633,13 @@ fi
 # A typo'd provider name would otherwise surface as bash's exit-127
 # "build_payload_...: command not found" instead of an error naming the
 # problem, because payload build runs before get_url_headers' own check.
-declare -f "build_payload_${LLM_PROVIDER}" >/dev/null \
-    || die "Unknown provider: $LLM_PROVIDER (see --provider in --help for the list)"
-"build_payload_${LLM_PROVIDER}" > "$payload_file"
+if [[ "$LLM_API_FORMAT" == responses ]]; then
+    build_payload_responses > "$payload_file"
+else
+    declare -f "build_payload_${LLM_PROVIDER}" >/dev/null \
+        || die "Unknown provider: $LLM_PROVIDER (see --provider in --help for the list)"
+    "build_payload_${LLM_PROVIDER}" > "$payload_file"
+fi
 
 # Get URL and headers
 url=""
@@ -1377,7 +1675,9 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
         LLM_DATA_MARKER="${LLM_RETRY_ERR}.emitted"
         LLM_STOP_MARKER="${LLM_RETRY_ERR}.stopped"
         _rc=0
-        ( "stream_${LLM_PROVIDER}" < <(curl -sS -N ${_net_args[@]+"${_net_args[@]}"} "${headers[@]}" -d @"$payload_file" "$url" 2>"$_curl_err") ) || _rc=$?
+        _stream_handler="stream_${LLM_PROVIDER}"
+        [[ "$LLM_API_FORMAT" == responses ]] && _stream_handler=stream_responses
+        ( "$_stream_handler" < <(curl -sS -N ${_net_args[@]+"${_net_args[@]}"} "${headers[@]}" -d @"$payload_file" "$url" 2>"$_curl_err") ) || _rc=$?
 
         _emitted=0
         [[ -e "$LLM_DATA_MARKER" ]] && _emitted=1
@@ -1411,7 +1711,11 @@ if [[ "$LLM_STREAM" -eq 1 ]]; then
             _retry_msg="empty response: stream ended without emitting anything"
             _rc=1
         fi
-        if [[ "$_emitted" -eq 0 && "$_attempt" -lt "$_max_attempts" ]]; then
+        _retryable=0
+        [[ "$_rc" -eq 75 || -n "$_ce" ]] && _retryable=1
+        [[ "$_retry_msg" == empty\ response:* ]] && _retryable=1
+        if [[ "$_emitted" -eq 0 && "$_retryable" -eq 1 \
+            && "$_attempt" -lt "$_max_attempts" ]]; then
             echo "llm: transient API failure (attempt $_attempt/$_max_attempts): ${_retry_msg:-${_ce:-exit $_rc}} — retrying" >&2
             sleep $(( LLM_RETRY_BACKOFF * _attempt ))
             continue
@@ -1443,7 +1747,11 @@ else
         # Nothing has been emitted yet on this path, so retrying is safe.
         if [[ "$http_code" != "000" && "$http_code" -lt 400 ]]; then
             if grep -q '[^[:space:]]' "$local_resp"; then
-                embedded_err=$("check_response_${LLM_PROVIDER}" < "$local_resp")
+                if [[ "$LLM_API_FORMAT" == responses ]]; then
+                    embedded_err=$(check_response_responses < "$local_resp")
+                else
+                    embedded_err=$("check_response_${LLM_PROVIDER}" < "$local_resp")
+                fi
             else
                 # A whitespace-only 200 is keep-alive padding from a provider
                 # that died mid-generation. The embedded-error checkers
@@ -1452,12 +1760,16 @@ else
                 embedded_err="whitespace-only response body"
             fi
             if [[ -n "$embedded_err" ]]; then
-                rm -f "$local_resp"
                 if [[ "$_attempt" -lt "$_max_attempts" ]]; then
+                    rm -f "$local_resp"
                     echo "llm: transient API failure (attempt $_attempt/$_max_attempts): $embedded_err — retrying" >&2
                     sleep $(( LLM_RETRY_BACKOFF * _attempt ))
                     continue
                 fi
+                if [[ "$LLM_API_FORMAT" == responses ]]; then
+                    printf '%s' "$(cat "$local_resp")" | write_response_file
+                fi
+                rm -f "$local_resp"
                 die "API error: $embedded_err"
             fi
         fi
@@ -1466,6 +1778,16 @@ else
 
     if [[ "$http_code" -ge 400 || "$http_code" == "000" ]]; then
         error_msg=$(jq -r '.error.message // .message // empty' "$local_resp" 2>/dev/null || true)
+        if [[ "$LLM_API_FORMAT" == responses ]]; then
+            if [[ -s "$local_resp" ]] && jq -e . "$local_resp" >/dev/null 2>&1; then
+                write_response_file < "$local_resp"
+            else
+                jq -nc --arg message "${error_msg:-HTTP $http_code}" \
+                    --arg code "$http_code" \
+                    '{error:{message:$message,http_code:$code}}' \
+                    | write_response_file
+            fi
+        fi
         rm -f "$local_resp"
         _llm_note error "$http_code" "${error_msg:-HTTP $http_code}"
         if [[ -n "$error_msg" ]]; then
@@ -1475,16 +1797,28 @@ else
     fi
     _llm_note ok
 
-    if [[ -n "$("check_truncated_${LLM_PROVIDER}" < "$local_resp")" ]]; then
+    if [[ "$LLM_API_FORMAT" == responses ]]; then
+        write_response_file < "$local_resp"
+        if [[ -n "$(check_truncated_responses < "$local_resp")" ]]; then
+            warn_truncated
+        else
+            _incomplete_reason=$(check_incomplete_responses < "$local_resp")
+            warn_incomplete_response "$_incomplete_reason"
+        fi
+    elif [[ -n "$("check_truncated_${LLM_PROVIDER}" < "$local_resp")" ]]; then
         warn_truncated
     fi
 
-    case "$LLM_PROVIDER" in
-        # opencode (Zen) speaks the Anthropic wire protocol, usage shape included.
-        anthropic|opencode) _u=$(jq -r '[(.usage.input_tokens // ""), (.usage.output_tokens // ""), "", (.usage.cache_read_input_tokens // "")] | @tsv' "$local_resp" 2>/dev/null) || _u="" ;;
-        gemini)    _u=$(jq -r '[(.usageMetadata.promptTokenCount // ""), (.usageMetadata.candidatesTokenCount // ""), (.usageMetadata.thoughtsTokenCount // ""), (.usageMetadata.cachedContentTokenCount // "")] | @tsv' "$local_resp" 2>/dev/null) || _u="" ;;
-        *)         _u=$(jq -r '[(.usage.prompt_tokens // ""), (.usage.completion_tokens // ""), (.usage.completion_tokens_details.reasoning_tokens // ""), (.usage.prompt_tokens_details.cached_tokens // "")] | @tsv' "$local_resp" 2>/dev/null) || _u="" ;;
-    esac
+    if [[ "$LLM_API_FORMAT" == responses ]]; then
+        _u=$(jq -r '[(.usage.input_tokens // ""), (.usage.output_tokens // ""), (.usage.output_tokens_details.reasoning_tokens // ""), (.usage.input_tokens_details.cached_tokens // "")] | @tsv' "$local_resp" 2>/dev/null) || _u=""
+    else
+        case "$LLM_PROVIDER" in
+            # opencode (Zen) speaks the Anthropic wire protocol, usage shape included.
+            anthropic|opencode) _u=$(jq -r '[(.usage.input_tokens // ""), (.usage.output_tokens // ""), "", (.usage.cache_read_input_tokens // "")] | @tsv' "$local_resp" 2>/dev/null) || _u="" ;;
+            gemini)    _u=$(jq -r '[(.usageMetadata.promptTokenCount // ""), (.usageMetadata.candidatesTokenCount // ""), (.usageMetadata.thoughtsTokenCount // ""), (.usageMetadata.cachedContentTokenCount // "")] | @tsv' "$local_resp" 2>/dev/null) || _u="" ;;
+            *)         _u=$(jq -r '[(.usage.prompt_tokens // ""), (.usage.completion_tokens // ""), (.usage.completion_tokens_details.reasoning_tokens // ""), (.usage.prompt_tokens_details.cached_tokens // "")] | @tsv' "$local_resp" 2>/dev/null) || _u="" ;;
+        esac
+    fi
     if [[ -n "$_u" ]]; then
         IFS=$'\t' read -r _u_in _u_out _u_think _u_cache <<<"$_u"
         write_usage "$_u_in" "$_u_out" "$_u_think" "$_u_cache"
@@ -1493,6 +1827,9 @@ else
 
     if [[ "$LLM_RAW" -eq 1 ]]; then
         cat "$local_resp"
+    elif [[ "$LLM_API_FORMAT" == responses ]]; then
+        extract_reasoning_responses < "$local_resp" >&2
+        extract_text_responses < "$local_resp"
     else
         "extract_text_${LLM_PROVIDER}" < "$local_resp"
     fi

--- a/bin/llm
+++ b/bin/llm
@@ -496,6 +496,9 @@ case "$LLM_API_FORMAT" in
             if [[ "$(jq -r '.background // false' "$LLM_RESPONSES_BODY_FILE")" == true ]]; then
                 die "background responses require lifecycle operations; use foreground Responses completion for now"
             fi
+            if jq -e 'has("conversation")' "$LLM_RESPONSES_BODY_FILE" >/dev/null 2>&1; then
+                die "conversation state cannot be combined with llm's previous_response_id continuation; omit conversation"
+            fi
         fi
         ;;
     *) die "Unknown LLM_API_FORMAT '$LLM_API_FORMAT' (expected chat or responses)" ;;
@@ -813,6 +816,10 @@ build_payload_responses() {
           else .previous_response_id = $previous end
         | if $effort == "" then .
           else .reasoning = ((.reasoning // {}) + {effort: $effort, summary: "auto"}) end
+        | .include = ((.include // [])
+            | if index("reasoning.encrypted_content") == null
+              then . + ["reasoning.encrypted_content"]
+              else . end)
     '
 }
 
@@ -1214,7 +1221,14 @@ _die_if_no_stream_data() {
         if printf '%s' "$_err_buf" | jq -e . >/dev/null 2>&1; then
             printf '%s' "$_err_buf" | write_response_file
             if printf '%s' "$_err_buf" | jq -e '
-                [(.error.param? // ""), (.error.code? // ""), (.error.message? // "")]
+                [
+                    (.error.param? // ""),
+                    (.error.code? // ""),
+                    (.error.message? // ""),
+                    (.param? // ""),
+                    (.code? // ""),
+                    (.message? // "")
+                ]
                 | map(tostring | ascii_downcase) | join(" ")
                 | test("previous[ _]response[ _]id|previous response")
             ' >/dev/null 2>&1; then
@@ -1225,7 +1239,7 @@ _die_if_no_stream_data() {
                 | write_response_file
         fi
     fi
-    _err=$(printf '%s' "$_err_buf" | jq -r '.error.message // empty' 2>/dev/null || true)
+    _err=$(printf '%s' "$_err_buf" | jq -r '.error.message // .message // empty' 2>/dev/null || true)
     if [[ "$_continuation_error" -eq 1 ]]; then
         die "API error: ${_err:-previous_response_id was rejected}"
     fi
@@ -1434,7 +1448,14 @@ stream_responses() {
                     if [[ -e "$LLM_DATA_MARKER" ]]; then
                         die "API stream error: $_error_msg"
                     elif printf '%s' "$json" | jq -e '
-                        [(.error.param? // ""), (.error.code? // ""), (.error.message? // "")]
+                        [
+                            (.error.param? // ""),
+                            (.error.code? // ""),
+                            (.error.message? // ""),
+                            (.param? // ""),
+                            (.code? // ""),
+                            (.message? // "")
+                        ]
                         | map(tostring | ascii_downcase) | join(" ")
                         | test("previous[ _]response[ _]id|previous response")
                     ' >/dev/null 2>&1; then
@@ -1760,6 +1781,12 @@ else
                 embedded_err="whitespace-only response body"
             fi
             if [[ -n "$embedded_err" ]]; then
+                if [[ "$LLM_API_FORMAT" == responses ]] \
+                    && jq -e '.status == "failed"' "$local_resp" >/dev/null 2>&1; then
+                    write_response_file < "$local_resp"
+                    rm -f "$local_resp"
+                    die "API error: $embedded_err"
+                fi
                 if [[ "$_attempt" -lt "$_max_attempts" ]]; then
                     rm -f "$local_resp"
                     echo "llm: transient API failure (attempt $_attempt/$_max_attempts): $embedded_err — retrying" >&2

--- a/bin/llm
+++ b/bin/llm
@@ -1212,6 +1212,13 @@ _llm_ledger_append() {
 # Streaming handlers
 # ---------------------------------------------------------------------------
 
+# True when a Responses error names previous_response_id (expiry, ZDR, etc.).
+_responses_prev_id_error() {
+    jq -e '[.error.param?,.error.code?,.error.message?,.param?,.code?,.message?,.detail?]
+           | map(select(. != null) | tostring | ascii_downcase) | join(" ")
+           | test("previous[ _]response[ _]id|previous response")' >/dev/null 2>&1
+}
+
 # Shared stream tail: if no SSE data arrived, the buffered lines are an API
 # error body. Reads the caller's _saw_data/_err_buf via dynamic scoping.
 _die_if_no_stream_data() {
@@ -1220,20 +1227,7 @@ _die_if_no_stream_data() {
     if [[ "$LLM_API_FORMAT" == responses && -n "$LLM_RESPONSE_FILE" ]]; then
         if printf '%s' "$_err_buf" | jq -e . >/dev/null 2>&1; then
             printf '%s' "$_err_buf" | write_response_file
-            if printf '%s' "$_err_buf" | jq -e '
-                [
-                    (.error.param? // ""),
-                    (.error.code? // ""),
-                    (.error.message? // ""),
-                    (.param? // ""),
-                    (.code? // ""),
-                    (.message? // "")
-                ]
-                | map(tostring | ascii_downcase) | join(" ")
-                | test("previous[ _]response[ _]id|previous response")
-            ' >/dev/null 2>&1; then
-                _continuation_error=1
-            fi
+            printf '%s' "$_err_buf" | _responses_prev_id_error && _continuation_error=1
         else
             jq -nc --arg message "$_err_buf" '{error:{message:$message}}' \
                 | write_response_file
@@ -1445,20 +1439,7 @@ stream_responses() {
                     printf '%s' "$json" | write_response_file
                     local _error_msg=""
                     _error_msg=$(printf '%s' "$json" | jq -r '.error.message // .message // "unknown error"' 2>/dev/null) || _error_msg="unknown error"
-                    if [[ -e "$LLM_DATA_MARKER" ]]; then
-                        die "API stream error: $_error_msg"
-                    elif printf '%s' "$json" | jq -e '
-                        [
-                            (.error.param? // ""),
-                            (.error.code? // ""),
-                            (.error.message? // ""),
-                            (.param? // ""),
-                            (.code? // ""),
-                            (.message? // "")
-                        ]
-                        | map(tostring | ascii_downcase) | join(" ")
-                        | test("previous[ _]response[ _]id|previous response")
-                    ' >/dev/null 2>&1; then
+                    if [[ -e "$LLM_DATA_MARKER" ]] || printf '%s' "$json" | _responses_prev_id_error; then
                         die "API stream error: $_error_msg"
                     else
                         die_retryable "API stream error: $_error_msg"

--- a/bin/recap
+++ b/bin/recap
@@ -330,12 +330,12 @@ _summarize_window() {
     jq -n -c \
         --argjson idx "$idx" \
         --argjson body "$body" \
-        --argjson start "$first_line" --argjson end "$last_line" \
+        --argjson start "$first_line" --argjson stop "$last_line" \
         --arg fs "$first_step" --arg ls "$last_step" \
         --arg fts "$first_ts" --arg lts "$last_ts" \
         --argjson n "$n" --argjson partial "$partial" \
         --arg model "$MAP_MODEL" --arg created "$(date +%Y-%m-%dT%H:%M:%S)" '
-        {idx: $idx, raw_start_line: $start, raw_end_line: $end,
+        {idx: $idx, raw_start_line: $start, raw_end_line: $stop,
          first_step: $fs, last_step: $ls, first_ts: $fts, last_ts: $lts,
          n_steps: $n, partial: $partial, model: $model, created: $created}
         + {title: ($body.title // "untitled"),
@@ -565,10 +565,10 @@ _ctx_seal_tier1() {
     note "rollup t1 [$s,$e)"
     body=$(_llm_json "$MAP_MODEL" "$_ROLLUP_SYSTEM" "$text" 1024) || die "rollup t1 [$s,$e): bad JSON"
     mkdir -p "$(dirname "$file")"
-    jq -n -c --argjson tier 1 --argjson start "$s" --argjson end "$e" --argjson n "$((e - s))" \
+    jq -n -c --argjson tier 1 --argjson start "$s" --argjson stop "$e" --argjson n "$((e - s))" \
         --argjson body "$body" --arg fid "$fid" --arg lid "$lid" \
         --arg model "$MAP_MODEL" --argjson pv "$ROLLUP_PROMPT_VERSION" --arg created "$(date +%Y-%m-%dT%H:%M:%S)" '
-        {tier:$tier, start:$start, end:$end, n:$n,
+        {tier:$tier, start:$start, end:$stop, n:$n,
          summary:($body.summary // ""), themes:($body.themes // []),
          step_ids:(($body.step_ids // []) | if length==0 then [$fid,$lid] else . end),
          model:$model, prompt_version:$pv, created:$created}' > "$file"
@@ -595,10 +595,10 @@ _ctx_seal_tierk() {
     # once the payload outgrows the pipe buffer (large --fanout).
     fb_json=$(printf '%s' "$fallback" | awk 'NF && ++c <= 4' | jq -R . | jq -sc .)
     mkdir -p "$(dirname "$file")"
-    jq -n -c --argjson tier "$tier" --argjson start "$s" --argjson end "$e" --argjson n "$((e - s))" \
+    jq -n -c --argjson tier "$tier" --argjson start "$s" --argjson stop "$e" --argjson n "$((e - s))" \
         --argjson body "$body" --argjson fb "$fb_json" \
         --arg model "$MAP_MODEL" --argjson pv "$ROLLUP_PROMPT_VERSION" --arg created "$(date +%Y-%m-%dT%H:%M:%S)" '
-        {tier:$tier, start:$start, end:$end, n:$n,
+        {tier:$tier, start:$start, end:$stop, n:$n,
          summary:($body.summary // ""), themes:($body.themes // []),
          step_ids:(($body.step_ids // []) | if length==0 then $fb else . end),
          model:$model, prompt_version:$pv, created:$created}' > "$file"

--- a/bin/responses
+++ b/bin/responses
@@ -361,21 +361,41 @@ run_list() {
     emit "$merged"
 }
 
+# One object-returning request owns provider setup, query includes, transport,
+# and output. Command-specific validation/body construction precedes this call.
+request_object() {
+    resolve_provider; net_args
+    QUERY=""
+    qadd_includes
+    do_request "$@"
+    emit "$RESP_FILE"
+}
+
+# Stored-resource operations share the same id validation and URL shape.
+# Build the path only after want_pos succeeds, including under bash set -u.
+request_ids() {  # allowed-options count what method collection [suffix]
+    allow_opts "$1"
+    want_pos "$2" "$3"
+    local path="$5/${POS[0]}${6:-}"
+    [[ "$2" -ne 2 ]] || path="$path/${POS[1]}"
+    request_object "$4" "$path"
+}
+
 # --- streaming get ----------------------------------------------------------
 
-# The SSE resume channel for a background response: every data payload becomes
-# one JSON line, and only a terminal event makes this a success. Anything the
-# server sent that was not an SSE data line is kept so an HTTP error body can
-# still be reported as the reason.
+# The SSE resume channel returns typed JSON events for the requested response.
+# A terminal tag succeeds only with that response's matching terminal status.
+# Keep non-data lines separately so an HTTP error body can explain a refusal.
 stream_get() {
-    local url="$BASE$1" line payload etype terminal=0 other msg rc=0
+    local url="$BASE$1" wanted="$2" line payload etype terminal=0 other msg rc=0
     [[ -n "$QUERY" ]] && url="$url?$QUERY"
     other=$(mktmp)
     mkfifo "$_tmp_dir/stream"
     curl --globoff -sS -N ${NET[@]+"${NET[@]}"} "${HEADERS[@]}" "$url" \
         > "$_tmp_dir/stream" 2>/dev/null &
     _curl_pid=$!
-    while IFS= read -r line; do
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
         case "$line" in
             data:*) ;;
             *) printf '%s\n' "$line" >> "$other"; continue ;;
@@ -383,12 +403,23 @@ stream_get() {
         payload="${line#data:}"
         payload="${payload# }"
         [[ -z "$payload" || "$payload" == "[DONE]" ]] && continue
-        etype=$(printf '%s' "$payload" | jq -r '.type // empty' 2>/dev/null) || etype=""
-        printf '%s' "$payload" | jq -c . 2>/dev/null || printf '%s\n' "$payload"
+        payload=$(printf '%s' "$payload" | jq -cs --arg wanted "$wanted" '
+            if length != 1 then error("event cardinality") else .[0] end
+            | if type != "object" then error("event object")
+              elif (.type | type) != "string" or .type == "" then error("event type")
+              elif has("response") and (.response | type) != "object" then error("response object")
+              elif has("response") and .response.id != $wanted then error("response identity")
+              elif has("response_id") and .response_id != $wanted then error("response identity")
+              else . end' 2>/dev/null) || die "invalid or foreign response stream event"
+        etype=$(printf '%s' "$payload" | jq -r '.type')
         case "$etype" in
             response.completed|response.incomplete|response.failed|response.cancelled)
+                printf '%s' "$payload" | jq -e --arg wanted "$wanted" --arg status "${etype#response.}" \
+                    '.response.id == $wanted and .response.status == $status' >/dev/null 2>&1 \
+                    || die "terminal response identity or status does not match"
                 terminal=1 ;;
         esac
+        printf '%s\n' "$payload"
     done < "$_tmp_dir/stream"
     wait "$_curl_pid" || rc=$?
     _curl_pid=""
@@ -405,27 +436,21 @@ stream_get() {
 # These validators run in the caller's shell rather than returning their input
 # through a command substitution, so a usage_error inside one really does end
 # the process with exit 2 instead of only ending a subshell.
-require_json_array() {  # require_json_array <file> <what>
-    [[ -f "$1" ]] || usage_error "$2: no such file: $1"
-    jq -e 'type == "array"' < "$1" >/dev/null 2>&1 \
-        || usage_error "$2 must hold a JSON array: $1"
-}
-
-require_json_object_file() {  # require_json_object_file <file> <what>
-    [[ -f "$1" ]] || usage_error "$2: no such file: $1"
-    jq -e 'type == "object"' < "$1" >/dev/null 2>&1 \
-        || usage_error "$2 must hold a JSON object: $1"
+require_json_file() {  # file kind what
+    [[ -f "$1" ]] || usage_error "$3: no such file: $1"
+    jq -es --arg kind "$2" 'length == 1 and (.[0] | type == $kind)' < "$1" >/dev/null 2>&1 \
+        || usage_error "$3 must hold a JSON $2: $1"
 }
 
 require_json_object() {  # require_json_object <json> <what>
-    printf '%s' "$1" | jq -e 'type == "object"' >/dev/null 2>&1 \
+    printf '%s' "$1" | jq -es 'length == 1 and (.[0] | type == "object")' >/dev/null 2>&1 \
         || usage_error "$2 must be a JSON object"
 }
 
 # Sets BODY to {"items": [...]}. The API takes 20 items at a time, so a longer
 # file is a usage error here rather than a rejected request.
 build_items_body() {  # build_items_body <file>
-    require_json_array "$1" "--items-file"
+    require_json_file "$1" array "--items-file"
     local count
     count=$(jq 'length' < "$1")
     [[ "$count" -le 20 ]] \
@@ -458,7 +483,7 @@ case "$COMMAND" in
             qadd stream true
             [[ -n "$OPT_STARTING_AFTER" ]] && qadd starting_after "$OPT_STARTING_AFTER"
             qadd_includes
-            stream_get "/responses/${POS[0]}"
+            stream_get "/responses/${POS[0]}" "${POS[0]}"
         else
             [[ -n "$OPT_STARTING_AFTER" ]] && usage_error "--starting-after only means something with --stream"
             qadd_includes
@@ -467,18 +492,10 @@ case "$COMMAND" in
         fi
         ;;
     cancel)
-        allow_opts ""
-        want_pos 1 "one response id"
-        resolve_provider; net_args
-        do_request POST "/responses/${POS[0]}/cancel"
-        emit "$RESP_FILE"
+        request_ids "" 1 "one response id" POST /responses /cancel
         ;;
     delete)
-        allow_opts ""
-        want_pos 1 "one response id"
-        resolve_provider; net_args
-        do_request DELETE "/responses/${POS[0]}"
-        emit "$RESP_FILE"
+        request_ids "" 1 "one response id" DELETE /responses
         ;;
     input-items)
         allow_opts "--after --limit --order --include --all"
@@ -496,13 +513,13 @@ case "$COMMAND" in
             && usage_error "compact takes --input-file or --previous-response-id, not both"
         _base_body='{}'
         if [[ -n "$OPT_BODY_FILE" ]]; then
-            require_json_object_file "$OPT_BODY_FILE" "--body-file"
+            require_json_file "$OPT_BODY_FILE" object "--body-file"
             _base_body=$(cat "$OPT_BODY_FILE")
         fi
         _filter='$body + {model: $model}'
         _jq_args=(--argjson body "$_base_body" --arg model "$OPT_MODEL")
         if [[ -n "$OPT_INPUT_FILE" ]]; then
-            require_json_array "$OPT_INPUT_FILE" "--input-file"
+            require_json_file "$OPT_INPUT_FILE" array "--input-file"
             _jq_args+=(--slurpfile input "$OPT_INPUT_FILE")
             _filter="$_filter + {input: \$input[0]}"
         else
@@ -550,22 +567,14 @@ case "$COMMAND" in
                 want_pos 0 "no positional arguments"
                 BODY='{}'
                 [[ -n "$OPT_ITEMS_FILE" ]] && build_items_body "$OPT_ITEMS_FILE"
-                if [[ -n "$OPT_METADATA" ]]; then
+                if [[ " $OPT_SEEN " == *" --metadata "* ]]; then
                     require_json_object "$OPT_METADATA" "--metadata"
                     BODY=$(printf '%s' "$BODY" | jq -c --argjson m "$OPT_METADATA" '. + {metadata: $m}')
                 fi
-                resolve_provider; net_args
-                QUERY=""
-                do_request POST "/conversations"
-                emit "$RESP_FILE"
+                request_object POST /conversations
                 ;;
             get)
-                allow_opts ""
-                want_pos 1 "one conversation id"
-                resolve_provider; net_args
-                QUERY=""
-                do_request GET "/conversations/${POS[0]}"
-                emit "$RESP_FILE"
+                request_ids "" 1 "one conversation id" GET /conversations
                 ;;
             update)
                 allow_opts "--metadata"
@@ -573,18 +582,10 @@ case "$COMMAND" in
                 [[ -n "$OPT_METADATA" ]] || usage_error "conversations update requires --metadata"
                 require_json_object "$OPT_METADATA" "--metadata"
                 BODY=$(jq -nc --argjson m "$OPT_METADATA" '{metadata: $m}')
-                resolve_provider; net_args
-                QUERY=""
-                do_request POST "/conversations/${POS[0]}"
-                emit "$RESP_FILE"
+                request_object POST "/conversations/${POS[0]}"
                 ;;
             delete)
-                allow_opts ""
-                want_pos 1 "one conversation id"
-                resolve_provider; net_args
-                QUERY=""
-                do_request DELETE "/conversations/${POS[0]}"
-                emit "$RESP_FILE"
+                request_ids "" 1 "one conversation id" DELETE /conversations
                 ;;
             items)
                 allow_opts "--after --limit --order --include --all"
@@ -597,26 +598,13 @@ case "$COMMAND" in
                 want_pos 1 "one conversation id"
                 [[ -n "$OPT_ITEMS_FILE" ]] || usage_error "conversations add requires --items-file"
                 build_items_body "$OPT_ITEMS_FILE"
-                resolve_provider; net_args
-                QUERY=""; qadd_includes
-                do_request POST "/conversations/${POS[0]}/items"
-                emit "$RESP_FILE"
+                request_object POST "/conversations/${POS[0]}/items"
                 ;;
             item)
-                allow_opts "--include"
-                want_pos 2 "a conversation id and an item id"
-                resolve_provider; net_args
-                QUERY=""; qadd_includes
-                do_request GET "/conversations/${POS[0]}/items/${POS[1]}"
-                emit "$RESP_FILE"
+                request_ids "--include" 2 "a conversation id and an item id" GET /conversations /items
                 ;;
             remove)
-                allow_opts ""
-                want_pos 2 "a conversation id and an item id"
-                resolve_provider; net_args
-                QUERY=""
-                do_request DELETE "/conversations/${POS[0]}/items/${POS[1]}"
-                emit "$RESP_FILE"
+                request_ids "" 2 "a conversation id and an item id" DELETE /conversations /items
                 ;;
             *)
                 usage_error "unknown conversations subcommand: $SUB"

--- a/bin/responses
+++ b/bin/responses
@@ -34,9 +34,24 @@ PRETTY=0
 CONNECT_TIMEOUT="${LLM_CONNECT_TIMEOUT:-10}"
 MAX_TIME="${LLM_MAX_TIME:-600}"
 
-_tmp_files=""
-_cleanup() { [[ -n "$_tmp_files" ]] && rm -rf $_tmp_files; return 0; }
+_tmp_dir=""
+_curl_pid=""
+_cleanup() {
+    # curl is a direct, owned child, including while streaming. Stop and reap
+    # it before removing files it may still be reading or writing.
+    if [[ -n "$_curl_pid" ]]; then
+        kill -TERM "$_curl_pid" 2>/dev/null || true
+        kill -KILL "$_curl_pid" 2>/dev/null || true
+        wait "$_curl_pid" 2>/dev/null || true
+        _curl_pid=""
+    fi
+    [[ -z "$_tmp_dir" ]] || rm -rf -- "$_tmp_dir"
+    return 0
+}
 trap _cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 die() { printf 'responses: error: %s\n' "$*" >&2; exit 1; }
 usage_error() {
@@ -44,11 +59,15 @@ usage_error() {
     printf "Try 'responses --help'.\n" >&2
     exit 2
 }
+init_tmp() {
+    [[ -z "$_tmp_dir" ]] || return 0
+    umask 077
+    _tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/responses.XXXXXX") \
+        || die "cannot create a temporary directory"
+}
 mktmp() {
-    local f
-    f=$(mktemp "${TMPDIR:-/tmp}/responses.XXXXXX") || die "cannot create a temporary file"
-    _tmp_files="$_tmp_files $f"
-    printf '%s' "$f"
+    # Allocation may run in a subshell; ownership stays with the parent dir.
+    mktemp "$_tmp_dir/file.XXXXXX" || die "cannot create a temporary file"
 }
 
 usage() {
@@ -147,7 +166,13 @@ shift_pos() {
 
 want_pos() {  # want_pos <count> <what>
     [[ "${#POS[@]}" -eq "$1" ]] || usage_error "$COMMAND takes $2"
+    local id
+    for id in ${POS[@]+"${POS[@]}"}; do
+        valid_id "$id" || usage_error "ids must contain only letters, digits, underscores, or hyphens"
+    done
 }
+
+valid_id() { [[ "$1" =~ ^[A-Za-z0-9_-]+$ ]]; }
 
 # ---------------------------------------------------------------------------
 # Provider, base URL, auth
@@ -186,6 +211,7 @@ add_auth_header() {
 BASE=""
 HEADERS=()
 resolve_provider() {
+    init_tmp
     [[ -n "$PROVIDER" ]] || PROVIDER="openai"
     HEADERS=(-H "Content-Type: application/json")
     case "$PROVIDER" in
@@ -251,18 +277,26 @@ BODY=""
 # do_request <method> <path>. Reads QUERY and BODY, leaves the reply in
 # $RESP_FILE, and dies on a non-2xx with the API's own message.
 RESP_FILE=""
+REQUEST_MAX_BYTES=0
 do_request() {
-    local method="$1" url="$BASE$2" code body_file=""
+    local method="$1" url="$BASE$2" code code_file body_file="" rc=0
     [[ -n "$QUERY" ]] && url="$url?$QUERY"
     RESP_FILE=$(mktmp)
-    local args=(-sS -o "$RESP_FILE" -w '%{http_code}')
+    code_file=$(mktmp)
+    local args=(--globoff -sS -o "$RESP_FILE" -w '%{http_code}')
     args+=(${NET[@]+"${NET[@]}"} "${HEADERS[@]}" -X "$method")
+    [[ "$REQUEST_MAX_BYTES" -eq 0 ]] || args+=(--max-filesize "$REQUEST_MAX_BYTES")
     if [[ -n "$BODY" ]]; then
         body_file=$(mktmp)
         printf '%s' "$BODY" > "$body_file"
         args+=(-d @"$body_file")
     fi
-    code=$(curl "${args[@]}" "$url" 2>/dev/null) || code="000"
+    curl "${args[@]}" "$url" > "$code_file" 2>/dev/null &
+    _curl_pid=$!
+    wait "$_curl_pid" || rc=$?
+    _curl_pid=""
+    code=$(cat "$code_file")
+    [[ "$rc" -eq 0 ]] || code="000"
     [[ "$code" =~ ^2[0-9][0-9]$ ]] && return 0
     local msg=""
     msg=$(jq -r '(.error.message // .message // empty)' < "$RESP_FILE" 2>/dev/null) || msg=""
@@ -280,8 +314,11 @@ emit() {
 # the ids bracket the whole set.
 run_list() {
     local path="$1" after="$OPT_AFTER" n=0 has_more last pages merged
-    pages=$(mktemp -d "${TMPDIR:-/tmp}/responses-pages.XXXXXX") || die "cannot create a temporary directory"
-    _tmp_files="$_tmp_files $pages"
+    local seen="|$OPT_AFTER|" bytes=0 size
+    pages="$_tmp_dir/pages"
+    mkdir "$pages"
+    # Bound both each transfer and the aggregate before slurping it into jq.
+    REQUEST_MAX_BYTES=67108864
     while :; do
         n=$(( n + 1 ))
         QUERY=""
@@ -291,14 +328,30 @@ run_list() {
         qadd_includes
         do_request GET "$path"
         if [[ "$OPT_ALL" -ne 1 ]]; then emit "$RESP_FILE"; return 0; fi
+        size=$(wc -c < "$RESP_FILE")
+        bytes=$((bytes + size))
+        [[ "$bytes" -le "$REQUEST_MAX_BYTES" ]] || die "paginated reply exceeds 64 MiB; list is incomplete"
+        jq -se 'length == 1 and (.[0] |
+            type == "object" and (.data | type == "array") and
+            (.has_more | type == "boolean") and
+            all(.data[]; type == "object" and (.id | type == "string") and
+                (.id | test("^[A-Za-z0-9_-]+$"))) and
+            ((has("last_id") | not) or .last_id == (.data[-1].id // null)))' \
+            < "$RESP_FILE" >/dev/null 2>&1 || die "malformed list page $n; list is incomplete"
         cp "$RESP_FILE" "$pages/$(printf '%05d' "$n").json"
-        has_more=$(jq -r '.has_more // false' < "$RESP_FILE" 2>/dev/null) || has_more="false"
-        last=$(jq -r '(.data // []) | if length > 0 then (.[-1].id // "") else "" end' < "$RESP_FILE" 2>/dev/null) || last=""
-        [[ "$has_more" == "true" && -n "$last" && "$last" != "$after" && "$n" -lt 500 ]] || break
+        has_more=$(jq -r '.has_more' < "$RESP_FILE")
+        [[ "$has_more" == "true" ]] || break
+        last=$(jq -r '.data[-1].id // empty' < "$RESP_FILE")
+        [[ -n "$last" ]] || die "empty continuing page $n; list is incomplete"
+        case "$seen" in *"|$last|"*) die "pagination cursor did not progress (page $n); list is incomplete" ;; esac
+        [[ "$n" -lt 500 ]] || die "pagination reached the 500-page limit; list is incomplete"
+        seen="$seen$last|"
         after="$last"
     done
     merged=$(mktmp)
-    jq -s '(map((.data // [])[])) as $d
+    jq -s '(map(.data[])) as $d
+           | if ($d | map(.id) | unique | length) != ($d | length)
+             then error("duplicate item ids; list is incomplete") else . end
            | {object: (.[0].object // "list"),
               data: $d,
               first_id: (if ($d | length) > 0 then $d[0].id else null end),
@@ -315,9 +368,13 @@ run_list() {
 # server sent that was not an SSE data line is kept so an HTTP error body can
 # still be reported as the reason.
 stream_get() {
-    local url="$BASE$1" line payload etype terminal=0 other msg
+    local url="$BASE$1" line payload etype terminal=0 other msg rc=0
     [[ -n "$QUERY" ]] && url="$url?$QUERY"
     other=$(mktmp)
+    mkfifo "$_tmp_dir/stream"
+    curl --globoff -sS -N ${NET[@]+"${NET[@]}"} "${HEADERS[@]}" "$url" \
+        > "$_tmp_dir/stream" 2>/dev/null &
+    _curl_pid=$!
     while IFS= read -r line; do
         case "$line" in
             data:*) ;;
@@ -332,8 +389,10 @@ stream_get() {
             response.completed|response.incomplete|response.failed|response.cancelled)
                 terminal=1 ;;
         esac
-    done < <(curl -sS -N ${NET[@]+"${NET[@]}"} "${HEADERS[@]}" "$url" 2>/dev/null)
-    [[ "$terminal" -eq 1 ]] && return 0
+    done < "$_tmp_dir/stream"
+    wait "$_curl_pid" || rc=$?
+    _curl_pid=""
+    [[ "$terminal" -eq 1 && "$rc" -eq 0 ]] && return 0
     msg=$(jq -r '(.error.message // .message // empty)' < "$other" 2>/dev/null) || msg=""
     [[ -n "$msg" ]] || msg="the stream ended without a terminal response event"
     die "$msg"
@@ -380,6 +439,11 @@ build_items_body() {  # build_items_body <file>
 
 parse_opts "$@"
 [[ "${#POS[@]}" -gt 0 ]] || usage_error "no command given"
+[[ -z "$OPT_AFTER" ]] || valid_id "$OPT_AFTER" || usage_error "invalid --after id"
+[[ -z "$OPT_PREV" ]] || valid_id "$OPT_PREV" || usage_error "invalid --previous-response-id"
+[[ -z "$OPT_LIMIT" || "$OPT_LIMIT" =~ ^[1-9][0-9]*$ ]] || usage_error "--limit must be a positive integer"
+[[ -z "$OPT_ORDER" || "$OPT_ORDER" == asc || "$OPT_ORDER" == desc ]] || usage_error "--order must be asc or desc"
+[[ -z "$OPT_STARTING_AFTER" || "$OPT_STARTING_AFTER" =~ ^[0-9]+$ ]] || usage_error "--starting-after must be a nonnegative integer"
 COMMAND="${POS[0]}"
 shift_pos
 NET=()
@@ -453,6 +517,26 @@ case "$COMMAND" in
         resolve_provider; net_args
         QUERY=""
         do_request POST "/responses/compact"
+        # Compaction is billable inference too. Use the completion ledger's
+        # units/schema without overwriting the parent completion usage file.
+        _ledger_home="${IDENTITY_DIR:-${HEADLONG_HOME:-${SHELLM_HOME:-$HOME/.headlong}}}"
+        _ledger="${LLM_USAGE_LEDGER:-$_ledger_home/usage/llm.jsonl}"
+        _identity="${IDENTITY_NAME:-}"
+        [[ -n "$_identity" || -z "${IDENTITY_DIR:-}" ]] || _identity=$(basename "$IDENTITY_DIR")
+        if [[ "$_ledger" != /dev/null ]] && mkdir -p "$(dirname "$_ledger")" 2>/dev/null; then
+            jq -c --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg provider "$PROVIDER" \
+                --arg model "$OPT_MODEL" --arg identity "$_identity" \
+                --arg run_id "${LLM_RUN_ID:-${SHELLM_RUN_STEP_ID:-}}" '
+                select(.usage | type == "object") | .usage as $u
+                | {ts:$ts,provider:$provider,model:$model,operation:"responses.compact"}
+                + (if ($u.input_tokens | type) == "number" then {in_tok:$u.input_tokens} else {} end)
+                + (if ($u.output_tokens | type) == "number" then {out_tok:$u.output_tokens} else {} end)
+                + (if ($u.input_tokens_details.cached_tokens | type) == "number" then {cache_tok:$u.input_tokens_details.cached_tokens} else {} end)
+                + (if ($u.output_tokens_details.reasoning_tokens | type) == "number" then {think_tok:$u.output_tokens_details.reasoning_tokens} else {} end)
+                + (if $identity == "" then {} else {identity:$identity} end)
+                + (if $run_id == "" then {} else {run_id:$run_id} end)' \
+                "$RESP_FILE" >> "$_ledger" 2>/dev/null || true
+        fi
         emit "$RESP_FILE"
         ;;
     conversations)

--- a/bin/responses
+++ b/bin/responses
@@ -1,0 +1,545 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# responses: OpenAI Responses lifecycle operations (design/responses-lifecycle.md).
+#
+# bin/llm is the completion boundary: one request, one terminal object. The
+# Responses API also has server-side state with a life of its own, so fetching,
+# cancelling, deleting, listing, compacting, and the Conversations family live
+# here instead. Stdout is the machine channel: the API object exactly as
+# returned, one JSON document per command. Errors go to stderr and exit 1;
+# usage errors exit 2.
+
+# Load .env files the way bin/llm does, layered: the cwd's .env, then the state
+# home's. Each fills in only vars that are not already set, so the real
+# environment always wins over a file.
+_res_load_env() {
+    local envfile="$1"
+    [[ -f "$envfile" ]] || return 1
+    local key val
+    while IFS= read -r key; do
+        [[ -n "$key" ]] || continue
+        [[ -n "${!key+x}" ]] && continue
+        # shellcheck disable=SC1090  # sourcing the user's own env file
+        val=$(set -a; . "$envfile" >/dev/null 2>&1; printf '%s' "${!key}") || { printf 'responses: warning: could not read %s; ignoring it\n' "$envfile" >&2; return 0; }
+        export "$key=$val"
+    done < <(sed -n 's/^[[:space:]]*\(export[[:space:]]\{1,\}\)\{0,1\}\([A-Za-z_][A-Za-z0-9_]*\)[[:space:]]*=.*/\2/p' "$envfile")
+    return 0
+}
+_res_load_env ".env" || true
+_res_load_env "${HEADLONG_HOME:-${SHELLM_HOME:-$HOME/.headlong}}/.env" || true
+
+PROVIDER="${LLM_PROVIDER:-}"
+PRETTY=0
+CONNECT_TIMEOUT="${LLM_CONNECT_TIMEOUT:-10}"
+MAX_TIME="${LLM_MAX_TIME:-600}"
+
+_tmp_files=""
+_cleanup() { [[ -n "$_tmp_files" ]] && rm -rf $_tmp_files; return 0; }
+trap _cleanup EXIT
+
+die() { printf 'responses: error: %s\n' "$*" >&2; exit 1; }
+usage_error() {
+    printf 'responses: error: %s\n' "$*" >&2
+    printf "Try 'responses --help'.\n" >&2
+    exit 2
+}
+mktmp() {
+    local f
+    f=$(mktemp "${TMPDIR:-/tmp}/responses.XXXXXX") || die "cannot create a temporary file"
+    _tmp_files="$_tmp_files $f"
+    printf '%s' "$f"
+}
+
+usage() {
+    cat <<'EOF'
+Usage: responses [--provider P] [--pretty] <command> [options]
+
+Operations on stored Responses state. Completions stay in `llm`.
+
+  responses get ID [--include V]... [--stream] [--starting-after N]
+  responses cancel ID
+  responses delete ID
+  responses input-items ID [--after ID] [--limit N] [--order asc|desc]
+                           [--include V]... [--all]
+  responses compact --model M (--input-file F | --previous-response-id ID)
+                    [--instructions S] [--body-file F]
+  responses conversations create [--items-file F] [--metadata JSON]
+  responses conversations get CID
+  responses conversations update CID --metadata JSON
+  responses conversations delete CID
+  responses conversations items CID [--after ID] [--limit N]
+                                    [--order asc|desc] [--include V]... [--all]
+  responses conversations add CID --items-file F [--include V]...
+  responses conversations item CID ITEM_ID
+  responses conversations remove CID ITEM_ID
+
+Options:
+  --provider P    openai (default), openrouter, or openai-compatible;
+                  LLM_PROVIDER is the environment spelling.
+  --pretty        Indent the JSON on stdout.
+
+Environment: OPENAI_API_KEY / OPENROUTER_API_KEY / LLM_API_KEY, LLM_API_URL
+(its /responses or /chat/completions suffix is stripped to find the API base),
+LLM_CONNECT_TIMEOUT, LLM_MAX_TIME.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+
+POS=()
+INCLUDES=()
+OPT_SEEN=""
+OPT_AFTER=""; OPT_LIMIT=""; OPT_ORDER=""; OPT_ALL=0
+OPT_STREAM=0; OPT_STARTING_AFTER=""
+OPT_MODEL=""; OPT_INPUT_FILE=""; OPT_PREV=""; OPT_INSTRUCTIONS=""
+OPT_BODY_FILE=""; OPT_ITEMS_FILE=""; OPT_METADATA=""
+
+_need_value() { [[ "$2" -ge 2 ]] || usage_error "$1 requires a value"; }
+_seen() { OPT_SEEN="$OPT_SEEN $1"; }
+
+parse_opts() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --provider)  _need_value "$1" $#; PROVIDER="$2"; shift 2 ;;
+            --pretty)    PRETTY=1; shift ;;
+            -h|--help)   usage; exit 0 ;;
+            --include)   _need_value "$1" $#; _seen "$1"; INCLUDES+=("$2"); shift 2 ;;
+            --after)     _need_value "$1" $#; _seen "$1"; OPT_AFTER="$2"; shift 2 ;;
+            --limit)     _need_value "$1" $#; _seen "$1"; OPT_LIMIT="$2"; shift 2 ;;
+            --order)     _need_value "$1" $#; _seen "$1"; OPT_ORDER="$2"; shift 2 ;;
+            --all)       _seen "$1"; OPT_ALL=1; shift ;;
+            --stream)    _seen "$1"; OPT_STREAM=1; shift ;;
+            --starting-after) _need_value "$1" $#; _seen "$1"; OPT_STARTING_AFTER="$2"; shift 2 ;;
+            --model)     _need_value "$1" $#; _seen "$1"; OPT_MODEL="$2"; shift 2 ;;
+            --input-file) _need_value "$1" $#; _seen "$1"; OPT_INPUT_FILE="$2"; shift 2 ;;
+            --previous-response-id) _need_value "$1" $#; _seen "$1"; OPT_PREV="$2"; shift 2 ;;
+            --instructions) _need_value "$1" $#; _seen "$1"; OPT_INSTRUCTIONS="$2"; shift 2 ;;
+            --body-file) _need_value "$1" $#; _seen "$1"; OPT_BODY_FILE="$2"; shift 2 ;;
+            --items-file) _need_value "$1" $#; _seen "$1"; OPT_ITEMS_FILE="$2"; shift 2 ;;
+            --metadata)  _need_value "$1" $#; _seen "$1"; OPT_METADATA="$2"; shift 2 ;;
+            --)          shift; while [[ $# -gt 0 ]]; do POS+=("$1"); shift; done ;;
+            -*)          usage_error "unknown option: $1" ;;
+            *)           POS+=("$1"); shift ;;
+        esac
+    done
+}
+
+# Each command declares the options it understands, so a flag that belongs to
+# another subcommand is a usage error instead of a silent no-op.
+allow_opts() {
+    local seen
+    for seen in $OPT_SEEN; do
+        case " $1 " in
+            *" $seen "*) ;;
+            *) usage_error "$COMMAND does not take $seen" ;;
+        esac
+    done
+}
+
+# Drop the leading positional (the command name) without tripping over an
+# empty array under set -u in bash 3.2.
+shift_pos() {
+    if [[ "${#POS[@]}" -gt 1 ]]; then POS=("${POS[@]:1}"); else POS=(); fi
+}
+
+want_pos() {  # want_pos <count> <what>
+    [[ "${#POS[@]}" -eq "$1" ]] || usage_error "$COMMAND takes $2"
+}
+
+# ---------------------------------------------------------------------------
+# Provider, base URL, auth
+# ---------------------------------------------------------------------------
+
+# LLM_API_URL names a completion endpoint; the lifecycle paths hang off the
+# same API base, so drop the completion suffix and keep the rest.
+api_base_from_url() {
+    local u="$1"
+    u="${u%/}"
+    case "$u" in
+        */responses) u="${u%/responses}" ;;
+        */chat/completions) u="${u%/chat/completions}" ;;
+    esac
+    printf '%s' "${u%/}"
+}
+
+# Secret headers reach curl through a 0600 config file (-K), never argv, which
+# is readable by every same-host process. This is bin/llm's add_auth_header,
+# escaping included: curl config values are double quoted, so every character
+# curl treats specially inside those quotes has to be escaped or an unusual key
+# could add a second config option.
+add_auth_header() {
+    local h="$1" f
+    h="${h//\\/\\\\}"
+    h="${h//\"/\\\"}"
+    h="${h//$'\t'/\\t}"
+    h="${h//$'\n'/\\n}"
+    h="${h//$'\r'/\\r}"
+    h="${h//$'\v'/\\v}"
+    f=$(mktmp)
+    ( umask 077; printf 'header = "%s"\n' "$h" > "$f" )
+    HEADERS+=(-K "$f")
+}
+
+BASE=""
+HEADERS=()
+resolve_provider() {
+    [[ -n "$PROVIDER" ]] || PROVIDER="openai"
+    HEADERS=(-H "Content-Type: application/json")
+    case "$PROVIDER" in
+        openai)
+            [[ -n "${OPENAI_API_KEY:-}" ]] || die "OPENAI_API_KEY is not set"
+            BASE=$(api_base_from_url "${LLM_API_URL:-https://api.openai.com/v1}")
+            add_auth_header "Authorization: Bearer $OPENAI_API_KEY"
+            ;;
+        openrouter)
+            [[ -n "${OPENROUTER_API_KEY:-}" ]] || die "OPENROUTER_API_KEY is not set"
+            BASE=$(api_base_from_url "${LLM_API_URL:-https://openrouter.ai/api/v1}")
+            add_auth_header "Authorization: Bearer $OPENROUTER_API_KEY"
+            ;;
+        openai-compatible)
+            local u="${LLM_API_URL:-${SHELLM_API_URL:-}}"
+            [[ -n "$u" ]] || die "LLM_API_URL is not set (openai-compatible has no default endpoint)"
+            BASE=$(api_base_from_url "$u")
+            if [[ -n "${LLM_API_KEY:-}" ]]; then
+                add_auth_header "Authorization: Bearer $LLM_API_KEY"
+            fi
+            ;;
+        *)
+            usage_error "provider $PROVIDER has no Responses lifecycle API (use openai, openrouter, or openai-compatible)"
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+urlencode() {
+    local s="$1" out="" c i
+    for (( i = 0; i < ${#s}; i++ )); do
+        c="${s:i:1}"
+        case "$c" in
+            [A-Za-z0-9._~-]) out="$out$c" ;;
+            *) out="$out$(printf '%%%02X' "'$c")" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
+QUERY=""
+# The key is a literal we control (include[] keeps its brackets, which is how
+# the OpenAI SDKs encode an array parameter); only the value is escaped.
+qadd() { QUERY="${QUERY:+$QUERY&}$1=$(urlencode "$2")"; }
+qadd_includes() {
+    local v
+    for v in ${INCLUDES[@]+"${INCLUDES[@]}"}; do qadd 'include[]' "$v"; done
+}
+
+net_args() {
+    NET=()
+    [[ "$CONNECT_TIMEOUT" =~ ^[0-9]+$ && "$CONNECT_TIMEOUT" -gt 0 ]] \
+        && NET+=(--connect-timeout "$CONNECT_TIMEOUT")
+    [[ "$MAX_TIME" =~ ^[0-9]+$ && "$MAX_TIME" -gt 0 ]] \
+        && NET+=(--max-time "$MAX_TIME")
+    return 0
+}
+
+BODY=""
+# do_request <method> <path>. Reads QUERY and BODY, leaves the reply in
+# $RESP_FILE, and dies on a non-2xx with the API's own message.
+RESP_FILE=""
+do_request() {
+    local method="$1" url="$BASE$2" code body_file=""
+    [[ -n "$QUERY" ]] && url="$url?$QUERY"
+    RESP_FILE=$(mktmp)
+    local args=(-sS -o "$RESP_FILE" -w '%{http_code}')
+    args+=(${NET[@]+"${NET[@]}"} "${HEADERS[@]}" -X "$method")
+    if [[ -n "$BODY" ]]; then
+        body_file=$(mktmp)
+        printf '%s' "$BODY" > "$body_file"
+        args+=(-d @"$body_file")
+    fi
+    code=$(curl "${args[@]}" "$url" 2>/dev/null) || code="000"
+    [[ "$code" =~ ^2[0-9][0-9]$ ]] && return 0
+    local msg=""
+    msg=$(jq -r '(.error.message // .message // empty)' < "$RESP_FILE" 2>/dev/null) || msg=""
+    [[ -n "$msg" ]] || msg="HTTP $code from $method $url"
+    die "$msg"
+}
+
+emit() {
+    if [[ "$PRETTY" -eq 1 ]]; then jq . < "$1"; else jq -c . < "$1"; fi \
+        || die "the API reply was not JSON"
+}
+
+# GET a list endpoint, following has_more when --all was asked for. The merged
+# object is one page as far as a caller is concerned, so has_more is false and
+# the ids bracket the whole set.
+run_list() {
+    local path="$1" after="$OPT_AFTER" n=0 has_more last pages merged
+    pages=$(mktemp -d "${TMPDIR:-/tmp}/responses-pages.XXXXXX") || die "cannot create a temporary directory"
+    _tmp_files="$_tmp_files $pages"
+    while :; do
+        n=$(( n + 1 ))
+        QUERY=""
+        [[ -n "$after" ]] && qadd after "$after"
+        [[ -n "$OPT_LIMIT" ]] && qadd limit "$OPT_LIMIT"
+        [[ -n "$OPT_ORDER" ]] && qadd order "$OPT_ORDER"
+        qadd_includes
+        do_request GET "$path"
+        if [[ "$OPT_ALL" -ne 1 ]]; then emit "$RESP_FILE"; return 0; fi
+        cp "$RESP_FILE" "$pages/$(printf '%05d' "$n").json"
+        has_more=$(jq -r '.has_more // false' < "$RESP_FILE" 2>/dev/null) || has_more="false"
+        last=$(jq -r '(.data // []) | if length > 0 then (.[-1].id // "") else "" end' < "$RESP_FILE" 2>/dev/null) || last=""
+        [[ "$has_more" == "true" && -n "$last" && "$last" != "$after" && "$n" -lt 500 ]] || break
+        after="$last"
+    done
+    merged=$(mktmp)
+    jq -s '(map((.data // [])[])) as $d
+           | {object: (.[0].object // "list"),
+              data: $d,
+              first_id: (if ($d | length) > 0 then $d[0].id else null end),
+              last_id: (if ($d | length) > 0 then $d[-1].id else null end),
+              has_more: false}' "$pages"/*.json > "$merged" \
+        || die "cannot merge the paginated reply"
+    emit "$merged"
+}
+
+# --- streaming get ----------------------------------------------------------
+
+# The SSE resume channel for a background response: every data payload becomes
+# one JSON line, and only a terminal event makes this a success. Anything the
+# server sent that was not an SSE data line is kept so an HTTP error body can
+# still be reported as the reason.
+stream_get() {
+    local url="$BASE$1" line payload etype terminal=0 other msg
+    [[ -n "$QUERY" ]] && url="$url?$QUERY"
+    other=$(mktmp)
+    while IFS= read -r line; do
+        case "$line" in
+            data:*) ;;
+            *) printf '%s\n' "$line" >> "$other"; continue ;;
+        esac
+        payload="${line#data:}"
+        payload="${payload# }"
+        [[ -z "$payload" || "$payload" == "[DONE]" ]] && continue
+        etype=$(printf '%s' "$payload" | jq -r '.type // empty' 2>/dev/null) || etype=""
+        printf '%s' "$payload" | jq -c . 2>/dev/null || printf '%s\n' "$payload"
+        case "$etype" in
+            response.completed|response.incomplete|response.failed|response.cancelled)
+                terminal=1 ;;
+        esac
+    done < <(curl -sS -N ${NET[@]+"${NET[@]}"} "${HEADERS[@]}" "$url" 2>/dev/null)
+    [[ "$terminal" -eq 1 ]] && return 0
+    msg=$(jq -r '(.error.message // .message // empty)' < "$other" 2>/dev/null) || msg=""
+    [[ -n "$msg" ]] || msg="the stream ended without a terminal response event"
+    die "$msg"
+}
+
+# ---------------------------------------------------------------------------
+# Bodies
+# ---------------------------------------------------------------------------
+
+# These validators run in the caller's shell rather than returning their input
+# through a command substitution, so a usage_error inside one really does end
+# the process with exit 2 instead of only ending a subshell.
+require_json_array() {  # require_json_array <file> <what>
+    [[ -f "$1" ]] || usage_error "$2: no such file: $1"
+    jq -e 'type == "array"' < "$1" >/dev/null 2>&1 \
+        || usage_error "$2 must hold a JSON array: $1"
+}
+
+require_json_object_file() {  # require_json_object_file <file> <what>
+    [[ -f "$1" ]] || usage_error "$2: no such file: $1"
+    jq -e 'type == "object"' < "$1" >/dev/null 2>&1 \
+        || usage_error "$2 must hold a JSON object: $1"
+}
+
+require_json_object() {  # require_json_object <json> <what>
+    printf '%s' "$1" | jq -e 'type == "object"' >/dev/null 2>&1 \
+        || usage_error "$2 must be a JSON object"
+}
+
+# Sets BODY to {"items": [...]}. The API takes 20 items at a time, so a longer
+# file is a usage error here rather than a rejected request.
+build_items_body() {  # build_items_body <file>
+    require_json_array "$1" "--items-file"
+    local count
+    count=$(jq 'length' < "$1")
+    [[ "$count" -le 20 ]] \
+        || usage_error "--items-file holds $count items; the API takes at most 20 at a time"
+    BODY=$(jq -c '{items: .}' < "$1")
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+parse_opts "$@"
+[[ "${#POS[@]}" -gt 0 ]] || usage_error "no command given"
+COMMAND="${POS[0]}"
+shift_pos
+NET=()
+
+case "$COMMAND" in
+    get)
+        allow_opts "--include --stream --starting-after"
+        want_pos 1 "one response id"
+        resolve_provider; net_args
+        QUERY=""
+        if [[ "$OPT_STREAM" -eq 1 ]]; then
+            qadd stream true
+            [[ -n "$OPT_STARTING_AFTER" ]] && qadd starting_after "$OPT_STARTING_AFTER"
+            qadd_includes
+            stream_get "/responses/${POS[0]}"
+        else
+            [[ -n "$OPT_STARTING_AFTER" ]] && usage_error "--starting-after only means something with --stream"
+            qadd_includes
+            do_request GET "/responses/${POS[0]}"
+            emit "$RESP_FILE"
+        fi
+        ;;
+    cancel)
+        allow_opts ""
+        want_pos 1 "one response id"
+        resolve_provider; net_args
+        do_request POST "/responses/${POS[0]}/cancel"
+        emit "$RESP_FILE"
+        ;;
+    delete)
+        allow_opts ""
+        want_pos 1 "one response id"
+        resolve_provider; net_args
+        do_request DELETE "/responses/${POS[0]}"
+        emit "$RESP_FILE"
+        ;;
+    input-items)
+        allow_opts "--after --limit --order --include --all"
+        want_pos 1 "one response id"
+        resolve_provider; net_args
+        run_list "/responses/${POS[0]}/input_items"
+        ;;
+    compact)
+        allow_opts "--model --input-file --previous-response-id --instructions --body-file"
+        want_pos 0 "no positional arguments"
+        [[ -n "$OPT_MODEL" ]] || usage_error "compact requires --model"
+        [[ -n "$OPT_INPUT_FILE" || -n "$OPT_PREV" ]] \
+            || usage_error "compact requires --input-file or --previous-response-id"
+        [[ -n "$OPT_INPUT_FILE" && -n "$OPT_PREV" ]] \
+            && usage_error "compact takes --input-file or --previous-response-id, not both"
+        _base_body='{}'
+        if [[ -n "$OPT_BODY_FILE" ]]; then
+            require_json_object_file "$OPT_BODY_FILE" "--body-file"
+            _base_body=$(cat "$OPT_BODY_FILE")
+        fi
+        _filter='$body + {model: $model}'
+        _jq_args=(--argjson body "$_base_body" --arg model "$OPT_MODEL")
+        if [[ -n "$OPT_INPUT_FILE" ]]; then
+            require_json_array "$OPT_INPUT_FILE" "--input-file"
+            _jq_args+=(--slurpfile input "$OPT_INPUT_FILE")
+            _filter="$_filter + {input: \$input[0]}"
+        else
+            _jq_args+=(--arg prev "$OPT_PREV")
+            _filter="$_filter + {previous_response_id: \$prev}"
+        fi
+        if [[ -n "$OPT_INSTRUCTIONS" ]]; then
+            _jq_args+=(--arg instructions "$OPT_INSTRUCTIONS")
+            _filter="$_filter + {instructions: \$instructions}"
+        fi
+        BODY=$(jq -nc "${_jq_args[@]}" "$_filter") || die "cannot build the compact request body"
+        resolve_provider; net_args
+        QUERY=""
+        do_request POST "/responses/compact"
+        emit "$RESP_FILE"
+        ;;
+    conversations)
+        [[ "${#POS[@]}" -gt 0 ]] || usage_error "conversations needs a subcommand"
+        SUB="${POS[0]}"
+        shift_pos
+        COMMAND="conversations $SUB"
+        case "$SUB" in
+            create)
+                allow_opts "--items-file --metadata"
+                want_pos 0 "no positional arguments"
+                BODY='{}'
+                [[ -n "$OPT_ITEMS_FILE" ]] && build_items_body "$OPT_ITEMS_FILE"
+                if [[ -n "$OPT_METADATA" ]]; then
+                    require_json_object "$OPT_METADATA" "--metadata"
+                    BODY=$(printf '%s' "$BODY" | jq -c --argjson m "$OPT_METADATA" '. + {metadata: $m}')
+                fi
+                resolve_provider; net_args
+                QUERY=""
+                do_request POST "/conversations"
+                emit "$RESP_FILE"
+                ;;
+            get)
+                allow_opts ""
+                want_pos 1 "one conversation id"
+                resolve_provider; net_args
+                QUERY=""
+                do_request GET "/conversations/${POS[0]}"
+                emit "$RESP_FILE"
+                ;;
+            update)
+                allow_opts "--metadata"
+                want_pos 1 "one conversation id"
+                [[ -n "$OPT_METADATA" ]] || usage_error "conversations update requires --metadata"
+                require_json_object "$OPT_METADATA" "--metadata"
+                BODY=$(jq -nc --argjson m "$OPT_METADATA" '{metadata: $m}')
+                resolve_provider; net_args
+                QUERY=""
+                do_request POST "/conversations/${POS[0]}"
+                emit "$RESP_FILE"
+                ;;
+            delete)
+                allow_opts ""
+                want_pos 1 "one conversation id"
+                resolve_provider; net_args
+                QUERY=""
+                do_request DELETE "/conversations/${POS[0]}"
+                emit "$RESP_FILE"
+                ;;
+            items)
+                allow_opts "--after --limit --order --include --all"
+                want_pos 1 "one conversation id"
+                resolve_provider; net_args
+                run_list "/conversations/${POS[0]}/items"
+                ;;
+            add)
+                allow_opts "--items-file --include"
+                want_pos 1 "one conversation id"
+                [[ -n "$OPT_ITEMS_FILE" ]] || usage_error "conversations add requires --items-file"
+                build_items_body "$OPT_ITEMS_FILE"
+                resolve_provider; net_args
+                QUERY=""; qadd_includes
+                do_request POST "/conversations/${POS[0]}/items"
+                emit "$RESP_FILE"
+                ;;
+            item)
+                allow_opts "--include"
+                want_pos 2 "a conversation id and an item id"
+                resolve_provider; net_args
+                QUERY=""; qadd_includes
+                do_request GET "/conversations/${POS[0]}/items/${POS[1]}"
+                emit "$RESP_FILE"
+                ;;
+            remove)
+                allow_opts ""
+                want_pos 2 "a conversation id and an item id"
+                resolve_provider; net_args
+                QUERY=""
+                do_request DELETE "/conversations/${POS[0]}/items/${POS[1]}"
+                emit "$RESP_FILE"
+                ;;
+            *)
+                usage_error "unknown conversations subcommand: $SUB"
+                ;;
+        esac
+        ;;
+    *)
+        usage_error "unknown command: $COMMAND"
+        ;;
+esac

--- a/bin/shellm
+++ b/bin/shellm
@@ -95,6 +95,7 @@ unset _shellm_process_shellm_api_url_set _shellm_process_shellm_api_url \
     _shellm_process_llm_api_url_set _shellm_process_llm_api_url 2>/dev/null || true
 SHELLM_API_FORMAT="${SHELLM_API_FORMAT:-chat}"
 SHELLM_RESPONSES_BODY_FILE="${SHELLM_RESPONSES_BODY_FILE:-}"
+SHELLM_RESPONSES_BACKGROUND="${SHELLM_RESPONSES_BACKGROUND:-}"
 # Clear any inherited LLM_API_URL so llm uses per-provider defaults
 unset LLM_API_URL 2>/dev/null || true
 if [[ -n "$SHELLM_API_URL" ]]; then
@@ -176,6 +177,10 @@ if [[ -n "$SHELLM_RESPONSES_BODY_FILE" ]]; then
         || die "SHELLM_RESPONSES_BODY_FILE not found: $SHELLM_RESPONSES_BODY_FILE"
     SHELLM_RESPONSES_BODY_FILE=$(realpath "$SHELLM_RESPONSES_BODY_FILE")
 fi
+case "$SHELLM_RESPONSES_BACKGROUND" in
+    ""|0|1) ;;
+    *) die "Invalid SHELLM_RESPONSES_BACKGROUND: $SHELLM_RESPONSES_BACKGROUND (expected 0 or 1)" ;;
+esac
 
 # A local model bound to the Docker host is usually configured as localhost
 # for thinkers and other llm calls that run on that host. Code executed in a
@@ -346,6 +351,10 @@ Environment:
   SHELLM_RESPONSES_BODY_FILE
                           Optional Responses create-body JSON object passed to
                           llm (tools, include, store, text format, etc.)
+  SHELLM_RESPONSES_BACKGROUND
+                          1 runs each Responses create in the background
+                          (llm polls or resumes the stream, and cancels the
+                          job if killed); 0 forces foreground
   SHELLM_EMPTY_RESPONSE_RETRIES
                           Empty-response retries before the run dies
                           (default 8; set empty for unlimited)
@@ -1599,6 +1608,13 @@ call_llm() {
         else
             unset LLM_RESPONSES_BODY_FILE 2>/dev/null || true
         fi
+        # Background creates change nothing here: llm still hands back one
+        # terminal object per call, polling or resuming on its own.
+        if [[ -n "${SHELLM_RESPONSES_BACKGROUND:-}" ]]; then
+            export LLM_RESPONSES_BACKGROUND="$SHELLM_RESPONSES_BACKGROUND"
+        else
+            unset LLM_RESPONSES_BACKGROUND 2>/dev/null || true
+        fi
         local replay_has_history=0
         if [[ -n "$replay_file" && -s "$replay_file" ]] \
             && jq -e 'type == "array" and length > 0' "$replay_file" >/dev/null 2>&1; then
@@ -1653,7 +1669,7 @@ call_llm() {
         fi
     else
         unset LLM_RESPONSE_FILE LLM_RESPONSES_BODY_FILE LLM_PREVIOUS_RESPONSE_ID \
-            2>/dev/null || true
+            LLM_RESPONSES_BACKGROUND 2>/dev/null || true
     fi
 
     while true; do
@@ -2953,6 +2969,8 @@ exit \$__shellm_rc
             LLM_API_FORMAT="$SHELLM_API_FORMAT"
             SHELLM_RESPONSES_BODY_FILE="$SHELLM_RESPONSES_BODY_FILE"
             LLM_RESPONSES_BODY_FILE="$SHELLM_RESPONSES_BODY_FILE"
+            SHELLM_RESPONSES_BACKGROUND="$SHELLM_RESPONSES_BACKGROUND"
+            LLM_RESPONSES_BACKGROUND="$SHELLM_RESPONSES_BACKGROUND"
             SHELLM_API_URL="$execution_api_url"
             LLM_API_URL="$execution_api_url"
             SHELLM_DOCKER_IMAGE="$SHELLM_DOCKER_IMAGE"

--- a/bin/shellm
+++ b/bin/shellm
@@ -94,7 +94,12 @@ fi
 unset _shellm_process_shellm_api_url_set _shellm_process_shellm_api_url \
     _shellm_process_llm_api_url_set _shellm_process_llm_api_url 2>/dev/null || true
 SHELLM_API_FORMAT="${SHELLM_API_FORMAT:-chat}"
+SHELLM_API_TRANSPORT="${SHELLM_API_TRANSPORT:-https}"
 SHELLM_RESPONSES_BODY_FILE="${SHELLM_RESPONSES_BODY_FILE:-}"
+# The provider this run inherited, kept because the websocket transport
+# overwrites LLM_PROVIDER for llm calls and the Docker sandbox must still be
+# told the original: the host broker's socket does not exist in a container.
+_SHELLM_HOST_PROVIDER="${LLM_PROVIDER:-}"
 # Clear any inherited LLM_API_URL so llm uses per-provider defaults
 unset LLM_API_URL 2>/dev/null || true
 if [[ -n "$SHELLM_API_URL" ]]; then
@@ -170,6 +175,18 @@ die() { echo "shellm: error: $*" >&2; exit 1; }
 case "$SHELLM_API_FORMAT" in
     chat|responses) ;;
     *) die "Invalid SHELLM_API_FORMAT: $SHELLM_API_FORMAT (expected chat or responses)" ;;
+esac
+case "$SHELLM_API_TRANSPORT" in
+    https) ;;
+    websocket)
+        # WebSocket mode is a Responses transport and nothing else: the
+        # protocol on the wire is response.create and Responses events, so
+        # asking for it under Chat Completions is a configuration mistake
+        # rather than something to silently downgrade.
+        [[ "$SHELLM_API_FORMAT" == "responses" ]] \
+            || die "SHELLM_API_TRANSPORT=websocket needs SHELLM_API_FORMAT=responses"
+        ;;
+    *) die "Invalid SHELLM_API_TRANSPORT: $SHELLM_API_TRANSPORT (expected https or websocket)" ;;
 esac
 if [[ -n "$SHELLM_RESPONSES_BODY_FILE" ]]; then
     [[ -f "$SHELLM_RESPONSES_BODY_FILE" ]] \
@@ -343,6 +360,9 @@ Environment:
                           Responses persists and reuses previous_response_id
                           within a run, with one full-context fallback when a
                           provider rejects continuation
+  SHELLM_API_TRANSPORT    How Responses calls travel: https (default) or
+                          websocket, which holds one connection open for the
+                          whole run through tools/responses-ws
   SHELLM_RESPONSES_BODY_FILE
                           Optional Responses create-body JSON object passed to
                           llm (tools, include, store, text format, etc.)
@@ -2649,6 +2669,35 @@ run_loop() {
         fi
     fi
 
+    # WebSocket transport: one connection for the whole run instead of one
+    # handshake per turn. The broker holds it and hands out stream_id lanes;
+    # llm reaches it through the adapter seam, so nothing in the completion
+    # path grows a Python dependency. The socket lives in rundir, which is
+    # already a private 0700 directory that disappears at cleanup.
+    if [[ "$SHELLM_API_TRANSPORT" == "websocket" ]]; then
+        local _ws_tool
+        _ws_tool=$(resolve_shellm_tool_path "$(realpath "$0")" "responses-ws" || true)
+        [[ -n "$_ws_tool" ]] \
+            || die "SHELLM_API_TRANSPORT=websocket needs tools/responses-ws, which was not found next to bin/shellm"
+        _SHELLM_WS_SOCKET="$rundir/.responses-ws.sock"
+        _SHELLM_WS_TOOL="$_ws_tool"
+        "$_ws_tool" serve --socket "$_SHELLM_WS_SOCKET" \
+            > "$rundir/.responses-ws.log" 2>&1 &
+        _SHELLM_WS_PID=$!
+        local _ws_wait=0
+        while [[ ! -e "$_SHELLM_WS_SOCKET" && "$_ws_wait" -lt 60 ]]; do
+            sleep 0.5
+            _ws_wait=$((_ws_wait + 1))
+        done
+        if [[ ! -e "$_SHELLM_WS_SOCKET" ]]; then
+            kill "$_SHELLM_WS_PID" 2>/dev/null || true
+            die "responses-ws broker did not open $_SHELLM_WS_SOCKET: $(tail -1 "$rundir/.responses-ws.log" 2>/dev/null)"
+        fi
+        export LLM_PROVIDER=adapter
+        export LLM_ADAPTER="$_ws_tool"
+        export RESPONSES_WS_SOCKET="$_SHELLM_WS_SOCKET"
+    fi
+
     # Launcher opt-in: report this run's header step_id to the given file so
     # the caller can pair its own steps with this exact run — the trajectory
     # alone can't tell whose header is whose when concurrent runs interleave.
@@ -2686,6 +2735,21 @@ run_loop() {
     _cleanup_ctx_pid="${_ctx_summary_pid:-}"
     cleanup() {
         stop_activity_beacon
+        # Stop the WebSocket broker before rundir goes, so it can unlink its
+        # own socket and close the upstream connection rather than being
+        # killed with a response still in flight.
+        if [[ -n "${_SHELLM_WS_SOCKET:-}" ]]; then
+            [[ -n "${_SHELLM_WS_TOOL:-}" ]] \
+                && "$_SHELLM_WS_TOOL" stop --socket "$_SHELLM_WS_SOCKET" >/dev/null 2>&1
+            if [[ -n "${_SHELLM_WS_PID:-}" ]]; then
+                local _ws_grace=0
+                while kill -0 "$_SHELLM_WS_PID" 2>/dev/null && [[ "$_ws_grace" -lt 5 ]]; do
+                    sleep 1
+                    _ws_grace=$((_ws_grace + 1))
+                done
+                kill "$_SHELLM_WS_PID" 2>/dev/null || true
+            fi
+        fi
         # Give run-summary background process time to finish
         if [[ -n "$_cleanup_ctx_pid" ]] && kill -0 "$_cleanup_ctx_pid" 2>/dev/null; then
             local _ctx_wait=0
@@ -2942,7 +3006,11 @@ exit \$__shellm_rc
             # The generic openai-compatible provider is configured entirely by
             # env (never auto-detected), so llm calls inside generated code
             # need these two like they need the vendor keys above/below.
-            LLM_PROVIDER="${LLM_PROVIDER:-}"
+            # The run's own provider, not the websocket override: the broker's
+            # unix socket is on the host and a nested llm inside the sandbox
+            # cannot reach it, so sandboxed calls take the ordinary HTTPS
+            # Responses path.
+            LLM_PROVIDER="$_SHELLM_HOST_PROVIDER"
             LLM_API_KEY="${LLM_API_KEY:-}"
             SHELLM_MODEL="$SHELLM_MODEL"
             SHELLM_MAX_TOKENS="$SHELLM_MAX_TOKENS"

--- a/bin/shellm
+++ b/bin/shellm
@@ -97,6 +97,7 @@ SHELLM_API_FORMAT="${SHELLM_API_FORMAT:-chat}"
 SHELLM_API_TRANSPORT="${SHELLM_API_TRANSPORT:-https}"
 SHELLM_RESPONSES_BODY_FILE="${SHELLM_RESPONSES_BODY_FILE:-}"
 SHELLM_RESPONSES_BACKGROUND="${SHELLM_RESPONSES_BACKGROUND:-}"
+SHELLM_RESPONSES_COMPACT_THRESHOLD="${SHELLM_RESPONSES_COMPACT_THRESHOLD:-}"
 # The provider this run inherited, kept because the websocket transport
 # overwrites LLM_PROVIDER for llm calls and the Docker sandbox must still be
 # told the original: the host broker's socket does not exist in a container.
@@ -198,6 +199,10 @@ case "$SHELLM_RESPONSES_BACKGROUND" in
     ""|0|1) ;;
     *) die "Invalid SHELLM_RESPONSES_BACKGROUND: $SHELLM_RESPONSES_BACKGROUND (expected 0 or 1)" ;;
 esac
+if [[ -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ]]; then
+    [[ "$SHELLM_RESPONSES_COMPACT_THRESHOLD" =~ ^[1-9][0-9]*$ ]] \
+        || die "Invalid SHELLM_RESPONSES_COMPACT_THRESHOLD: $SHELLM_RESPONSES_COMPACT_THRESHOLD (expected a positive integer)"
+fi
 
 # A local model bound to the Docker host is usually configured as localhost
 # for thinkers and other llm calls that run on that host. Code executed in a
@@ -375,6 +380,13 @@ Environment:
                           1 runs each Responses create in the background
                           (llm polls or resumes the stream, and cancels the
                           job if killed); 0 forces foreground
+  SHELLM_RESPONSES_COMPACT_THRESHOLD
+                          Input-token count at which the Responses window is
+                          compacted. Stateful runs pass it to llm and the
+                          server compacts inside the turn; replay runs
+                          (OpenRouter, ZDR, after a continuation fallback)
+                          call the compact endpoint and swap the chain for
+                          the window it returns
   SHELLM_EMPTY_RESPONSE_RETRIES
                           Empty-response retries before the run dies
                           (default 8; set empty for unlimited)
@@ -1599,6 +1611,65 @@ execute_code() {
 # LLM API call (delegates to the `llm` tool)
 # ---------------------------------------------------------------------------
 
+# Compaction upkeep for the process-local replay chain, run once per terminal
+# response. Two independent things happen here. A server that compacted inside
+# the turn returns a compaction item in the output, and the API says that item
+# is where the next window starts, so everything before it is dropped. Then, in
+# replay mode only, nobody is compacting on our behalf: once the reported input
+# tokens reach SHELLM_RESPONSES_COMPACT_THRESHOLD we call the compact endpoint
+# and swap the chain for the window it hands back, which must be sent as is.
+# A failed compact call is not fatal. The chain is still correct, only longer,
+# and the next crossing tries again.
+compact_replay_chain() {
+    local replay_file="$1" response_file="$2" replay_mode="$3"
+    local replay_dir chain_tmp
+    [[ -n "$replay_file" && -s "$replay_file" && -s "$response_file" ]] || return 0
+    replay_dir=$(dirname "$replay_file")
+
+    if jq -e 'any(.output[]?; .type == "compaction")' "$response_file" >/dev/null 2>&1; then
+        chain_tmp=$(mktemp "$replay_dir/.responses-replay.XXXXXX") || return 0
+        chmod 600 "$chain_tmp"
+        if jq '(map(.type? == "compaction") | index(true)) as $at
+               | if $at == null then . else .[$at:] end' \
+                "$replay_file" > "$chain_tmp" 2>/dev/null; then
+            mv -f "$chain_tmp" "$replay_file"
+        else
+            rm -f "$chain_tmp"
+        fi
+    fi
+
+    [[ "$replay_mode" -eq 1 && -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ]] || return 0
+    local input_tokens
+    input_tokens=$(jq -r '.usage.input_tokens // empty' "$response_file" 2>/dev/null || true)
+    [[ "$input_tokens" =~ ^[0-9]+$ ]] || return 0
+    [[ "$input_tokens" -ge "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ]] || return 0
+
+    progress "compacting the Responses replay chain at $input_tokens input tokens"
+    local compact_out compact_err
+    compact_out=$(mktemp) || return 0
+    compact_err=$(mktemp) || { rm -f "$compact_out"; return 0; }
+    if ! responses compact --model "$SHELLM_MODEL" --input-file "$replay_file" \
+            > "$compact_out" 2> "$compact_err"; then
+        echo "shellm: warning: compaction failed, keeping the replay chain: $(tail -c 300 "$compact_err")" >&2
+        rm -f "$compact_out" "$compact_err"
+        return 0
+    fi
+    if ! jq -e '.output | type == "array" and length > 0' "$compact_out" >/dev/null 2>&1; then
+        echo "shellm: warning: compaction failed, the compact reply carried no window" >&2
+        rm -f "$compact_out" "$compact_err"
+        return 0
+    fi
+    chain_tmp=$(mktemp "$replay_dir/.responses-replay.XXXXXX") || {
+        rm -f "$compact_out" "$compact_err"; return 0; }
+    chmod 600 "$chain_tmp"
+    if jq '.output' "$compact_out" > "$chain_tmp" 2>/dev/null; then
+        mv -f "$chain_tmp" "$replay_file"
+    else
+        rm -f "$chain_tmp"
+    fi
+    rm -f "$compact_out" "$compact_err"
+}
+
 call_llm() {
     local system_prompt="$1"
     local full_messages_json="$2"
@@ -1615,6 +1686,10 @@ call_llm() {
     local new_messages_json="$full_messages_json"
     local previous_response_id=""
     local fallback_used=0
+    # Set once the run is replaying the chain itself rather than continuing by
+    # response id. Compaction splits on it: the server can only compact what it
+    # holds, so a replaying run has to call the compact endpoint on its own.
+    local replay_mode=0
 
     export LLM_API_FORMAT="$api_format"
     if [[ "$api_format" == "responses" ]]; then
@@ -1678,6 +1753,7 @@ call_llm() {
         new_messages_json=$(printf '%s' "$new_messages_json" | jq -c 'map(del(.step_ids))')
         request_messages_json="$full_messages_json"
         if [[ "$stateless" == "1" || ( -n "$disabled_file" && -e "$disabled_file" ) ]]; then
+            replay_mode=1
             if [[ "$replay_has_history" -eq 1 ]]; then
                 request_messages_json=$(printf '%s' "$new_messages_json" \
                     | jq --slurpfile history "$replay_file" '($history[0] // []) + .')
@@ -1689,7 +1765,7 @@ call_llm() {
         fi
     else
         unset LLM_RESPONSE_FILE LLM_RESPONSES_BODY_FILE LLM_PREVIOUS_RESPONSE_ID \
-            LLM_RESPONSES_BACKGROUND 2>/dev/null || true
+            LLM_RESPONSES_BACKGROUND LLM_RESPONSES_COMPACT_THRESHOLD 2>/dev/null || true
     fi
 
     while true; do
@@ -1715,6 +1791,14 @@ call_llm() {
                 export LLM_PREVIOUS_RESPONSE_ID="$previous_response_id"
             else
                 unset LLM_PREVIOUS_RESPONSE_ID 2>/dev/null || true
+            fi
+            # Server-side compaction only makes sense while the server holds
+            # the window. A replaying run keeps its own chain, so it asks for
+            # nothing here and compacts after the turn instead.
+            if [[ "$replay_mode" -eq 0 && -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ]]; then
+                export LLM_RESPONSES_COMPACT_THRESHOLD="$SHELLM_RESPONSES_COMPACT_THRESHOLD"
+            else
+                unset LLM_RESPONSES_COMPACT_THRESHOLD 2>/dev/null || true
             fi
             [[ -z "$response_file" ]] || rm -f "$response_file"
         fi
@@ -1768,6 +1852,7 @@ call_llm() {
                         "$replay_file" "$turn_tmp" "$response_file" > "$replay_tmp"
                     mv -f "$replay_tmp" "$replay_file"
                     rm -f "$turn_tmp"
+                    compact_replay_chain "$replay_file" "$response_file" "$replay_mode"
                 fi
                 if [[ -n "$context_file" && "$messages_are_delta" != "1" ]]; then
                     local context_dir context_tmp
@@ -1844,6 +1929,7 @@ call_llm() {
                 request_messages_json="$full_messages_json"
             fi
             fallback_used=1
+            replay_mode=1
             rm -f "$text_file" "$stderr_file" "$messages_file"
             [[ -z "$thinking_output_file" ]] || : > "$thinking_output_file"
             progress "responses continuation rejected; retrying once with exact replay context"

--- a/bin/shellm
+++ b/bin/shellm
@@ -97,6 +97,11 @@ SHELLM_API_FORMAT="${SHELLM_API_FORMAT:-chat}"
 SHELLM_API_TRANSPORT="${SHELLM_API_TRANSPORT:-https}"
 SHELLM_RESPONSES_BODY_FILE="${SHELLM_RESPONSES_BODY_FILE:-}"
 SHELLM_RESPONSES_BACKGROUND="${SHELLM_RESPONSES_BACKGROUND:-}"
+# Server-held conversation state instead of the process-local chain: "new"
+# creates one at run start, a conv_ id joins an existing one. The id is
+# durable on purpose (Conversations do not expire), so it is recorded in the
+# run header and a resume of that run picks it back up.
+SHELLM_RESPONSES_CONVERSATION="${SHELLM_RESPONSES_CONVERSATION:-}"
 # The provider this run inherited, kept because the websocket transport
 # overwrites LLM_PROVIDER for llm calls and the Docker sandbox must still be
 # told the original: the host broker's socket does not exist in a container.
@@ -198,6 +203,17 @@ case "$SHELLM_RESPONSES_BACKGROUND" in
     ""|0|1) ;;
     *) die "Invalid SHELLM_RESPONSES_BACKGROUND: $SHELLM_RESPONSES_BACKGROUND (expected 0 or 1)" ;;
 esac
+if [[ -n "$SHELLM_RESPONSES_CONVERSATION" ]]; then
+    # Conversations are a Responses-only container, and an operator who asked
+    # for durable server state under Chat Completions has a configuration
+    # mistake rather than something to silently ignore.
+    [[ "$SHELLM_API_FORMAT" == "responses" ]] \
+        || die "SHELLM_RESPONSES_CONVERSATION needs SHELLM_API_FORMAT=responses"
+    case "$SHELLM_RESPONSES_CONVERSATION" in
+        new|conv_*) ;;
+        *) die "Invalid SHELLM_RESPONSES_CONVERSATION: $SHELLM_RESPONSES_CONVERSATION (expected new or a conv_ id)" ;;
+    esac
+fi
 
 # A local model bound to the Docker host is usually configured as localhost
 # for thinkers and other llm calls that run on that host. Code executed in a
@@ -375,6 +391,11 @@ Environment:
                           1 runs each Responses create in the background
                           (llm polls or resumes the stream, and cancels the
                           job if killed); 0 forces foreground
+  SHELLM_RESPONSES_CONVERSATION
+                          new, or a conv_ id: keep the turns in a server-side
+                          Conversation instead of the process-local chain.
+                          new creates one per run, the id is recorded in the
+                          run header, and --resume of that run reuses it
   SHELLM_EMPTY_RESPONSE_RETRIES
                           Empty-response retries before the run dies
                           (default 8; set empty for unlimited)
@@ -1611,6 +1632,7 @@ call_llm() {
     local replay_file="${SHELLM_RESPONSES_REPLAY_FILE:-}"
     local context_file="${SHELLM_RESPONSES_CONTEXT_FILE:-}"
     local stateless="${SHELLM_RESPONSES_STATELESS:-0}"
+    local conversation="${SHELLM_RESPONSES_CONVERSATION_ID:-}"
     local request_messages_json="$full_messages_json"
     local new_messages_json="$full_messages_json"
     local previous_response_id=""
@@ -1635,6 +1657,13 @@ call_llm() {
         else
             unset LLM_RESPONSES_BACKGROUND 2>/dev/null || true
         fi
+        # Conversation mode and previous_response_id are alternatives, and llm
+        # refuses the pair; the id file this run never writes keeps them apart.
+        if [[ -n "$conversation" ]]; then
+            export LLM_RESPONSES_CONVERSATION="$conversation"
+        else
+            unset LLM_RESPONSES_CONVERSATION 2>/dev/null || true
+        fi
         local replay_has_history=0
         if [[ -n "$replay_file" && -s "$replay_file" ]] \
             && jq -e 'type == "array" and length > 0' "$replay_file" >/dev/null 2>&1; then
@@ -1658,7 +1687,8 @@ call_llm() {
         local seen_src=/dev/null sent_ids_json='{}'
         [[ -n "$context_file" && -s "$context_file" ]] && seen_src="$context_file"
         if [[ "$messages_are_delta" != "1" \
-            && ( -n "$previous_response_id" || "$replay_has_history" -eq 1 ) ]]; then
+            && ( -n "$previous_response_id" || "$replay_has_history" -eq 1 \
+                 || ( -n "$conversation" && "$seen_src" != /dev/null ) ) ]]; then
             [[ "$seen_src" != /dev/null ]] \
                 || die "Responses continuation context is missing"
             new_messages_json=$(printf '%s' "$full_messages_json" | jq -c --slurpfile seen_file "$seen_src" '
@@ -1684,12 +1714,12 @@ call_llm() {
             else
                 request_messages_json="$new_messages_json"
             fi
-        elif [[ -n "$previous_response_id" ]]; then
+        elif [[ -n "$previous_response_id" || -n "$conversation" ]]; then
             request_messages_json="$new_messages_json"
         fi
     else
         unset LLM_RESPONSE_FILE LLM_RESPONSES_BODY_FILE LLM_PREVIOUS_RESPONSE_ID \
-            LLM_RESPONSES_BACKGROUND 2>/dev/null || true
+            LLM_RESPONSES_BACKGROUND LLM_RESPONSES_CONVERSATION 2>/dev/null || true
     fi
 
     while true; do
@@ -2392,6 +2422,8 @@ run_loop() {
     mkdir -p "$_run_traj_dir"
 
     local _run_traj_id _new_output run_name
+    # A conversation carried by the trajectory this run resumes.
+    local _resume_conversation=""
 
     if [[ -n "$_use_traj" ]]; then
         # --- Use existing trajectory (--traj / --resume) ---
@@ -2418,6 +2450,7 @@ run_loop() {
             _orig_workdir=$(printf '%s' "$_orig_meta" | jq -r '.workdir // empty')
             _orig_env=$(printf '%s' "$_orig_meta" | jq -r '.env.name // empty')
             _orig_image=$(printf '%s' "$_orig_meta" | jq -r '.env.docker_image // empty')
+            _resume_conversation=$(printf '%s' "$_orig_meta" | jq -r '.conversation // empty')
             [[ -z "$_SHELLM_WORKDIR_USER" && -n "$_orig_workdir" ]] && _SHELLM_WORKDIR_USER="$_orig_workdir"
             [[ -z "$_SHELLM_ENV_NAME" && -n "$_orig_env" ]] && _SHELLM_ENV_NAME="$_orig_env"
             SHELLM_DOCKER_IMAGE=$(_resume_docker_image \
@@ -2630,6 +2663,39 @@ run_loop() {
         _ctx_files_json=$(printf '%s' "$_ctx_files_json" | jq --arg f "$_cf" '. + [$f]')
     done
 
+    # Resolve the conversation before the header row, because the row is where
+    # the id becomes durable. "new" means one per run, except on a resume of a
+    # run that already has one: reusing it is the whole point of recording it.
+    # A literal id always wins, so an operator can redirect a resumed run.
+    local _run_conversation=""
+    if [[ -n "$SHELLM_RESPONSES_CONVERSATION" ]]; then
+        if [[ "$SHELLM_RESPONSES_CONVERSATION" != "new" ]]; then
+            _run_conversation="$SHELLM_RESPONSES_CONVERSATION"
+        elif [[ -n "$_resume_conversation" ]]; then
+            _run_conversation="$_resume_conversation"
+            progress "Reusing conversation $_run_conversation from the resumed run"
+        else
+            local _conv_tool _conv_json _conv_err
+            _conv_tool=$(resolve_shellm_tool_path "$_SHELLM_SCRIPT_PATH" "responses" || true)
+            [[ -n "$_conv_tool" ]] \
+                || die "SHELLM_RESPONSES_CONVERSATION=new needs bin/responses, which was not found next to bin/shellm"
+            _conv_err=$(mktemp)
+            _conv_json=$("$_conv_tool" conversations create \
+                --metadata "$(jq -nc --arg run "$_run_traj_id" '{shellm_run: $run}')" \
+                2>"$_conv_err") || {
+                local _conv_msg=""
+                [[ -s "$_conv_err" ]] && _conv_msg=$(tail -c 500 "$_conv_err")
+                rm -f "$_conv_err"
+                die "could not create a Responses conversation: $_conv_msg"
+            }
+            rm -f "$_conv_err"
+            _run_conversation=$(printf '%s' "$_conv_json" | jq -r '.id // empty')
+            [[ -n "$_run_conversation" ]] \
+                || die "responses conversations create returned no conversation id"
+            progress "Created conversation $_run_conversation"
+        fi
+    fi
+
     # Write shellm-run step
     local _shellm_run_json
     _shellm_run_json=$(jq -nc \
@@ -2638,6 +2704,7 @@ run_loop() {
         --arg model "$SHELLM_MODEL" \
         --arg effort "$SHELLM_EFFORT" \
         --arg api_format "$SHELLM_API_FORMAT" \
+        --arg conversation "$_run_conversation" \
         --arg max_iter "${SHELLM_MAX_ITERATIONS:-}" \
         --arg max_tok "${SHELLM_MAX_TOKENS:-}" \
         --arg inactivity_timeout "$SHELLM_INACTIVITY_TIMEOUT" \
@@ -2648,6 +2715,7 @@ run_loop() {
         --arg launched_by "${SHELLM_LAUNCHED_BY:-}" \
         --arg wake "${SHELLM_WAKE:-}" \
         '{type:"shellm-run", command:$cmd, workdir:$wd, model:$model, effort:$effort, api_format:$api_format, max_iterations:$max_iter, max_tokens:$max_tok, inactivity_timeout:$inactivity_timeout, context_files:$ctx, env:$env, resumed:$resumed}
+         + (if $conversation == "" then {} else {conversation: $conversation} end)
          + (if $trigger == "" then {} else {trigger_step: $trigger} end)
          + (if $launched_by == "" then {} else {launched_by: $launched_by} end)
          + (if $wake == "" then {} else {wake: $wake} end)')
@@ -2666,22 +2734,31 @@ run_loop() {
     local SHELLM_RESPONSES_REPLAY_FILE=""
     local SHELLM_RESPONSES_CONTEXT_FILE=""
     local SHELLM_RESPONSES_STATELESS=0
+    local SHELLM_RESPONSES_CONVERSATION_ID=""
     if [[ "$SHELLM_API_FORMAT" == "responses" ]]; then
         SHELLM_RESPONSE_FILE="$rundir/.last_response.json"
-        SHELLM_RESPONSE_ID_FILE="$rundir/.response-id"
-        SHELLM_RESPONSES_DISABLED_FILE="$rundir/.continuation-disabled"
-        SHELLM_RESPONSES_REPLAY_FILE="$rundir/.responses-replay.json"
         SHELLM_RESPONSES_CONTEXT_FILE="$rundir/.responses-sent-ids.json"
-        ( umask 077; printf '[]' > "$SHELLM_RESPONSES_REPLAY_FILE" )
-        chmod 600 "$SHELLM_RESPONSES_REPLAY_FILE"
+        if [[ -n "$_run_conversation" ]]; then
+            # The conversation holds the history, so none of the local chain
+            # applies: no response id to carry, no replay to keep, and no
+            # fallback, because the operator asked for durable server state
+            # and there is nothing safe to quietly downgrade to.
+            SHELLM_RESPONSES_CONVERSATION_ID="$_run_conversation"
+        else
+            SHELLM_RESPONSE_ID_FILE="$rundir/.response-id"
+            SHELLM_RESPONSES_DISABLED_FILE="$rundir/.continuation-disabled"
+            SHELLM_RESPONSES_REPLAY_FILE="$rundir/.responses-replay.json"
+            ( umask 077; printf '[]' > "$SHELLM_RESPONSES_REPLAY_FILE" )
+            chmod 600 "$SHELLM_RESPONSES_REPLAY_FILE"
 
-        # OpenRouter documents /responses as stateless: store=true and a
-        # non-null previous_response_id are rejected. Native OpenAI and
-        # generic compatible endpoints optimistically use continuation and
-        # fall back to this same exact replay chain when needed.
-        if [[ "${LLM_PROVIDER:-}" == "openrouter" \
-            || ( -z "${LLM_PROVIDER:-}" && "$SHELLM_MODEL" == */* ) ]]; then
-            SHELLM_RESPONSES_STATELESS=1
+            # OpenRouter documents /responses as stateless: store=true and a
+            # non-null previous_response_id are rejected. Native OpenAI and
+            # generic compatible endpoints optimistically use continuation and
+            # fall back to this same exact replay chain when needed.
+            if [[ "${LLM_PROVIDER:-}" == "openrouter" \
+                || ( -z "${LLM_PROVIDER:-}" && "$SHELLM_MODEL" == */* ) ]]; then
+                SHELLM_RESPONSES_STATELESS=1
+            fi
         fi
     fi
 
@@ -3039,6 +3116,10 @@ exit \$__shellm_rc
             LLM_RESPONSES_BODY_FILE="$SHELLM_RESPONSES_BODY_FILE"
             SHELLM_RESPONSES_BACKGROUND="$SHELLM_RESPONSES_BACKGROUND"
             LLM_RESPONSES_BACKGROUND="$SHELLM_RESPONSES_BACKGROUND"
+            # The resolved id, never "new": a nested run inside the sandbox
+            # joins this run's conversation instead of creating its own.
+            SHELLM_RESPONSES_CONVERSATION="${SHELLM_RESPONSES_CONVERSATION_ID:-}"
+            LLM_RESPONSES_CONVERSATION="${SHELLM_RESPONSES_CONVERSATION_ID:-}"
             SHELLM_API_URL="$execution_api_url"
             LLM_API_URL="$execution_api_url"
             SHELLM_DOCKER_IMAGE="$SHELLM_DOCKER_IMAGE"

--- a/bin/shellm
+++ b/bin/shellm
@@ -98,6 +98,7 @@ SHELLM_API_TRANSPORT="${SHELLM_API_TRANSPORT:-https}"
 SHELLM_RESPONSES_BODY_FILE="${SHELLM_RESPONSES_BODY_FILE:-}"
 SHELLM_RESPONSES_BACKGROUND="${SHELLM_RESPONSES_BACKGROUND:-}"
 SHELLM_RESPONSES_COMPACT_THRESHOLD="${SHELLM_RESPONSES_COMPACT_THRESHOLD:-}"
+SHELLM_RESPONSES_COMPACT_MODE="${SHELLM_RESPONSES_COMPACT_MODE:-auto}"
 # Server-held conversation state instead of the process-local chain: "new"
 # creates one at run start, a conv_ id joins an existing one. The id is
 # durable on purpose (Conversations do not expire), so it is recorded in the
@@ -199,6 +200,11 @@ if [[ -n "$SHELLM_RESPONSES_BODY_FILE" ]]; then
     [[ -f "$SHELLM_RESPONSES_BODY_FILE" ]] \
         || die "SHELLM_RESPONSES_BODY_FILE not found: $SHELLM_RESPONSES_BODY_FILE"
     SHELLM_RESPONSES_BODY_FILE=$(realpath "$SHELLM_RESPONSES_BODY_FILE")
+    jq -e 'type == "object"' "$SHELLM_RESPONSES_BODY_FILE" >/dev/null 2>&1 \
+        || die "SHELLM_RESPONSES_BODY_FILE must contain a JSON object"
+    if jq -e '.conversation != null' "$SHELLM_RESPONSES_BODY_FILE" >/dev/null; then
+        die "body-file conversation is not supported by shellm; use SHELLM_RESPONSES_CONVERSATION instead"
+    fi
 fi
 case "$SHELLM_RESPONSES_BACKGROUND" in
     ""|0|1) ;;
@@ -208,6 +214,10 @@ if [[ -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ]]; then
     [[ "$SHELLM_RESPONSES_COMPACT_THRESHOLD" =~ ^[1-9][0-9]*$ ]] \
         || die "Invalid SHELLM_RESPONSES_COMPACT_THRESHOLD: $SHELLM_RESPONSES_COMPACT_THRESHOLD (expected a positive integer)"
 fi
+case "$SHELLM_RESPONSES_COMPACT_MODE" in
+    auto|server|standalone) ;;
+    *) die "Invalid SHELLM_RESPONSES_COMPACT_MODE (expected auto, server, or standalone)" ;;
+esac
 if [[ -n "$SHELLM_RESPONSES_CONVERSATION" ]]; then
     # Conversations are a Responses-only container, and an operator who asked
     # for durable server state under Chat Completions has a configuration
@@ -391,23 +401,30 @@ Environment:
                           whole run through tools/responses-ws
   SHELLM_RESPONSES_BODY_FILE
                           Optional Responses create-body JSON object passed to
-                          llm (tools, include, store, text format, etc.)
+                          llm (tools, include, store, text format, etc.). A body
+                          conversation is refused; use the dedicated setting
   SHELLM_RESPONSES_BACKGROUND
                           1 runs each Responses create in the background
                           (llm polls or resumes the stream, and cancels the
                           job if killed); 0 forces foreground
   SHELLM_RESPONSES_COMPACT_THRESHOLD
                           Input-token count at which the Responses window is
-                          compacted. Stateful runs pass it to llm and the
-                          server compacts inside the turn; replay runs
-                          (OpenRouter, ZDR, after a continuation fallback)
-                          call the compact endpoint and swap the chain for
-                          the window it returns
+                          compacted (opt-in; unset disables automatic upkeep)
+  SHELLM_RESPONSES_COMPACT_MODE
+                          auto (default): native OpenAI uses server compaction,
+                          including store=false replay; other providers use
+                          standalone compact. server declares endpoint support;
+                          standalone forces replay and uses /responses/compact.
+                          A failed standalone call disables upkeep for this run
   SHELLM_RESPONSES_CONVERSATION
                           new, or a conv_ id: keep the turns in a server-side
                           Conversation instead of the process-local chain.
                           new creates one per run, the id is recorded in the
-                          run header, and --resume of that run reuses it
+                          run header. --resume/--traj reuses it with new or an
+                          empty/unset value; a different literal id redirects.
+                          Private acknowledgements live under SHELLM_TRAJ_DIR;
+                          ambiguous delivery or stale locks require reconciliation.
+                          Generated child calls do not inherit the Conversation
   SHELLM_EMPTY_RESPONSE_RETRIES
                           Empty-response retries before the run dies
                           (default 8; set empty for unlimited)
@@ -1632,15 +1649,42 @@ execute_code() {
 # LLM API call (delegates to the `llm` tool)
 # ---------------------------------------------------------------------------
 
+# Conversation checkpoints are private, atomic files. A mkdir lock is held for
+# the whole run; it is never stolen, including after a crash. An in-flight
+# checkpoint means delivery is unknown and requires operator reconciliation.
+# There is deliberately no automatic retry or inferred acknowledgement.
+conversation_checkpoint() {
+    local state="$1" ids_file="$2" tmp
+    [[ -n "${SHELLM_CONVERSATION_CHECKPOINT:-}" ]] || return 0
+    tmp=$(mktemp "${SHELLM_CONVERSATION_CHECKPOINT}.XXXXXX") || return 1
+    chmod 600 "$tmp" || { rm -f "$tmp"; return 1; }
+    if jq -n --arg state "$state" --slurpfile ids "$ids_file" \
+        --arg conversation "$SHELLM_RESPONSES_CONVERSATION_ID" \
+        --arg trajectory "$_SHELLM_CONVERSATION_TRAJECTORY" \
+        --arg provider "$_SHELLM_HOST_PROVIDER" --arg endpoint "$SHELLM_API_URL" \
+        '{version:1,state:$state,conversation:$conversation,trajectory:$trajectory,
+          provider:$provider,endpoint:$endpoint,sent:$ids[0]}' > "$tmp"; then
+        mv -f "$tmp" "$SHELLM_CONVERSATION_CHECKPOINT"
+    else
+        rm -f "$tmp"
+        return 1
+    fi
+}
+
+release_conversation_lock() {
+    [[ -z "${_SHELLM_CONVERSATION_LOCK:-}" ]] \
+        || rmdir "$_SHELLM_CONVERSATION_LOCK" 2>/dev/null || true
+}
+
 # Compaction upkeep for the process-local replay chain, run once per terminal
 # response. Two independent things happen here. A server that compacted inside
 # the turn returns a compaction item in the output, and the API says that item
 # is where the next window starts, so everything before it is dropped. Then, in
-# replay mode only, nobody is compacting on our behalf: once the reported input
+# standalone mode only: once the reported input
 # tokens reach SHELLM_RESPONSES_COMPACT_THRESHOLD we call the compact endpoint
 # and swap the chain for the window it hands back, which must be sent as is.
 # A failed compact call is not fatal. The chain is still correct, only longer,
-# and the next crossing tries again.
+# and standalone compaction is disabled for the rest of this run.
 compact_replay_chain() {
     local replay_file="$1" response_file="$2" replay_mode="$3"
     local replay_dir chain_tmp
@@ -1650,33 +1694,49 @@ compact_replay_chain() {
     if jq -e 'any(.output[]?; .type == "compaction")' "$response_file" >/dev/null 2>&1; then
         chain_tmp=$(mktemp "$replay_dir/.responses-replay.XXXXXX") || return 0
         chmod 600 "$chain_tmp"
-        if jq '(map(.type? == "compaction") | index(true)) as $at
+        if jq '(map(.type? == "compaction") | rindex(true)) as $at
                | if $at == null then . else .[$at:] end' \
                 "$replay_file" > "$chain_tmp" 2>/dev/null; then
             mv -f "$chain_tmp" "$replay_file"
         else
             rm -f "$chain_tmp"
         fi
+        # The server already compacted this turn; its pre-compaction usage
+        # must not immediately trigger another standalone compaction.
+        return 0
     fi
 
-    [[ "$replay_mode" -eq 1 && -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ]] || return 0
+    [[ "${_SHELLM_COMPACT_MODE:-auto}" == standalone \
+        && "$replay_mode" -eq 1 && -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" \
+        && ! -e "$replay_dir/.compact-disabled" ]] || return 0
     local input_tokens
     input_tokens=$(jq -r '.usage.input_tokens // empty' "$response_file" 2>/dev/null || true)
     [[ "$input_tokens" =~ ^[0-9]+$ ]] || return 0
     [[ "$input_tokens" -ge "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ]] || return 0
 
+    local compact_max_time="${LLM_MAX_TIME:-600}"
+    if [[ "$compact_max_time" =~ ^[0-9]+$ && "$compact_max_time" -gt 0 ]]; then
+        compact_max_time=$((compact_max_time - SECONDS + ${_call_started:-$SECONDS}))
+        if [[ "$compact_max_time" -le 0 ]]; then
+            echo "shellm: warning: no completion deadline budget remains for compaction; keeping replay chain" >&2
+            return 0
+        fi
+    fi
     progress "compacting the Responses replay chain at $input_tokens input tokens"
     local compact_out compact_err
     compact_out=$(mktemp) || return 0
     compact_err=$(mktemp) || { rm -f "$compact_out"; return 0; }
-    if ! responses compact --model "$SHELLM_MODEL" --input-file "$replay_file" \
+    if ! LLM_MAX_TIME="$compact_max_time" responses compact --provider "$_SHELLM_HOST_PROVIDER" \
+            --model "$SHELLM_MODEL" --input-file "$replay_file" --instructions "$system_prompt" \
             > "$compact_out" 2> "$compact_err"; then
-        echo "shellm: warning: compaction failed, keeping the replay chain: $(tail -c 300 "$compact_err")" >&2
+        echo "shellm: warning: compaction failed, keeping the replay chain; disabling standalone compaction for this run" >&2
+        ( umask 077; : > "$replay_dir/.compact-disabled" )
         rm -f "$compact_out" "$compact_err"
         return 0
     fi
     if ! jq -e '.output | type == "array" and length > 0' "$compact_out" >/dev/null 2>&1; then
         echo "shellm: warning: compaction failed, the compact reply carried no window" >&2
+        ( umask 077; : > "$replay_dir/.compact-disabled" )
         rm -f "$compact_out" "$compact_err"
         return 0
     fi
@@ -1694,6 +1754,7 @@ compact_replay_chain() {
 call_llm() {
     local system_prompt="$1"
     local full_messages_json="$2"
+    local _call_started=$SECONDS
     local thinking_output_file="${3:-}"
     local messages_are_delta="${4:-0}"
     local api_format="${SHELLM_API_FORMAT:-chat}"
@@ -1708,9 +1769,8 @@ call_llm() {
     local new_messages_json="$full_messages_json"
     local previous_response_id=""
     local fallback_used=0
-    # Set once the run is replaying the chain itself rather than continuing by
-    # response id. Compaction splits on it: the server can only compact what it
-    # holds, so a replaying run has to call the compact endpoint on its own.
+    # Continuation and compaction capability are independent: native OpenAI
+    # can compact input-array replay even when store=false.
     local replay_mode=0
 
     export LLM_API_FORMAT="$api_format"
@@ -1761,9 +1821,14 @@ call_llm() {
         # eventually resend it. Growth is a few dozen bytes per turn.
         local seen_src=/dev/null sent_ids_json='{}'
         [[ -n "$context_file" && -s "$context_file" ]] && seen_src="$context_file"
+        local conversation_has_history=0
+        if [[ -n "$conversation" && "$seen_src" != /dev/null ]] \
+            && jq -e 'length > 0' "$seen_src" >/dev/null; then
+            conversation_has_history=1
+        fi
         if [[ "$messages_are_delta" != "1" \
             && ( -n "$previous_response_id" || "$replay_has_history" -eq 1 \
-                 || ( -n "$conversation" && "$seen_src" != /dev/null ) ) ]]; then
+                 || "$conversation_has_history" -eq 1 ) ]]; then
             [[ "$seen_src" != /dev/null ]] \
                 || die "Responses continuation context is missing"
             new_messages_json=$(printf '%s' "$full_messages_json" | jq -c --slurpfile seen_file "$seen_src" '
@@ -1776,7 +1841,7 @@ call_llm() {
             sent_ids_json=$(printf '%s' "$full_messages_json" | jq -c --slurpfile seen_file "$seen_src" '
                 ($seen_file[0] // {}) as $seen
                 | $seen + ([.[] | .step_ids[]?] | map({key: ., value: true}) | from_entries)
-            ')
+            ') || die "could not compute Responses sent-step acknowledgement"
         fi
         # Nothing past this line may carry step_ids to a provider.
         full_messages_json=$(printf '%s' "$full_messages_json" | jq -c 'map(del(.step_ids))')
@@ -1795,8 +1860,8 @@ call_llm() {
         fi
     else
         unset LLM_RESPONSE_FILE LLM_RESPONSES_BODY_FILE LLM_PREVIOUS_RESPONSE_ID \
-            LLM_RESPONSES_BACKGROUND LLM_RESPONSES_COMPACT_THRESHOLD 2>/dev/null || true
-            LLM_RESPONSES_BACKGROUND LLM_RESPONSES_CONVERSATION 2>/dev/null || true
+            LLM_RESPONSES_BACKGROUND LLM_RESPONSES_COMPACT_THRESHOLD \
+            LLM_RESPONSES_CONVERSATION 2>/dev/null || true
     fi
 
     while true; do
@@ -1823,15 +1888,17 @@ call_llm() {
             else
                 unset LLM_PREVIOUS_RESPONSE_ID 2>/dev/null || true
             fi
-            # Server-side compaction only makes sense while the server holds
-            # the window. A replaying run keeps its own chain, so it asks for
-            # nothing here and compacts after the turn instead.
-            if [[ "$replay_mode" -eq 0 && -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ]]; then
+            if [[ "${_SHELLM_COMPACT_MODE:-auto}" == server && -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ]]; then
                 export LLM_RESPONSES_COMPACT_THRESHOLD="$SHELLM_RESPONSES_COMPACT_THRESHOLD"
             else
                 unset LLM_RESPONSES_COMPACT_THRESHOLD 2>/dev/null || true
             fi
             [[ -z "$response_file" ]] || rm -f "$response_file"
+        fi
+
+        if [[ -n "$conversation" ]]; then
+            conversation_checkpoint in_flight "$context_file" \
+                || die "could not persist Conversation in-flight state; no request sent"
         fi
 
         # Run llm, capturing stdout to text_file and stderr to stderr_file.
@@ -1856,7 +1923,9 @@ call_llm() {
         if [[ "$llm_exit" -eq 0 ]]; then
             if [[ "$api_format" == "responses" ]] \
                 && { [[ -z "$response_file" || ! -s "$response_file" ]] \
-                    || ! jq -e '.status == "completed" or .status == "incomplete"' \
+                    || ! jq -e '(.status == "completed" or .status == "incomplete")
+                        and .error == null and (.id | type == "string" and length > 0)
+                        and (.output | type == "array")' \
                         "$response_file" >/dev/null 2>&1; }; then
                 rm -f "$text_file" "$stderr_file" "$messages_file"
                 die "llm returned Responses output without a terminal response"
@@ -1890,10 +1959,16 @@ call_llm() {
                     context_dir=$(dirname "$context_file")
                     mkdir -p "$context_dir"
                     chmod 700 "$context_dir" 2>/dev/null || true
-                    context_tmp=$(mktemp "$context_dir/.responses-sent-ids.XXXXXX")
-                    chmod 600 "$context_tmp"
-                    printf '%s' "$sent_ids_json" > "$context_tmp"
-                    mv -f "$context_tmp" "$context_file"
+                    context_tmp=$(mktemp "$context_dir/.responses-sent-ids.XXXXXX") \
+                        || die "could not allocate Responses acknowledgement"
+                    chmod 600 "$context_tmp" \
+                        && printf '%s' "$sent_ids_json" > "$context_tmp" \
+                        && mv -f "$context_tmp" "$context_file" \
+                        || die "could not persist Responses acknowledgement; reconciliation required"
+                fi
+                if [[ -n "$conversation" ]]; then
+                    conversation_checkpoint ready "$context_file" \
+                        || die "could not acknowledge Conversation delivery; reconciliation required"
                 fi
 
                 local terminal_response_id
@@ -1935,7 +2010,11 @@ call_llm() {
         if [[ "$api_format" == "responses" && -n "$previous_response_id" \
             && "$fallback_used" -eq 0 && -n "$response_file" && -s "$response_file" \
             && ! -s "$text_file" ]] \
-            && jq -e '[.error.param?,.error.code?,.error.message?,.param?,.code?,.message?,.detail?]
+            && jq -e 'select(.id == null and .status == null
+                         and .error.code != "outcome_unknown" and .code != "outcome_unknown")
+                      | (.error // .) as $e
+                      | select($e.type == "invalid_request_error" or $e.code == "previous_response_not_found")
+                      | [.error.param?,.error.code?,.error.message?,.param?,.code?,.message?,.detail?]
                       | map(select(. != null) | tostring | ascii_downcase) | join(" ")
                       | test("previous[ _]response[ _]id|previous response")' \
                 "$response_file" >/dev/null 2>&1; then
@@ -2426,6 +2505,9 @@ ${combined}"
     rm -f "$_prompt_tmp"
 
     local text
+    # Summaries are independent calls, never a turn in the run's Conversation.
+    unset LLM_RESPONSES_CONVERSATION LLM_PREVIOUS_RESPONSE_ID LLM_RESPONSE_FILE
+    export LLM_RESPONSES_BODY_FILE="$SHELLM_RESPONSES_BODY_FILE"
     text=$(llm -m "$summary_model" -t 2048 \
         -s "You produce concise summaries as JSON. Output only valid JSON. No markdown fences. No preamble." \
         -M "$msg_json" 2>/dev/null) || true
@@ -2495,6 +2577,59 @@ run_loop() {
     local context_files=("$@")
     local num_files=${#context_files[@]}
 
+    # Resolve the underlying provider after --model parsing, before lifecycle
+    # operations, summary generation, or the transport's adapter override.
+    if [[ -z "$_SHELLM_HOST_PROVIDER" ]]; then
+        case "$SHELLM_MODEL" in
+            claude-*) _SHELLM_HOST_PROVIDER=anthropic ;;
+            gpt-*|o1*|o3*|o4*|chatgpt-*) _SHELLM_HOST_PROVIDER=openai ;;
+            gemini-*) _SHELLM_HOST_PROVIDER=gemini ;;
+            opencode-go/*) _SHELLM_HOST_PROVIDER=opencode-go ;;
+            opencode/*) _SHELLM_HOST_PROVIDER=opencode ;;
+            */*) _SHELLM_HOST_PROVIDER=openrouter ;;
+        esac
+    fi
+    local _SHELLM_COMPACT_MODE="$SHELLM_RESPONSES_COMPACT_MODE"
+    if [[ "$_SHELLM_COMPACT_MODE" == auto ]]; then
+        _SHELLM_COMPACT_MODE=standalone
+        if [[ "$_SHELLM_HOST_PROVIDER" == openai \
+            && ( -z "$SHELLM_API_URL" || "$(_shellm_url_host "$SHELLM_API_URL")" == api.openai.com ) ]]; then
+            _SHELLM_COMPACT_MODE=server
+        fi
+    fi
+    if [[ "$SHELLM_API_FORMAT" == responses ]]; then
+        case "$_SHELLM_HOST_PROVIDER" in
+            openai|openai-compatible|openrouter|adapter) ;;
+            *) die "Responses format is not supported for this provider" ;;
+        esac
+    fi
+    if [[ "$SHELLM_API_TRANSPORT" == websocket ]]; then
+        case "$_SHELLM_HOST_PROVIDER" in
+            openai|openai-compatible) ;;
+            *) die "SHELLM_API_TRANSPORT=websocket does not support this provider" ;;
+        esac
+        [[ -z "${LLM_OR_ONLY:-}${LLM_OR_ZDR:-}${LLM_OR_DATA_COLLECTION:-}" ]] \
+            || die "WebSocket transport does not support OpenRouter routing/privacy options"
+        [[ -z "${RESPONSES_WS_URL:-}" ]] \
+            || die "shellm WebSocket transport uses SHELLM_API_URL/LLM_API_URL, not RESPONSES_WS_URL, so lifecycle and completion share a destination"
+        if [[ -n "$SHELLM_RESPONSES_BODY_FILE" ]]; then
+            jq -e --arg background "$SHELLM_RESPONSES_BACKGROUND" \
+                '($background == "0" or .background == null or .background == false)
+                and (has("provider") | not) and (has("stream_options") | not)' \
+                "$SHELLM_RESPONSES_BODY_FILE" >/dev/null \
+                || die "WebSocket body configuration does not support background, provider, or stream_options; remove these options or use HTTPS"
+        fi
+        case "$SHELLM_RESPONSES_BACKGROUND" in
+            ""|0) ;;
+            *) die "WebSocket transport does not support background Responses" ;;
+        esac
+        export RESPONSES_WS_PROVIDER="$_SHELLM_HOST_PROVIDER"
+        # The broker validates endpoint/auth and effective body policy before
+        # exposing its socket. Pass the same configuration as each llm turn.
+        export LLM_RESPONSES_BODY_FILE="$SHELLM_RESPONSES_BODY_FILE"
+        export LLM_RESPONSES_BACKGROUND="$SHELLM_RESPONSES_BACKGROUND"
+    fi
+
     local rundir
     local workdir
     local messages_json
@@ -2530,7 +2665,7 @@ run_loop() {
         # not kill the run — jq exits 5 on a parse error and set -e would
         # abort silently. The || true shields against traj tail's SIGPIPE.
         local _orig_meta
-        _orig_meta=$(traj tail -n 50 --raw --traj_dir "$_run_traj_dir" "$_use_traj" \
+        _orig_meta=$(traj cat --raw --traj_dir "$_run_traj_dir" "$_use_traj" \
             | jq -cR 'fromjson? | select(.type=="shellm-run")' 2>/dev/null | tail -1) || true
         if [[ -n "$_orig_meta" ]]; then
             local _orig_workdir _orig_env _orig_image
@@ -2750,11 +2885,62 @@ run_loop() {
         _ctx_files_json=$(printf '%s' "$_ctx_files_json" | jq --arg f "$_cf" '. + [$f]')
     done
 
+    # Install early cleanup before starting the broker or taking a durable
+    # Conversation lock. Later startup failures must release our own lock.
+    _cleanup_rundir="$rundir"
+    _SHELLM_CONVERSATION_LOCK=""
+    early_responses_cleanup() {
+        release_conversation_lock
+        if [[ -n "${_SHELLM_WS_PID:-}" ]]; then
+            "$_SHELLM_WS_TOOL" stop --socket "$_SHELLM_WS_SOCKET" >/dev/null 2>&1 || true
+            kill "$_SHELLM_WS_PID" 2>/dev/null || true
+        fi
+        rm -rf "$_cleanup_rundir"
+    }
+    trap early_responses_cleanup EXIT
+
+    # Start/validate transport BEFORE any Conversation create or model call.
+    if [[ "$SHELLM_API_TRANSPORT" == "websocket" ]]; then
+        local _ws_tool
+        _ws_tool=$(resolve_shellm_tool_path "$_SHELLM_SCRIPT_PATH" "responses-ws" || true)
+        [[ -n "$_ws_tool" ]] \
+            || die "SHELLM_API_TRANSPORT=websocket needs tools/responses-ws, which was not found next to bin/shellm"
+        if head -n 1 "$_ws_tool" | grep -q 'uv run'; then
+            command -v uv >/dev/null 2>&1 \
+                || die "WebSocket transport requires uv; install uv or select SHELLM_API_TRANSPORT=https"
+        fi
+        _SHELLM_WS_SOCKET="$rundir/.responses-ws.sock"
+        _SHELLM_WS_TOOL="$_ws_tool"
+        "$_ws_tool" serve --socket "$_SHELLM_WS_SOCKET" \
+            > "$rundir/.responses-ws.log" 2>&1 &
+        _SHELLM_WS_PID=$!
+        local _ws_wait=0
+        while [[ ! -e "$_SHELLM_WS_SOCKET" && "$_ws_wait" -lt 60 ]]; do
+            kill -0 "$_SHELLM_WS_PID" 2>/dev/null || break
+            sleep 0.5
+            _ws_wait=$((_ws_wait + 1))
+        done
+        [[ -e "$_SHELLM_WS_SOCKET" ]] \
+            || die "responses-ws broker failed configuration/startup validation"
+        export LLM_PROVIDER=adapter
+        export LLM_ADAPTER="$_ws_tool"
+        export RESPONSES_WS_SOCKET="$_SHELLM_WS_SOCKET"
+    fi
+
     # Resolve the conversation before the header row, because the row is where
     # the id becomes durable. "new" means one per run, except on a resume of a
     # run that already has one: reusing it is the whole point of recording it.
     # A literal id always wins, so an operator can redirect a resumed run.
     local _run_conversation=""
+    # Empty/unset and "new" both reuse the latest header's Conversation on
+    # --resume/--traj. Use a different literal id to intentionally redirect.
+    if [[ "$SHELLM_API_FORMAT" == responses && -z "$SHELLM_RESPONSES_CONVERSATION" ]]; then
+        SHELLM_RESPONSES_CONVERSATION="$_resume_conversation"
+    fi
+    if [[ -n "$SHELLM_RESPONSES_CONVERSATION" \
+        && -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" && "$_SHELLM_COMPACT_MODE" == standalone ]]; then
+        die "Conversation compaction requires declared server support (SHELLM_RESPONSES_COMPACT_MODE=server)"
+    fi
     if [[ -n "$SHELLM_RESPONSES_CONVERSATION" ]]; then
         if [[ "$SHELLM_RESPONSES_CONVERSATION" != "new" ]]; then
             _run_conversation="$SHELLM_RESPONSES_CONVERSATION"
@@ -2767,7 +2953,7 @@ run_loop() {
             [[ -n "$_conv_tool" ]] \
                 || die "SHELLM_RESPONSES_CONVERSATION=new needs bin/responses, which was not found next to bin/shellm"
             _conv_err=$(mktemp)
-            _conv_json=$("$_conv_tool" conversations create \
+            _conv_json=$("$_conv_tool" conversations create --provider "$_SHELLM_HOST_PROVIDER" \
                 --metadata "$(jq -nc --arg run "$_run_traj_id" '{shellm_run: $run}')" \
                 2>"$_conv_err") || {
                 local _conv_msg=""
@@ -2780,6 +2966,43 @@ run_loop() {
             [[ -n "$_run_conversation" ]] \
                 || die "responses conversations create returned no conversation id"
             progress "Created conversation $_run_conversation"
+        fi
+    fi
+
+    local SHELLM_CONVERSATION_CHECKPOINT=""
+    local SHELLM_RESPONSES_CONVERSATION_ID="$_run_conversation"
+    local _SHELLM_CONVERSATION_TRAJECTORY=""
+    if [[ -n "$_run_conversation" ]]; then
+        [[ "$_run_conversation" =~ ^conv_[A-Za-z0-9_-]+$ ]] \
+            || die "invalid Conversation id returned or configured"
+        _SHELLM_CONVERSATION_TRAJECTORY=$(traj show "$_run_traj_id" --traj_dir "$_run_traj_dir" \
+            | sed -n 's/^File:[[:space:]]*//p')
+        [[ -f "$_SHELLM_CONVERSATION_TRAJECTORY" ]] || die "cannot resolve Conversation trajectory"
+        _SHELLM_CONVERSATION_TRAJECTORY=$(realpath "$_SHELLM_CONVERSATION_TRAJECTORY")
+        local _ack_dir="$_run_traj_dir/.responses-conversations" _lock_path
+        ( umask 077; mkdir -p "$_ack_dir" )
+        chmod 700 "$_ack_dir"
+        _lock_path="$_ack_dir/$_run_conversation.lock"
+        ( umask 077; mkdir "$_lock_path" ) 2>/dev/null \
+            || die "Conversation is locked by another run or a crash; reconcile before reuse"
+        _SHELLM_CONVERSATION_LOCK="$_lock_path"
+        SHELLM_CONVERSATION_CHECKPOINT="$_ack_dir/$_run_conversation.json"
+        if [[ -e "$SHELLM_CONVERSATION_CHECKPOINT" ]]; then
+            jq -e --arg conv "$_run_conversation" --arg traj "$_SHELLM_CONVERSATION_TRAJECTORY" \
+                --arg provider "$_SHELLM_HOST_PROVIDER" --arg endpoint "$SHELLM_API_URL" \
+                '.version == 1 and .state == "ready" and .conversation == $conv
+                 and .trajectory == $traj and .provider == $provider and .endpoint == $endpoint
+                 and (.sent | type == "object") and ([.sent[] | . == true] | all)' \
+                "$SHELLM_CONVERSATION_CHECKPOINT" >/dev/null 2>&1 \
+                || die "Conversation checkpoint is ambiguous or belongs to another trajectory/provider; reconcile before reuse"
+        elif jq -neR --arg conv "$_run_conversation" \
+            'any(inputs | fromjson?; .type == "shellm-run" and .conversation == $conv)' \
+            < "$_SHELLM_CONVERSATION_TRAJECTORY" >/dev/null; then
+            die "Conversation acknowledgement is missing; reconcile before reuse or choose a different Conversation"
+        else
+            ( umask 077; printf '{}' > "$rundir/.initial-sent.json" )
+            conversation_checkpoint ready "$rundir/.initial-sent.json" \
+                || die "could not initialize Conversation acknowledgement"
         fi
     fi
 
@@ -2812,16 +3035,16 @@ run_loop() {
     local _run_step_id _prompt_step_id=""
     _run_step_id=$(printf '%s' "$_shellm_run_json" | traj append --traj_dir "$_run_traj_dir" "$_run_traj_id")
 
-    # Responses continuation belongs to this process only. A resumed shellm
-    # starts a fresh chain from its trajectory; remote response IDs and exact
-    # output-item replay state disappear with rundir at process cleanup.
+    # Non-Conversation continuation belongs to this process only. A resumed
+    # shellm starts a fresh chain from its trajectory; remote response IDs and
+    # exact output-item replay disappear with rundir. Conversation sent-step
+    # acknowledgements instead survive in the private checkpoint above.
     local SHELLM_RESPONSE_FILE=""
     local SHELLM_RESPONSE_ID_FILE=""
     local SHELLM_RESPONSES_DISABLED_FILE=""
     local SHELLM_RESPONSES_REPLAY_FILE=""
     local SHELLM_RESPONSES_CONTEXT_FILE=""
     local SHELLM_RESPONSES_STATELESS=0
-    local SHELLM_RESPONSES_CONVERSATION_ID=""
     if [[ "$SHELLM_API_FORMAT" == "responses" ]]; then
         SHELLM_RESPONSE_FILE="$rundir/.last_response.json"
         SHELLM_RESPONSES_CONTEXT_FILE="$rundir/.responses-sent-ids.json"
@@ -2831,6 +3054,7 @@ run_loop() {
             # fallback, because the operator asked for durable server state
             # and there is nothing safe to quietly downgrade to.
             SHELLM_RESPONSES_CONVERSATION_ID="$_run_conversation"
+            ( umask 077; jq '.sent' "$SHELLM_CONVERSATION_CHECKPOINT" > "$SHELLM_RESPONSES_CONTEXT_FILE" )
         else
             SHELLM_RESPONSE_ID_FILE="$rundir/.response-id"
             SHELLM_RESPONSES_DISABLED_FILE="$rundir/.continuation-disabled"
@@ -2842,40 +3066,13 @@ run_loop() {
             # non-null previous_response_id are rejected. Native OpenAI and
             # generic compatible endpoints optimistically use continuation and
             # fall back to this same exact replay chain when needed.
-            if [[ "${LLM_PROVIDER:-}" == "openrouter" \
-                || ( -z "${LLM_PROVIDER:-}" && "$SHELLM_MODEL" == */* ) ]]; then
+            if [[ "$_SHELLM_HOST_PROVIDER" == openrouter \
+                || ( "$_SHELLM_COMPACT_MODE" == standalone && -n "$SHELLM_RESPONSES_COMPACT_THRESHOLD" ) ]] \
+                || { [[ -n "$SHELLM_RESPONSES_BODY_FILE" ]] \
+                     && jq -e '.store == false' "$SHELLM_RESPONSES_BODY_FILE" >/dev/null; }; then
                 SHELLM_RESPONSES_STATELESS=1
             fi
         fi
-    fi
-
-    # WebSocket transport: one connection for the whole run instead of one
-    # handshake per turn. The broker holds it and hands out stream_id lanes;
-    # llm reaches it through the adapter seam, so nothing in the completion
-    # path grows a Python dependency. The socket lives in rundir, which is
-    # already a private 0700 directory that disappears at cleanup.
-    if [[ "$SHELLM_API_TRANSPORT" == "websocket" ]]; then
-        local _ws_tool
-        _ws_tool=$(resolve_shellm_tool_path "$(realpath "$0")" "responses-ws" || true)
-        [[ -n "$_ws_tool" ]] \
-            || die "SHELLM_API_TRANSPORT=websocket needs tools/responses-ws, which was not found next to bin/shellm"
-        _SHELLM_WS_SOCKET="$rundir/.responses-ws.sock"
-        _SHELLM_WS_TOOL="$_ws_tool"
-        "$_ws_tool" serve --socket "$_SHELLM_WS_SOCKET" \
-            > "$rundir/.responses-ws.log" 2>&1 &
-        _SHELLM_WS_PID=$!
-        local _ws_wait=0
-        while [[ ! -e "$_SHELLM_WS_SOCKET" && "$_ws_wait" -lt 60 ]]; do
-            sleep 0.5
-            _ws_wait=$((_ws_wait + 1))
-        done
-        if [[ ! -e "$_SHELLM_WS_SOCKET" ]]; then
-            kill "$_SHELLM_WS_PID" 2>/dev/null || true
-            die "responses-ws broker did not open $_SHELLM_WS_SOCKET: $(tail -1 "$rundir/.responses-ws.log" 2>/dev/null)"
-        fi
-        export LLM_PROVIDER=adapter
-        export LLM_ADAPTER="$_ws_tool"
-        export RESPONSES_WS_SOCKET="$_SHELLM_WS_SOCKET"
     fi
 
     # Launcher opt-in: report this run's header step_id to the given file so
@@ -2915,6 +3112,7 @@ run_loop() {
     _cleanup_ctx_pid="${_ctx_summary_pid:-}"
     cleanup() {
         stop_activity_beacon
+        release_conversation_lock
         # Stop the WebSocket broker before rundir goes, so it can unlink its
         # own socket and close the upstream connection rather than being
         # killed with a response still in flight.
@@ -3203,10 +3401,13 @@ exit \$__shellm_rc
             LLM_RESPONSES_BODY_FILE="$SHELLM_RESPONSES_BODY_FILE"
             SHELLM_RESPONSES_BACKGROUND="$SHELLM_RESPONSES_BACKGROUND"
             LLM_RESPONSES_BACKGROUND="$SHELLM_RESPONSES_BACKGROUND"
-            # The resolved id, never "new": a nested run inside the sandbox
-            # joins this run's conversation instead of creating its own.
-            SHELLM_RESPONSES_CONVERSATION="${SHELLM_RESPONSES_CONVERSATION_ID:-}"
-            LLM_RESPONSES_CONVERSATION="${SHELLM_RESPONSES_CONVERSATION_ID:-}"
+            # Child calls have independent context. Sharing the parent's
+            # Conversation would mutate server state behind its checkpoint.
+            SHELLM_RESPONSES_CONVERSATION=""
+            LLM_RESPONSES_CONVERSATION=""
+            LLM_PREVIOUS_RESPONSE_ID=""
+            LLM_RESPONSE_FILE=""
+            SHELLM_API_TRANSPORT=https
             SHELLM_API_URL="$execution_api_url"
             LLM_API_URL="$execution_api_url"
             SHELLM_DOCKER_IMAGE="$SHELLM_DOCKER_IMAGE"

--- a/bin/shellm
+++ b/bin/shellm
@@ -1661,7 +1661,7 @@ conversation_checkpoint() {
     if jq -n --arg state "$state" --slurpfile ids "$ids_file" \
         --arg conversation "$SHELLM_RESPONSES_CONVERSATION_ID" \
         --arg trajectory "$_SHELLM_CONVERSATION_TRAJECTORY" \
-        --arg provider "$_SHELLM_HOST_PROVIDER" --arg endpoint "$SHELLM_API_URL" \
+        --arg provider "$_SHELLM_HOST_PROVIDER" --arg endpoint "$_SHELLM_CONVERSATION_ENDPOINT" \
         '{version:1,state:$state,conversation:$conversation,trajectory:$trajectory,
           provider:$provider,endpoint:$endpoint,sent:$ids[0]}' > "$tmp"; then
         mv -f "$tmp" "$SHELLM_CONVERSATION_CHECKPOINT"
@@ -1669,6 +1669,24 @@ conversation_checkpoint() {
         rm -f "$tmp"
         return 1
     fi
+}
+
+# A compaction item is opaque, but it is not structureless: the Responses
+# contract gives it a type plus non-empty encrypted_content. Compatible
+# endpoints may omit an item id or preserve more surrounding input items, so
+# validate only the fields required to carry the opaque window forward. If a
+# reply contains several markers, every marker must be usable; otherwise the
+# newest malformed marker could still poison the next request.
+has_usable_compaction_window() {
+    local response_file="$1"
+    jq -e '
+        (.output | type == "array")
+        and ([.output[] | select(.type? == "compaction")] as $markers
+             | ($markers | length) > 0
+             and all($markers[];
+                 (.encrypted_content | type) == "string"
+                 and (.encrypted_content | length) > 0))
+    ' "$response_file" >/dev/null 2>&1
 }
 
 release_conversation_lock() {
@@ -1692,6 +1710,11 @@ compact_replay_chain() {
     replay_dir=$(dirname "$replay_file")
 
     if jq -e 'any(.output[]?; .type == "compaction")' "$response_file" >/dev/null 2>&1; then
+        if ! has_usable_compaction_window "$response_file"; then
+            echo "shellm: warning: response carried an unusable compaction item; keeping the replay chain and disabling compaction for this run" >&2
+            ( umask 077; : > "$replay_dir/.compact-disabled" )
+            return 0
+        fi
         chain_tmp=$(mktemp "$replay_dir/.responses-replay.XXXXXX") || return 0
         chmod 600 "$chain_tmp"
         if jq '(map(.type? == "compaction") | rindex(true)) as $at
@@ -1728,14 +1751,9 @@ compact_replay_chain() {
     compact_err=$(mktemp) || { rm -f "$compact_out"; return 0; }
     if ! LLM_MAX_TIME="$compact_max_time" responses compact --provider "$_SHELLM_HOST_PROVIDER" \
             --model "$SHELLM_MODEL" --input-file "$replay_file" --instructions "$system_prompt" \
-            > "$compact_out" 2> "$compact_err"; then
-        echo "shellm: warning: compaction failed, keeping the replay chain; disabling standalone compaction for this run" >&2
-        ( umask 077; : > "$replay_dir/.compact-disabled" )
-        rm -f "$compact_out" "$compact_err"
-        return 0
-    fi
-    if ! jq -e '.output | type == "array" and length > 0' "$compact_out" >/dev/null 2>&1; then
-        echo "shellm: warning: compaction failed, the compact reply carried no window" >&2
+            > "$compact_out" 2> "$compact_err" \
+            || ! has_usable_compaction_window "$compact_out"; then
+        echo "shellm: warning: compaction failed or returned an unusable compaction item; keeping the replay chain and disabling standalone compaction for this run" >&2
         ( umask 077; : > "$replay_dir/.compact-disabled" )
         rm -f "$compact_out" "$compact_err"
         return 0
@@ -1948,7 +1966,14 @@ call_llm() {
                     turn_tmp=$(mktemp)
                     chmod 600 "$replay_tmp"
                     printf '%s' "$new_messages_json" > "$turn_tmp"
-                    jq -s '.[0] + .[1] + (.[2].output // [])' \
+                    # Do not carry a malformed compaction marker into the
+                    # otherwise known-good replay. compact_replay_chain below
+                    # will warn and refuse pruning; ordinary output items from
+                    # the same terminal response remain part of the turn.
+                    jq -s '.[0] + .[1] + ((.[2].output // [])
+                        | map(select(.type? != "compaction"
+                            or ((.encrypted_content | type) == "string"
+                                and (.encrypted_content | length) > 0))))' \
                         "$replay_file" "$turn_tmp" "$response_file" > "$replay_tmp"
                     mv -f "$replay_tmp" "$replay_file"
                     rm -f "$turn_tmp"
@@ -2597,6 +2622,14 @@ run_loop() {
             _SHELLM_COMPACT_MODE=server
         fi
     fi
+    # Conversation ownership is keyed by the effective remote route, not by
+    # the caller-selected trajectory root. Spell provider defaults explicitly
+    # so an unset URL and its equivalent configured URL contend on one lock.
+    local _SHELLM_CONVERSATION_ENDPOINT="${SHELLM_API_URL%/}"
+    case "$_SHELLM_HOST_PROVIDER:$_SHELLM_CONVERSATION_ENDPOINT" in
+        openai:) _SHELLM_CONVERSATION_ENDPOINT="https://api.openai.com/v1/responses" ;;
+        openrouter:) _SHELLM_CONVERSATION_ENDPOINT="https://openrouter.ai/api/v1/responses" ;;
+    esac
     if [[ "$SHELLM_API_FORMAT" == responses ]]; then
         case "$_SHELLM_HOST_PROVIDER" in
             openai|openai-compatible|openrouter|adapter) ;;
@@ -2982,14 +3015,33 @@ run_loop() {
         local _ack_dir="$_run_traj_dir/.responses-conversations" _lock_path
         ( umask 077; mkdir -p "$_ack_dir" )
         chmod 700 "$_ack_dir"
-        _lock_path="$_ack_dir/$_run_conversation.lock"
+        # Checkpoints remain trajectory-bound, but the ownership lock lives in
+        # the canonical state home. Hash the route because endpoints may carry
+        # unsafe path/query bytes (and credentials must never appear in names).
+        local _lock_root="$_shellm_home/run/responses-conversations"
+        local _lock_identity _lock_digest
+        ( umask 077; mkdir -p "$_lock_root" )
+        chmod 700 "$_lock_root"
+        _lock_identity=$(jq -nc --arg provider "$_SHELLM_HOST_PROVIDER" \
+            --arg endpoint "$_SHELLM_CONVERSATION_ENDPOINT" \
+            --arg conversation "$_run_conversation" \
+            '[$provider,$endpoint,$conversation]')
+        if command -v sha256sum >/dev/null 2>&1; then
+            _lock_digest=$(printf '%s' "$_lock_identity" | sha256sum)
+        elif command -v shasum >/dev/null 2>&1; then
+            _lock_digest=$(printf '%s' "$_lock_identity" | shasum -a 256)
+        else
+            die "Conversation locking requires sha256sum or shasum"
+        fi
+        _lock_digest=${_lock_digest%%[[:space:]]*}
+        _lock_path="$_lock_root/$_run_conversation-$_lock_digest.lock"
         ( umask 077; mkdir "$_lock_path" ) 2>/dev/null \
             || die "Conversation is locked by another run or a crash; reconcile before reuse"
         _SHELLM_CONVERSATION_LOCK="$_lock_path"
         SHELLM_CONVERSATION_CHECKPOINT="$_ack_dir/$_run_conversation.json"
         if [[ -e "$SHELLM_CONVERSATION_CHECKPOINT" ]]; then
             jq -e --arg conv "$_run_conversation" --arg traj "$_SHELLM_CONVERSATION_TRAJECTORY" \
-                --arg provider "$_SHELLM_HOST_PROVIDER" --arg endpoint "$SHELLM_API_URL" \
+                --arg provider "$_SHELLM_HOST_PROVIDER" --arg endpoint "$_SHELLM_CONVERSATION_ENDPOINT" \
                 '.version == 1 and .state == "ready" and .conversation == $conv
                  and .trajectory == $traj and .provider == $provider and .endpoint == $endpoint
                  and (.sent | type == "object") and ([.sent[] | . == true] | all)' \
@@ -3209,7 +3261,15 @@ run_loop() {
                 --tail "$SHELLM_CONTEXT_RUN_TAIL" --tail-block "$SHELLM_CONTEXT_RUN_TAIL_BLOCK")
             [[ -n "$_prompt_step_id" ]] && _ctx_args+=(--pin "$_prompt_step_id")
         fi
-        messages_json=$(context "${_ctx_args[@]}" 2>/dev/null) || messages_json='[]'
+        if ! messages_json=$(context "${_ctx_args[@]}" 2>/dev/null); then
+            # A Conversation has no replay fallback: dispatching after a
+            # failed render would send none of the newly appended rows while
+            # leaving the ready acknowledgement unchanged. Keep that evidence
+            # and stop before call_llm can mark delivery in flight.
+            [[ -z "$_run_conversation" ]] \
+                || die "could not render Conversation context; no model call was dispatched"
+            messages_json='[]'
+        fi
 
         # Call Claude (capture thinking/reasoning to file)
         local thinking_file="$rundir/.last_thinking"

--- a/bin/shellm
+++ b/bin/shellm
@@ -1783,7 +1783,11 @@ call_llm() {
         if [[ "$api_format" == "responses" && -n "$previous_response_id" \
             && "$fallback_used" -eq 0 && -n "$response_file" && -s "$response_file" \
             && ! -s "$text_file" ]] \
-            && jq -e '[.error.param?,.error.code?,.error.message?,.param?,.code?,.message?,.detail?]
+            && jq -e 'select(.id == null and .status == null
+                         and .error.code != "outcome_unknown" and .code != "outcome_unknown")
+                      | (.error // .) as $e
+                      | select($e.type == "invalid_request_error" or $e.code == "previous_response_not_found")
+                      | [.error.param?,.error.code?,.error.message?,.param?,.code?,.message?,.detail?]
                       | map(select(. != null) | tostring | ascii_downcase) | join(" ")
                       | test("previous[ _]response[ _]id|previous response")' \
                 "$response_file" >/dev/null 2>&1; then

--- a/bin/shellm
+++ b/bin/shellm
@@ -1615,26 +1615,26 @@ call_llm() {
         # message that renders a row not yet sent; assistant rows are the
         # model's own turns, already held by previous_response_id or the
         # replay chain, and elision markers render no row at all.
-        # The set rides a file, not argv, and keeps insertion order capped
-        # well above the widest render window (SHELLM_CONTEXT_RUN_TAIL), so a
-        # long run cannot outgrow the OS's per-argument cap.
-        local seen_src=/dev/null sent_ids_json='[]'
+        # The set is a JSON object keyed by step id (constant-time lookup)
+        # that rides a file, not argv, and is never pruned: a pinned prompt
+        # renders on every call however old it is, so any eviction rule would
+        # eventually resend it. Growth is a few dozen bytes per turn.
+        local seen_src=/dev/null sent_ids_json='{}'
         [[ -n "$context_file" && -s "$context_file" ]] && seen_src="$context_file"
         if [[ "$messages_are_delta" != "1" \
             && ( -n "$previous_response_id" || "$replay_has_history" -eq 1 ) ]]; then
             [[ "$seen_src" != /dev/null ]] \
                 || die "Responses continuation context is missing"
             new_messages_json=$(printf '%s' "$full_messages_json" | jq -c --slurpfile seen_file "$seen_src" '
-                ($seen_file[0] // []) as $seen
+                ($seen_file[0] // {}) as $seen
                 | map(select(.role != "assistant"
-                             and ((.step_ids // []) | any(. as $s | ($seen | index($s)) == null))))
+                             and ((.step_ids // []) | any(. as $s | ($seen[$s] // false) | not))))
             ') || die "Responses continuation could not tell new rows from sent ones in the rendered context"
         fi
         if [[ "$messages_are_delta" != "1" ]]; then
             sent_ids_json=$(printf '%s' "$full_messages_json" | jq -c --slurpfile seen_file "$seen_src" '
-                ($seen_file[0] // []) as $seen
-                | ($seen + ([.[] | .step_ids[]?] | map(select(. as $s | ($seen | index($s)) == null)) | unique))
-                | .[-2000:]
+                ($seen_file[0] // {}) as $seen
+                | $seen + ([.[] | .step_ids[]?] | map({key: ., value: true}) | from_entries)
             ')
         fi
         # Nothing past this line may carry step_ids to a provider.

--- a/bin/shellm
+++ b/bin/shellm
@@ -1616,7 +1616,10 @@ call_llm() {
         local -a args=(-m "$SHELLM_MODEL"
             --effort "$SHELLM_EFFORT" --thinking --system-prompt "$system_prompt" --messages-file "$messages_file")
         [[ -n "$SHELLM_MAX_TOKENS" ]] && args+=(-t "$SHELLM_MAX_TOKENS")
-        [[ "${SHELLM_STOP_AFTER_CODE_BLOCK:-1}" == 1 ]] && args+=(--stop-after-code-block)
+        # Responses needs the terminal event (id, usage, status). Cutting the
+        # stream at the first fence would drop it and break continuation.
+        [[ "${SHELLM_STOP_AFTER_CODE_BLOCK:-1}" == 1 && "$api_format" != responses ]] \
+            && args+=(--stop-after-code-block)
 
         if [[ "$api_format" == "responses" ]]; then
             if [[ -n "$previous_response_id" ]]; then
@@ -1707,20 +1710,10 @@ call_llm() {
         # disabled so an endpoint cannot trap shellm in a fallback loop.
         if [[ "$api_format" == "responses" && -n "$previous_response_id" \
             && "$fallback_used" -eq 0 && -n "$response_file" && -s "$response_file" ]] \
-            && jq -e '
-                [
-                    .error.param?,
-                    .error.code?,
-                    .error.message?,
-                    .param?,
-                    .code?,
-                    .message?,
-                    .detail?
-                ]
-                | map(select(. != null) | tostring | ascii_downcase)
-                | join(" ")
-                | test("previous[ _]response[ _]id|previous response")
-            ' "$response_file" >/dev/null 2>&1; then
+            && jq -e '[.error.param?,.error.code?,.error.message?,.param?,.code?,.message?,.detail?]
+                      | map(select(. != null) | tostring | ascii_downcase) | join(" ")
+                      | test("previous[ _]response[ _]id|previous response")' \
+                "$response_file" >/dev/null 2>&1; then
             [[ -z "$response_id_file" ]] || rm -f "$response_id_file"
             if [[ -n "$disabled_file" ]]; then
                 local disabled_dir disabled_tmp

--- a/bin/shellm
+++ b/bin/shellm
@@ -71,6 +71,8 @@ SHELLM_MAX_CONSECUTIVE_FAILURES="${SHELLM_MAX_CONSECUTIVE_FAILURES:-10}"
 SHELLM_MAX_REPEAT_FAILURES="${SHELLM_MAX_REPEAT_FAILURES:-3}"
 SHELLM_TRUNCATE="${SHELLM_TRUNCATE:-2000}"
 SHELLM_API_URL="${SHELLM_API_URL:-}"
+SHELLM_API_FORMAT="${SHELLM_API_FORMAT:-chat}"
+SHELLM_RESPONSES_BODY_FILE="${SHELLM_RESPONSES_BODY_FILE:-}"
 # Clear any inherited LLM_API_URL so llm uses per-provider defaults
 unset LLM_API_URL 2>/dev/null || true
 if [[ -n "$SHELLM_API_URL" ]]; then
@@ -142,6 +144,16 @@ _SHELLM_EXTRA_BINS=()
 # ---------------------------------------------------------------------------
 
 die() { echo "shellm: error: $*" >&2; exit 1; }
+
+case "$SHELLM_API_FORMAT" in
+    chat|responses) ;;
+    *) die "Invalid SHELLM_API_FORMAT: $SHELLM_API_FORMAT (expected chat or responses)" ;;
+esac
+if [[ -n "$SHELLM_RESPONSES_BODY_FILE" ]]; then
+    [[ -f "$SHELLM_RESPONSES_BODY_FILE" ]] \
+        || die "SHELLM_RESPONSES_BODY_FILE not found: $SHELLM_RESPONSES_BODY_FILE"
+    SHELLM_RESPONSES_BODY_FILE=$(realpath "$SHELLM_RESPONSES_BODY_FILE")
+fi
 
 # A local model bound to the Docker host is usually configured as localhost
 # for thinkers and other llm calls that run on that host. Code executed in a
@@ -305,6 +317,13 @@ Environment:
   SHELLM_CONTEXT_WHOLE_BLOCKS
                           How many newest blocks get the larger limit (default
                           1); in traj scope, the newest N rows
+  SHELLM_API_FORMAT       Completion protocol: chat (default) or responses.
+                          Responses persists and reuses previous_response_id
+                          within a run, with one full-context fallback when a
+                          provider rejects continuation
+  SHELLM_RESPONSES_BODY_FILE
+                          Optional Responses create-body JSON object passed to
+                          llm (tools, include, store, text format, etc.)
   SHELLM_EMPTY_RESPONSE_RETRIES
                           Empty-response retries before the run dies
                           (default 8; set empty for unlimited)
@@ -1527,64 +1546,214 @@ execute_code() {
 
 call_llm() {
     local system_prompt="$1"
-    local messages_json="$2"
+    local full_messages_json="$2"
     local thinking_output_file="${3:-}"
+    local api_format="${SHELLM_API_FORMAT:-chat}"
+    local response_file="${SHELLM_RESPONSE_FILE:-}"
+    local response_id_file="${SHELLM_RESPONSE_ID_FILE:-}"
+    local disabled_file="${SHELLM_RESPONSES_DISABLED_FILE:-}"
+    local replay_file="${SHELLM_RESPONSES_REPLAY_FILE:-}"
+    local stateless="${SHELLM_RESPONSES_STATELESS:-0}"
+    local request_messages_json="$full_messages_json"
+    local new_messages_json="$full_messages_json"
+    local previous_response_id=""
+    local fallback_used=0
 
-    # The message array rides a file, not argv: a long conversation (or the
-    # empty-response retry's fed-back thinking) can exceed the OS's per-argument
-    # cap (128KB on Linux), and exec would die with E2BIG before the call.
-    local messages_file
-    messages_file=$(mktemp)
-    printf '%s' "$messages_json" > "$messages_file"
-
-    local -a args=(-m "$SHELLM_MODEL"
-        --effort "$SHELLM_EFFORT" --thinking --system-prompt "$system_prompt" --messages-file "$messages_file")
-    [[ -n "$SHELLM_MAX_TOKENS" ]] && args+=(-t "$SHELLM_MAX_TOKENS")
-    [[ "${SHELLM_STOP_AFTER_CODE_BLOCK:-1}" == 1 ]] && args+=(--stop-after-code-block)
-
-    local text_file stderr_file
-    text_file=$(mktemp)
-    stderr_file=$(mktemp)
-
-    # Run llm, capturing stdout to text_file and stderr to stderr_file.
-    # When not quiet, also tee stdout to stderr (for live display) and
-    # stderr to the terminal. Use a subshell to capture llm's exit code
-    # despite the pipeline.
-    local llm_exit=0
-    if [[ "$QUIET" -eq 0 ]]; then
-        { llm "${args[@]}" 2>"$stderr_file"; echo $? > "$text_file.rc"; } | tee "$text_file" >&2
-        llm_exit=$(cat "$text_file.rc" 2>/dev/null) || llm_exit=0
-        rm -f "$text_file.rc"
-        # Replay stderr (thinking output + errors) to terminal and thinking file
-        if [[ -s "$stderr_file" ]]; then
-            cat "$stderr_file" >&2
-            [[ -n "$thinking_output_file" ]] && cp "$stderr_file" "$thinking_output_file"
+    export LLM_API_FORMAT="$api_format"
+    if [[ "$api_format" == "responses" ]]; then
+        if [[ -n "$response_file" ]]; then
+            export LLM_RESPONSE_FILE="$response_file"
+        else
+            unset LLM_RESPONSE_FILE 2>/dev/null || true
+        fi
+        if [[ -n "${SHELLM_RESPONSES_BODY_FILE:-}" ]]; then
+            export LLM_RESPONSES_BODY_FILE="$SHELLM_RESPONSES_BODY_FILE"
+        else
+            unset LLM_RESPONSES_BODY_FILE 2>/dev/null || true
+        fi
+        local replay_has_history=0
+        if [[ -n "$replay_file" && -s "$replay_file" ]] \
+            && jq -e 'type == "array" and length > 0' "$replay_file" >/dev/null 2>&1; then
+            replay_has_history=1
+        fi
+        if [[ "$stateless" != "1" && -n "$response_id_file" && -f "$response_id_file" \
+            && ( -z "$disabled_file" || ! -e "$disabled_file" ) ]]; then
+            previous_response_id=$(cat "$response_id_file")
+        fi
+        if [[ -n "$previous_response_id" || "$replay_has_history" -eq 1 ]]; then
+            new_messages_json=$(printf '%s' "$full_messages_json" | jq '
+                . as $messages
+                | (reduce range(0; length) as $i
+                    (-1; if $messages[$i].role == "assistant" then $i else . end)) as $last_assistant
+                | $messages[($last_assistant + 1):]
+            ')
+        fi
+        if [[ "$stateless" == "1" || ( -n "$disabled_file" && -e "$disabled_file" ) ]]; then
+            if [[ "$replay_has_history" -eq 1 ]]; then
+                request_messages_json=$(printf '%s' "$new_messages_json" \
+                    | jq --slurpfile history "$replay_file" '($history[0] // []) + .')
+            else
+                request_messages_json="$new_messages_json"
+            fi
+        elif [[ -n "$previous_response_id" ]]; then
+            request_messages_json="$new_messages_json"
         fi
     else
-        llm "${args[@]}" > "$text_file" 2>"$stderr_file" || llm_exit=$?
-        [[ -n "$thinking_output_file" ]] && cp "$stderr_file" "$thinking_output_file"
+        unset LLM_RESPONSE_FILE LLM_RESPONSES_BODY_FILE LLM_PREVIOUS_RESPONSE_ID \
+            2>/dev/null || true
     fi
 
-    # A failed llm call must never yield its partial stream as a response:
-    # a truncated code block that still parses would get executed. Stall
-    # timeouts (bin/llm net guards) land here after llm's own retries.
-    if [[ "$llm_exit" -ne 0 ]]; then
+    while true; do
+        # The message array rides a file, not argv: a long conversation (or the
+        # empty-response retry's fed-back thinking) can exceed the OS's per-argument
+        # cap (128KB on Linux), and exec would die with E2BIG before the call.
+        local messages_file text_file stderr_file
+        messages_file=$(mktemp)
+        text_file=$(mktemp)
+        stderr_file=$(mktemp)
+        printf '%s' "$request_messages_json" > "$messages_file"
+
+        local -a args=(-m "$SHELLM_MODEL"
+            --effort "$SHELLM_EFFORT" --thinking --system-prompt "$system_prompt" --messages-file "$messages_file")
+        [[ -n "$SHELLM_MAX_TOKENS" ]] && args+=(-t "$SHELLM_MAX_TOKENS")
+        [[ "${SHELLM_STOP_AFTER_CODE_BLOCK:-1}" == 1 ]] && args+=(--stop-after-code-block)
+
+        if [[ "$api_format" == "responses" ]]; then
+            if [[ -n "$previous_response_id" ]]; then
+                export LLM_PREVIOUS_RESPONSE_ID="$previous_response_id"
+            else
+                unset LLM_PREVIOUS_RESPONSE_ID 2>/dev/null || true
+            fi
+            [[ -z "$response_file" ]] || rm -f "$response_file"
+        fi
+
+        # Run llm, capturing stdout to text_file and stderr to stderr_file.
+        # When not quiet, also tee stdout to stderr (for live display) and
+        # stderr to the terminal. Use a subshell to capture llm's exit code
+        # despite the pipeline.
+        local llm_exit=0
+        if [[ "$QUIET" -eq 0 ]]; then
+            { llm "${args[@]}" 2>"$stderr_file"; echo $? > "$text_file.rc"; } | tee "$text_file" >&2
+            llm_exit=$(cat "$text_file.rc" 2>/dev/null) || llm_exit=0
+            rm -f "$text_file.rc"
+            # Replay stderr (thinking output + errors) to terminal and thinking file
+            if [[ -s "$stderr_file" ]]; then
+                cat "$stderr_file" >&2
+                [[ -n "$thinking_output_file" ]] && cp "$stderr_file" "$thinking_output_file"
+            fi
+        else
+            llm "${args[@]}" > "$text_file" 2>"$stderr_file" || llm_exit=$?
+            [[ -n "$thinking_output_file" ]] && cp "$stderr_file" "$thinking_output_file"
+        fi
+
+        if [[ "$llm_exit" -eq 0 ]]; then
+            if [[ "$api_format" == "responses" && -n "$response_file" \
+                && -s "$response_file" ]] \
+                && jq -e '.status == "completed" or .status == "incomplete"' \
+                    "$response_file" >/dev/null 2>&1; then
+                # Keep an exact process-local replay chain in parallel with
+                # stateful continuation. It is the primary path for OpenRouter
+                # and the safe fallback for ZDR/expired compatible endpoints.
+                if [[ -n "$replay_file" ]]; then
+                    local replay_dir replay_tmp turn_tmp
+                    replay_dir=$(dirname "$replay_file")
+                    mkdir -p "$replay_dir"
+                    chmod 700 "$replay_dir" 2>/dev/null || true
+                    [[ -s "$replay_file" ]] \
+                        || { ( umask 077; printf '[]' > "$replay_file" ); chmod 600 "$replay_file"; }
+                    replay_tmp=$(mktemp "$replay_dir/.responses-replay.XXXXXX")
+                    turn_tmp=$(mktemp)
+                    chmod 600 "$replay_tmp"
+                    printf '%s' "$new_messages_json" > "$turn_tmp"
+                    jq -s '.[0] + .[1] + (.[2].output // [])' \
+                        "$replay_file" "$turn_tmp" "$response_file" > "$replay_tmp"
+                    mv -f "$replay_tmp" "$replay_file"
+                    rm -f "$turn_tmp"
+                fi
+
+                local terminal_response_id
+                terminal_response_id=$(jq -r '
+                    select((.status == "completed" or .status == "incomplete")
+                        and (.id | type == "string") and (.id | length > 0))
+                    | .id
+                ' "$response_file" 2>/dev/null || true)
+                if [[ "$stateless" != "1" && -n "$response_id_file" \
+                    && -n "$terminal_response_id" \
+                    && ( -z "$disabled_file" || ! -e "$disabled_file" ) ]]; then
+                    local id_dir id_tmp
+                    id_dir=$(dirname "$response_id_file")
+                    mkdir -p "$id_dir"
+                    chmod 700 "$id_dir" 2>/dev/null || true
+                    id_tmp=$(mktemp "$id_dir/.response-id.XXXXXX")
+                    chmod 600 "$id_tmp"
+                    printf '%s\n' "$terminal_response_id" > "$id_tmp"
+                    mv -f "$id_tmp" "$response_id_file"
+                fi
+            fi
+
+            # No visible text is not a failure. `llm --thinking` streams reasoning to
+            # stderr, and a run that spends its whole token budget there returns 200,
+            # exits 0 and emits nothing on stdout, which is exactly what run_loop's
+            # empty-response retry feeds back as assistant context. Real failures exit
+            # non-zero and are caught below.
+            cat "$text_file"
+            rm -f "$text_file" "$stderr_file" "$messages_file"
+            return 0
+        fi
+
+        # Providers may reject a previous_response_id after expiry or when a
+        # compatible endpoint does not implement continuation. Retry once with
+        # the exact input/output-item replay chain, then leave continuation
+        # disabled so an endpoint cannot trap shellm in a fallback loop.
+        if [[ "$api_format" == "responses" && -n "$previous_response_id" \
+            && "$fallback_used" -eq 0 && -n "$response_file" && -s "$response_file" ]] \
+            && jq -e '
+                [
+                    .error.param?,
+                    .error.code?,
+                    .error.message?,
+                    .message?,
+                    .detail?
+                ]
+                | map(select(. != null) | tostring | ascii_downcase)
+                | join(" ")
+                | test("previous[ _]response[ _]id|previous response")
+            ' "$response_file" >/dev/null 2>&1; then
+            [[ -z "$response_id_file" ]] || rm -f "$response_id_file"
+            if [[ -n "$disabled_file" ]]; then
+                local disabled_dir disabled_tmp
+                disabled_dir=$(dirname "$disabled_file")
+                mkdir -p "$disabled_dir"
+                chmod 700 "$disabled_dir" 2>/dev/null || true
+                disabled_tmp=$(mktemp "$disabled_dir/.continuation-disabled.XXXXXX")
+                chmod 600 "$disabled_tmp"
+                printf 'provider rejected previous_response_id\n' > "$disabled_tmp"
+                mv -f "$disabled_tmp" "$disabled_file"
+            fi
+            previous_response_id=""
+            unset LLM_PREVIOUS_RESPONSE_ID 2>/dev/null || true
+            if [[ -n "$replay_file" && -s "$replay_file" ]] \
+                && jq -e 'type == "array" and length > 0' "$replay_file" >/dev/null 2>&1; then
+                request_messages_json=$(printf '%s' "$new_messages_json" \
+                    | jq --slurpfile history "$replay_file" '($history[0] // []) + .')
+            else
+                request_messages_json="$full_messages_json"
+            fi
+            fallback_used=1
+            rm -f "$text_file" "$stderr_file" "$messages_file"
+            [[ -z "$thinking_output_file" ]] || : > "$thinking_output_file"
+            progress "responses continuation rejected; retrying once with exact replay context"
+            continue
+        fi
+
+        # A failed llm call must never yield its partial stream as a response:
+        # a truncated code block that still parses would get executed. Stall
+        # timeouts (bin/llm net guards) land here after llm's own retries.
         local _llm_err=""
         [[ -s "$stderr_file" ]] && _llm_err=$(tail -c 500 "$stderr_file")
         rm -f "$text_file" "$stderr_file" "$messages_file"
         die "llm failed (exit $llm_exit): $_llm_err"
-    fi
-
-    # No visible text is not a failure. `llm --thinking` streams reasoning to
-    # stderr, and a run that spends its whole token budget there returns 200,
-    # exits 0 and emits nothing on stdout, which is exactly what run_loop's
-    # empty-response retry feeds back as assistant context. Dying on a
-    # non-empty stderr here made that retry unreachable and printed the
-    # model's reasoning as an error. Real failures exit non-zero and are
-    # caught above.
-
-    cat "$text_file"
-    rm -f "$text_file" "$stderr_file" "$messages_file"
+    done
 }
 
 # ---------------------------------------------------------------------------
@@ -2350,6 +2519,7 @@ run_loop() {
         --arg wd "$workdir" \
         --arg model "$SHELLM_MODEL" \
         --arg effort "$SHELLM_EFFORT" \
+        --arg api_format "$SHELLM_API_FORMAT" \
         --arg max_iter "${SHELLM_MAX_ITERATIONS:-}" \
         --arg max_tok "${SHELLM_MAX_TOKENS:-}" \
         --arg inactivity_timeout "$SHELLM_INACTIVITY_TIMEOUT" \
@@ -2359,7 +2529,7 @@ run_loop() {
         --arg trigger "${SHELLM_TRIGGER_STEP_ID:-}" \
         --arg launched_by "${SHELLM_LAUNCHED_BY:-}" \
         --arg wake "${SHELLM_WAKE:-}" \
-        '{type:"shellm-run", command:$cmd, workdir:$wd, model:$model, effort:$effort, max_iterations:$max_iter, max_tokens:$max_tok, inactivity_timeout:$inactivity_timeout, context_files:$ctx, env:$env, resumed:$resumed}
+        '{type:"shellm-run", command:$cmd, workdir:$wd, model:$model, effort:$effort, api_format:$api_format, max_iterations:$max_iter, max_tokens:$max_tok, inactivity_timeout:$inactivity_timeout, context_files:$ctx, env:$env, resumed:$resumed}
          + (if $trigger == "" then {} else {trigger_step: $trigger} end)
          + (if $launched_by == "" then {} else {launched_by: $launched_by} end)
          + (if $wake == "" then {} else {wake: $wake} end)')
@@ -2368,6 +2538,33 @@ run_loop() {
     # interleave in one shared trajectory)
     local _run_step_id _prompt_step_id=""
     _run_step_id=$(printf '%s' "$_shellm_run_json" | traj append --traj_dir "$_run_traj_dir" "$_run_traj_id")
+
+    # Responses continuation belongs to this process only. A resumed shellm
+    # starts a fresh chain from its trajectory; remote response IDs and exact
+    # output-item replay state disappear with rundir at process cleanup.
+    local SHELLM_RESPONSE_FILE=""
+    local SHELLM_RESPONSE_ID_FILE=""
+    local SHELLM_RESPONSES_DISABLED_FILE=""
+    local SHELLM_RESPONSES_REPLAY_FILE=""
+    local SHELLM_RESPONSES_STATELESS=0
+    if [[ "$SHELLM_API_FORMAT" == "responses" ]]; then
+        SHELLM_RESPONSE_FILE="$rundir/.last_response.json"
+        SHELLM_RESPONSE_ID_FILE="$rundir/.response-id"
+        SHELLM_RESPONSES_DISABLED_FILE="$rundir/.continuation-disabled"
+        SHELLM_RESPONSES_REPLAY_FILE="$rundir/.responses-replay.json"
+        ( umask 077; printf '[]' > "$SHELLM_RESPONSES_REPLAY_FILE" )
+        chmod 600 "$SHELLM_RESPONSES_REPLAY_FILE"
+
+        # OpenRouter documents /responses as stateless: store=true and a
+        # non-null previous_response_id are rejected. Native OpenAI and
+        # generic compatible endpoints optimistically use continuation and
+        # fall back to this same exact replay chain when needed.
+        if [[ "${LLM_PROVIDER:-}" == "openrouter" \
+            || ( -z "${LLM_PROVIDER:-}" && "$SHELLM_MODEL" == */* ) ]]; then
+            SHELLM_RESPONSES_STATELESS=1
+        fi
+    fi
+
     # Launcher opt-in: report this run's header step_id to the given file so
     # the caller can pair its own steps with this exact run — the trajectory
     # alone can't tell whose header is whose when concurrent runs interleave.
@@ -2640,6 +2837,10 @@ exit \$__shellm_rc
             SHELLM_MAX_ITERATIONS="$SHELLM_MAX_ITERATIONS"
             SHELLM_EFFORT="$SHELLM_EFFORT"
             SHELLM_TRUNCATE="$SHELLM_TRUNCATE"
+            SHELLM_API_FORMAT="$SHELLM_API_FORMAT"
+            LLM_API_FORMAT="$SHELLM_API_FORMAT"
+            SHELLM_RESPONSES_BODY_FILE="$SHELLM_RESPONSES_BODY_FILE"
+            LLM_RESPONSES_BODY_FILE="$SHELLM_RESPONSES_BODY_FILE"
             SHELLM_API_URL="$execution_api_url"
             LLM_API_URL="$execution_api_url"
             SHELLM_DOCKER_IMAGE="$SHELLM_DOCKER_IMAGE"

--- a/bin/shellm
+++ b/bin/shellm
@@ -1084,8 +1084,12 @@ docker_setup() {
         fi
     fi
 
-    # Build mount flags for -f file directories.
-    for f in "${context_files[@]+"${context_files[@]}"}"; do
+    # Build mount flags for -f file directories, and for the Responses create
+    # body file, which nested llm/shellm calls inside the container read at
+    # the same absolute path.
+    local -a _ro_files=("${context_files[@]+"${context_files[@]}"}")
+    [[ -n "$SHELLM_RESPONSES_BODY_FILE" ]] && _ro_files+=("$SHELLM_RESPONSES_BODY_FILE")
+    for f in "${_ro_files[@]+"${_ro_files[@]}"}"; do
         local abs_path abs_dir
         abs_path=$(realpath "$f")
         abs_dir=$(dirname "$abs_path")
@@ -1604,23 +1608,39 @@ call_llm() {
             && ( -z "$disabled_file" || ! -e "$disabled_file" ) ]]; then
             previous_response_id=$(cat "$response_id_file")
         fi
+        # Rows already sent are known by step id (context --ids), never by
+        # rendered bytes: the render shrinks a row as it ages out of the
+        # newest block and slides its window, so byte prefixes drift while
+        # the rows themselves have not changed. New input is every user-side
+        # message that renders a row not yet sent; assistant rows are the
+        # model's own turns, already held by previous_response_id or the
+        # replay chain, and elision markers render no row at all.
+        # The set rides a file, not argv, and keeps insertion order capped
+        # well above the widest render window (SHELLM_CONTEXT_RUN_TAIL), so a
+        # long run cannot outgrow the OS's per-argument cap.
+        local seen_src=/dev/null sent_ids_json='[]'
+        [[ -n "$context_file" && -s "$context_file" ]] && seen_src="$context_file"
         if [[ "$messages_are_delta" != "1" \
             && ( -n "$previous_response_id" || "$replay_has_history" -eq 1 ) ]]; then
-            [[ -n "$context_file" && -s "$context_file" ]] \
+            [[ "$seen_src" != /dev/null ]] \
                 || die "Responses continuation context is missing"
-            new_messages_json=$(printf '%s' "$full_messages_json" | jq --slurpfile previous "$context_file" '
-                ($previous[0] // null) as $prior
-                | if ($prior | type) != "array" or type != "array"
-                    or .[0:($prior | length)] != $prior
-                  then error("previous Responses context is not a prefix of the rendered context")
-                  else .[($prior | length):]
-                  end
-                | . as $new
-                | (reduce range(0; length) as $i
-                    (0; if . == $i and $new[$i].role == "assistant" then . + 1 else . end)) as $start
-                | $new[$start:]
-            ') || die "Responses continuation boundary fell outside the rendered context; increase SHELLM_CONTEXT_RUN_TAIL"
+            new_messages_json=$(printf '%s' "$full_messages_json" | jq -c --slurpfile seen_file "$seen_src" '
+                ($seen_file[0] // []) as $seen
+                | map(select(.role != "assistant"
+                             and ((.step_ids // []) | any(. as $s | ($seen | index($s)) == null))))
+            ') || die "Responses continuation could not tell new rows from sent ones in the rendered context"
         fi
+        if [[ "$messages_are_delta" != "1" ]]; then
+            sent_ids_json=$(printf '%s' "$full_messages_json" | jq -c --slurpfile seen_file "$seen_src" '
+                ($seen_file[0] // []) as $seen
+                | ($seen + ([.[] | .step_ids[]?] | map(select(. as $s | ($seen | index($s)) == null)) | unique))
+                | .[-2000:]
+            ')
+        fi
+        # Nothing past this line may carry step_ids to a provider.
+        full_messages_json=$(printf '%s' "$full_messages_json" | jq -c 'map(del(.step_ids))')
+        new_messages_json=$(printf '%s' "$new_messages_json" | jq -c 'map(del(.step_ids))')
+        request_messages_json="$full_messages_json"
         if [[ "$stateless" == "1" || ( -n "$disabled_file" && -e "$disabled_file" ) ]]; then
             if [[ "$replay_has_history" -eq 1 ]]; then
                 request_messages_json=$(printf '%s' "$new_messages_json" \
@@ -1718,9 +1738,9 @@ call_llm() {
                     context_dir=$(dirname "$context_file")
                     mkdir -p "$context_dir"
                     chmod 700 "$context_dir" 2>/dev/null || true
-                    context_tmp=$(mktemp "$context_dir/.responses-context.XXXXXX")
+                    context_tmp=$(mktemp "$context_dir/.responses-sent-ids.XXXXXX")
                     chmod 600 "$context_tmp"
-                    printf '%s' "$full_messages_json" > "$context_tmp"
+                    printf '%s' "$sent_ids_json" > "$context_tmp"
                     mv -f "$context_tmp" "$context_file"
                 fi
 
@@ -1758,8 +1778,11 @@ call_llm() {
         # compatible endpoint does not implement continuation. Retry once with
         # the exact input/output-item replay chain, then leave continuation
         # disabled so an endpoint cannot trap shellm in a fallback loop.
+        # A rejection can only precede generation, so a call that already
+        # emitted text is not one; that text is discarded and the run fails.
         if [[ "$api_format" == "responses" && -n "$previous_response_id" \
-            && "$fallback_used" -eq 0 && -n "$response_file" && -s "$response_file" ]] \
+            && "$fallback_used" -eq 0 && -n "$response_file" && -s "$response_file" \
+            && ! -s "$text_file" ]] \
             && jq -e '[.error.param?,.error.code?,.error.message?,.param?,.code?,.message?,.detail?]
                       | map(select(. != null) | tostring | ascii_downcase) | join(" ")
                       | test("previous[ _]response[ _]id|previous response")' \
@@ -2612,7 +2635,7 @@ run_loop() {
         SHELLM_RESPONSE_ID_FILE="$rundir/.response-id"
         SHELLM_RESPONSES_DISABLED_FILE="$rundir/.continuation-disabled"
         SHELLM_RESPONSES_REPLAY_FILE="$rundir/.responses-replay.json"
-        SHELLM_RESPONSES_CONTEXT_FILE="$rundir/.responses-context.json"
+        SHELLM_RESPONSES_CONTEXT_FILE="$rundir/.responses-sent-ids.json"
         ( umask 077; printf '[]' > "$SHELLM_RESPONSES_REPLAY_FILE" )
         chmod 600 "$SHELLM_RESPONSES_REPLAY_FILE"
 
@@ -2734,6 +2757,11 @@ run_loop() {
             --exclude-types "shellm-run,run-summary"
             --full-types prompt
             --block-limit "$SHELLM_CONTEXT_BLOCK_LIMIT" --whole-blocks "$SHELLM_CONTEXT_WHOLE_BLOCKS")
+        # Responses continuation tells new rows from re-rendered ones by id
+        # (call_llm), one row per message so a sent row and a new one never
+        # share a message (Responses needs no role alternation); chat context
+        # stays byte-identical.
+        [[ "$SHELLM_API_FORMAT" == "responses" ]] && _ctx_args+=(--ids --no-merge)
         if [[ "$SHELLM_CONTEXT_SCOPE" == "run" ]]; then
             _ctx_args+=(--run "$_run_step_id" --head 0
                 --tail "$SHELLM_CONTEXT_RUN_TAIL" --tail-block "$SHELLM_CONTEXT_RUN_TAIL_BLOCK")

--- a/bin/shellm
+++ b/bin/shellm
@@ -1712,6 +1712,8 @@ call_llm() {
                     .error.param?,
                     .error.code?,
                     .error.message?,
+                    .param?,
+                    .code?,
                     .message?,
                     .detail?
                 ]
@@ -2704,41 +2706,64 @@ run_loop() {
         fi
         rm -f "$thinking_file"
 
-        # Retry on empty response: feed captured thinking back as assistant
-        # context so the model continues from where it left off (max_tokens
-        # gets hit during thinking before any visible output is emitted).
+        # Retry on empty Chat output by feeding captured thinking back as
+        # assistant context. Responses mode keeps reasoning in the terminal
+        # Response item: continue from its ID/exact replay instead of inventing
+        # an assistant message containing a reasoning summary.
         # Default: 8 retries; SHELLM_EMPTY_RESPONSE_RETRIES overrides (set it
         # to the empty string for unlimited).
         local empty_retries=0
         local max_empty_retries="${SHELLM_EMPTY_RESPONSE_RETRIES-8}"
         local retry_messages_json="$messages_json"
         while [[ -z "$response" ]]; do
+            if [[ "$SHELLM_API_FORMAT" == "responses" ]]; then
+                if [[ -z "${SHELLM_RESPONSE_FILE:-}" || ! -s "$SHELLM_RESPONSE_FILE" ]]; then
+                    die "Empty Responses output without a terminal Response object"
+                fi
+                if jq -e '.output[]? | select(.type == "function_call")' \
+                    "$SHELLM_RESPONSE_FILE" >/dev/null 2>&1; then
+                    die "Responses returned function calls without visible shellm output; consume them through LLM_RESPONSE_FILE"
+                fi
+                if ! jq -e '
+                    .status == "incomplete"
+                    and .incomplete_details.reason == "max_output_tokens"
+                ' "$SHELLM_RESPONSE_FILE" >/dev/null 2>&1; then
+                    local response_status
+                    response_status=$(jq -r '.status // "unknown"' \
+                        "$SHELLM_RESPONSE_FILE" 2>/dev/null || printf 'unknown')
+                    die "Empty Responses output with terminal status $response_status"
+                fi
+            fi
             if [[ -n "$max_empty_retries" && "$empty_retries" -ge "$max_empty_retries" ]]; then
                 break
             fi
             empty_retries=$((empty_retries + 1))
-            # llm's own stderr lines ("llm: warning: output truncated...")
-            # arrive mixed into the captured thinking; they are harness noise,
-            # not the model's reasoning, and must not become assistant content.
-            local feedback
-            feedback=$(printf '%s\n' "$thinking" | grep -Ev '^llm: (warning|note): ') || feedback=""
-            if [[ -n "$feedback" ]]; then
-                progress "Empty response — feeding thinking back to continue (retry $empty_retries${max_empty_retries:+/$max_empty_retries})..."
-                debug "empty_response_retry: fed back ${#feedback} chars of thinking"
-                # --rawfile, not --arg: a full-budget thinking block can exceed
-                # the OS's 128KB per-argument cap.
-                local feedback_file
-                feedback_file=$(mktemp)
-                printf '%s' "$feedback" > "$feedback_file"
-                retry_messages_json=$(printf '%s' "$retry_messages_json" | jq \
-                    --rawfile t "$feedback_file" \
-                    '. + [{"role":"assistant","content":$t},{"role":"user","content":"Your previous response ran out of output tokens during the reasoning above before you could emit any visible text. Continue from where you left off and produce the bash code for the next step now."}]')
-                rm -f "$feedback_file"
-                sleep 1
+            if [[ "$SHELLM_API_FORMAT" == "responses" ]]; then
+                progress "Incomplete Responses output — continuing from terminal response state (retry $empty_retries${max_empty_retries:+/$max_empty_retries})..."
+                retry_messages_json='[{"role":"user","content":"Continue from the incomplete response and emit the bash code for the next step."}]'
             else
-                progress "Empty response from API (retry $empty_retries${max_empty_retries:+/$max_empty_retries})..."
-                sleep 1
+                # llm's own stderr lines ("llm: warning: output truncated...")
+                # arrive mixed into the captured thinking; they are harness noise,
+                # not the model's reasoning, and must not become assistant content.
+                local feedback
+                feedback=$(printf '%s\n' "$thinking" | grep -Ev '^llm: (warning|note): ') || feedback=""
+                if [[ -n "$feedback" ]]; then
+                    progress "Empty response — feeding thinking back to continue (retry $empty_retries${max_empty_retries:+/$max_empty_retries})..."
+                    debug "empty_response_retry: fed back ${#feedback} chars of thinking"
+                    # --rawfile, not --arg: a full-budget thinking block can exceed
+                    # the OS's 128KB per-argument cap.
+                    local feedback_file
+                    feedback_file=$(mktemp)
+                    printf '%s' "$feedback" > "$feedback_file"
+                    retry_messages_json=$(printf '%s' "$retry_messages_json" | jq \
+                        --rawfile t "$feedback_file" \
+                        '. + [{"role":"assistant","content":$t},{"role":"user","content":"Your previous response ran out of output tokens during the reasoning above before you could emit any visible text. Continue from where you left off and produce the bash code for the next step now."}]')
+                    rm -f "$feedback_file"
+                else
+                    progress "Empty response from API (retry $empty_retries${max_empty_retries:+/$max_empty_retries})..."
+                fi
             fi
+            sleep 1
 
             : > "$thinking_file"
             response=$(call_llm "$system_prompt" "$retry_messages_json" "$thinking_file")

--- a/bin/shellm
+++ b/bin/shellm
@@ -1548,11 +1548,13 @@ call_llm() {
     local system_prompt="$1"
     local full_messages_json="$2"
     local thinking_output_file="${3:-}"
+    local messages_are_delta="${4:-0}"
     local api_format="${SHELLM_API_FORMAT:-chat}"
     local response_file="${SHELLM_RESPONSE_FILE:-}"
     local response_id_file="${SHELLM_RESPONSE_ID_FILE:-}"
     local disabled_file="${SHELLM_RESPONSES_DISABLED_FILE:-}"
     local replay_file="${SHELLM_RESPONSES_REPLAY_FILE:-}"
+    local context_file="${SHELLM_RESPONSES_CONTEXT_FILE:-}"
     local stateless="${SHELLM_RESPONSES_STATELESS:-0}"
     local request_messages_json="$full_messages_json"
     local new_messages_json="$full_messages_json"
@@ -1580,13 +1582,22 @@ call_llm() {
             && ( -z "$disabled_file" || ! -e "$disabled_file" ) ]]; then
             previous_response_id=$(cat "$response_id_file")
         fi
-        if [[ -n "$previous_response_id" || "$replay_has_history" -eq 1 ]]; then
-            new_messages_json=$(printf '%s' "$full_messages_json" | jq '
-                . as $messages
+        if [[ "$messages_are_delta" != "1" \
+            && ( -n "$previous_response_id" || "$replay_has_history" -eq 1 ) ]]; then
+            [[ -n "$context_file" && -s "$context_file" ]] \
+                || die "Responses continuation context is missing"
+            new_messages_json=$(printf '%s' "$full_messages_json" | jq --slurpfile previous "$context_file" '
+                ($previous[0] // null) as $prior
+                | if ($prior | type) != "array" or type != "array"
+                    or .[0:($prior | length)] != $prior
+                  then error("previous Responses context is not a prefix of the rendered context")
+                  else .[($prior | length):]
+                  end
+                | . as $new
                 | (reduce range(0; length) as $i
-                    (-1; if $messages[$i].role == "assistant" then $i else . end)) as $last_assistant
-                | $messages[($last_assistant + 1):]
-            ')
+                    (0; if . == $i and $new[$i].role == "assistant" then . + 1 else . end)) as $start
+                | $new[$start:]
+            ') || die "Responses continuation boundary fell outside the rendered context; increase SHELLM_CONTEXT_RUN_TAIL"
         fi
         if [[ "$stateless" == "1" || ( -n "$disabled_file" && -e "$disabled_file" ) ]]; then
             if [[ "$replay_has_history" -eq 1 ]]; then
@@ -1650,6 +1661,13 @@ call_llm() {
         fi
 
         if [[ "$llm_exit" -eq 0 ]]; then
+            if [[ "$api_format" == "responses" ]] \
+                && { [[ -z "$response_file" || ! -s "$response_file" ]] \
+                    || ! jq -e '.status == "completed" or .status == "incomplete"' \
+                        "$response_file" >/dev/null 2>&1; }; then
+                rm -f "$text_file" "$stderr_file" "$messages_file"
+                die "llm returned Responses output without a terminal response"
+            fi
             if [[ "$api_format" == "responses" && -n "$response_file" \
                 && -s "$response_file" ]] \
                 && jq -e '.status == "completed" or .status == "incomplete"' \
@@ -1672,6 +1690,16 @@ call_llm() {
                         "$replay_file" "$turn_tmp" "$response_file" > "$replay_tmp"
                     mv -f "$replay_tmp" "$replay_file"
                     rm -f "$turn_tmp"
+                fi
+                if [[ -n "$context_file" && "$messages_are_delta" != "1" ]]; then
+                    local context_dir context_tmp
+                    context_dir=$(dirname "$context_file")
+                    mkdir -p "$context_dir"
+                    chmod 700 "$context_dir" 2>/dev/null || true
+                    context_tmp=$(mktemp "$context_dir/.responses-context.XXXXXX")
+                    chmod 600 "$context_tmp"
+                    printf '%s' "$full_messages_json" > "$context_tmp"
+                    mv -f "$context_tmp" "$context_file"
                 fi
 
                 local terminal_response_id
@@ -2541,12 +2569,14 @@ run_loop() {
     local SHELLM_RESPONSE_ID_FILE=""
     local SHELLM_RESPONSES_DISABLED_FILE=""
     local SHELLM_RESPONSES_REPLAY_FILE=""
+    local SHELLM_RESPONSES_CONTEXT_FILE=""
     local SHELLM_RESPONSES_STATELESS=0
     if [[ "$SHELLM_API_FORMAT" == "responses" ]]; then
         SHELLM_RESPONSE_FILE="$rundir/.last_response.json"
         SHELLM_RESPONSE_ID_FILE="$rundir/.response-id"
         SHELLM_RESPONSES_DISABLED_FILE="$rundir/.continuation-disabled"
         SHELLM_RESPONSES_REPLAY_FILE="$rundir/.responses-replay.json"
+        SHELLM_RESPONSES_CONTEXT_FILE="$rundir/.responses-context.json"
         ( umask 077; printf '[]' > "$SHELLM_RESPONSES_REPLAY_FILE" )
         chmod 600 "$SHELLM_RESPONSES_REPLAY_FILE"
 
@@ -2759,7 +2789,7 @@ run_loop() {
             sleep 1
 
             : > "$thinking_file"
-            response=$(call_llm "$system_prompt" "$retry_messages_json" "$thinking_file")
+            response=$(call_llm "$system_prompt" "$retry_messages_json" "$thinking_file" 1)
 
             thinking=""
             if [[ -s "$thinking_file" ]]; then

--- a/bin/thinkers
+++ b/bin/thinkers
@@ -344,6 +344,7 @@ _start_dispatcher() {
 
     # Start dispatcher in background
     (
+        unset HEADLONG_START_LOCKED
         trap '_cleanup_dispatcher' EXIT
         trap '_dispatcher_on_signal INT' INT
         trap '_dispatcher_on_signal TERM' TERM
@@ -1092,9 +1093,28 @@ _ensure_shellm_bins() {
 # Subcommands
 # ---------------------------------------------------------------------------
 
+_jobs_tool() {
+    local own_bin
+    own_bin=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+    if [[ -x "$own_bin/../tools/headlong-jobs" ]]; then
+        printf '%s\n' "$own_bin/../tools/headlong-jobs"
+    else
+        command -v headlong-jobs || die "headlong-jobs not installed"
+    fi
+}
+
 cmd_start() {
+    if [[ "${1:-}" == "--jobs-only" ]]; then
+        [[ $# -eq 1 ]] || die "--jobs-only cannot start legacy thinkers"
+        _ensure_shellm_bins
+        exec "$(_jobs_tool)" start
+    fi
+    [[ ! -f "$IDENTITY_DIR/jobs/mode.json" ]] || die "Identity uses durable jobs; start with --jobs-only"
     _require_env
     _ensure_shellm_bins
+    if [[ "${HEADLONG_START_LOCKED:-}" != "1" ]]; then
+        exec "$(_jobs_tool)" _legacy-start bash "${BASH_SOURCE[0]}" start "$@"
+    fi
 
     # Parse start-specific flags
     while [[ $# -gt 0 ]]; do
@@ -1279,6 +1299,11 @@ _drain_all_then_finish() {
 }
 
 cmd_stop() {
+    if [[ -f "$IDENTITY_DIR/jobs/mode.json" ]]; then
+        [[ $# -eq 0 ]] || die "Use thinkers jobs cancel JOB_ID for exact job cancellation"
+        _ensure_shellm_bins
+        exec "$(_jobs_tool)" stop
+    fi
     _require_env
 
     local run_dir="$IDENTITY_DIR/run"
@@ -1743,6 +1768,8 @@ usage() {
 thinkers — Modular reactive thought process manager
 
 Usage:
+  thinkers start --jobs-only   Start the exclusive durable application-job dispatcher
+  thinkers jobs <command>      Durable register/admit/get/list/cancel/recover/attempt API
   thinkers start [--no-self-trigger] [name ...]
                                Start all thinkers (or specific ones by name)
   thinkers stop [name ...] [--force] [--self] [--drain-timeout N]
@@ -1796,6 +1823,7 @@ cmd="${1:-}"
 [[ -n "$cmd" ]] && shift
 
 case "$cmd" in
+    jobs)     _ensure_shellm_bins; exec "$(_jobs_tool)" "$@" ;;
     start)    cmd_start "$@" ;;
     stop)     cmd_stop "$@" ;;
     status)   cmd_status ;;

--- a/design/providers.md
+++ b/design/providers.md
@@ -58,8 +58,9 @@ llm -m qwen3:8b "hello"
 | Variable | Meaning |
 |---|---|
 | `LLM_PROVIDER=openai-compatible` | Selects the provider (or pass `--provider openai-compatible`) |
-| `LLM_API_URL` | The chat-completions endpoint. Required, no default |
+| `LLM_API_URL` | The exact chat-completions or Responses endpoint. Required, no default |
 | `LLM_API_KEY` | Optional. When set, sent as `Authorization: Bearer` |
+| `LLM_API_FORMAT` | `chat` (default) or `responses` |
 
 What "compatible" means here, concretely: a chat-completions endpoint
 that accepts `model`, `messages`, and `max_tokens`; non-streaming
@@ -69,6 +70,15 @@ by `data: [DONE]`; and errors as non-2xx responses with a JSON body.
 That subset is what the code exercises and the tests pin. An endpoint
 that diverges from it is best effort — it may well work, but the
 divergence is not a core bug to absorb.
+
+With `LLM_API_FORMAT=responses`, compatibility instead means the synchronous
+OpenAI Responses create protocol at the exact configured URL: typed `input`
+items, terminal `output` items and status, Responses SSE events, and structured
+errors. `LLM_RESPONSES_BODY_FILE` carries create fields beyond the completion
+CLI's stable flags, while `LLM_RESPONSE_FILE` receives the full terminal object
+or error envelope. Server-side lifecycle operations (retrieve, cancel, delete,
+Conversations, background jobs, and WebSocket sessions) are not part of this
+completion-provider seam.
 
 `LLM_PROVIDER` is process-wide by design (decided 2026-08-26:
 environment overrides are authoritative, never pattern-guessed around),

--- a/design/providers.md
+++ b/design/providers.md
@@ -117,6 +117,17 @@ The contract, implemented by the invoker in `bin/llm` (pinned by
   [LEVEL]`, and `--no-stream`. The system prompt arrives via
   `--system-prompt-file PATH`. The messages array (the same JSON shape
   `llm -M` takes) arrives on stdin.
+- `LLM_API_FORMAT=responses` is legal for the adapter provider. `bin/llm`
+  then adds `--api-format responses` to the argv, and stdin carries typed
+  Responses `input` items rather than a chat messages array. The adapter
+  owes the Responses contract in return: text deltas on stdout, reasoning
+  summary deltas on stderr, the terminal Response object or error envelope
+  written to `LLM_RESPONSE_FILE` (atomic, mode 0600), and the same reading
+  of `LLM_PREVIOUS_RESPONSE_ID` and `LLM_RESPONSES_BODY_FILE` that
+  `bin/llm`'s own builder does, including the caller's body as the base and
+  the always-requested `reasoning.encrypted_content`. Those three variables
+  are exported to the adapter. Chat adapters never see `--api-format`.
+  `tools/responses-ws` is the adapter this exists for.
 - The adapter writes response text to stdout, streamed as it is
   produced, and diagnostics to stderr. It exits 0 on success and
   nonzero on failure with a one-line reason on stderr. It must not

--- a/design/responses-api.md
+++ b/design/responses-api.md
@@ -58,19 +58,24 @@ terminal response from `response.completed`, `response.incomplete`, or
 Incomplete responses warn with their reason. Failed responses and `error`
 events fail the call.
 
-Retries remain legal only before protocol output is emitted. A terminal output
-item counts as output even when it is a function call with no visible text.
-After a text, reasoning, or output-item event, a truncated or failed stream is
-never replayed automatically.
+Responses CREATE is never automatically retried by llm, including before the
+first token. No emitted output does not prove that generation or hosted tools
+never began. Lost acknowledgements, missing terminal events, and malformed
+success bodies fail with `error.code=outcome_unknown` in the sidecar (with a
+response ID when known). Reconcile before deciding whether to create again.
+Request tracing IDs are not an idempotency guarantee. Chat retry policy stays
+unchanged.
 
-The shared stream retry loop keeps its pre-existing rule for every protocol:
-any failure before output is retried, whatever the handler's exit status (an
-Anthropic overloaded error arrives as an in-stream event and exits 1). The one
-exception is a rejected `previous_response_id`, which is deterministic. The
-Responses handler reports it through a private exit code (`die_permanent`) so
-the loop stops at once and `shellm` can fall back to its replay chain without
-waiting through retries. That decision is made on the error body alone and
-does not depend on `LLM_RESPONSE_FILE` being set.
+Buffered and streamed completion require a terminal object with a nonempty
+ID, an output array, completed/incomplete status, and no embedded error. Failed
+or cancelled Responses fail without recreating; incomplete Responses still
+deliver partial output with a warning. Stream identity and terminal event/status
+must agree. A function-only result remains a valid protocol success.
+
+A deterministic rejection of `previous_response_id` still allows shellm's
+explicit replay fallback. A known response, terminal failure, or typed unknown
+outcome cannot enter that fallback merely because its diagnostic mentions a
+previous response. This decision does not depend on visible text alone.
 
 `LLM_STOP_AFTER_CODE_BLOCK` keeps its contract in Responses mode: the stream
 is cut when the first fenced block closes and the cut is a clean finish. The

--- a/design/responses-api.md
+++ b/design/responses-api.md
@@ -13,7 +13,10 @@ This change covers synchronous buffered and SSE response creation, including
 reasoning summaries, function call items and outputs, structured and
 multimodal input items, terminal status and errors, usage, and continuation.
 Response retrieval/deletion/cancellation, input-item listing, Conversations,
-background responses, and WebSocket mode are separate lifecycle work.
+and WebSocket mode are separate lifecycle work (design/responses-lifecycle.md).
+Background responses live in `bin/llm` because the caller still receives one
+terminal object per call: llm polls or resumes the stream itself and cancels
+the job when it is killed or out of time; the contract is in that document.
 
 ## Wire contract
 

--- a/design/responses-api.md
+++ b/design/responses-api.md
@@ -16,7 +16,8 @@ Response retrieval/deletion/cancellation, input-item listing, Conversations,
 and WebSocket mode are separate lifecycle work (design/responses-lifecycle.md).
 Background responses live in `bin/llm` because the caller still receives one
 terminal object per call: llm polls or resumes the stream itself and cancels
-the job when it is killed or out of time; the contract is in that document.
+the job best effort when it is killed or out of time; the contract is in that
+document. Cancellation requests do not guarantee server settlement.
 
 ## Wire contract
 
@@ -35,8 +36,10 @@ the job when it is killed or out of time; the contract is in that document.
 - `LLM_RESPONSES_BODY_FILE` may name a JSON object containing other synchronous
   create fields. `bin/llm` owns and overwrites `model`, `input`, `instructions`,
   `max_output_tokens`, `stream`, and `previous_response_id` so command-line and
-  continuation semantics remain deterministic. Conversation state is rejected
-  because it conflicts with this continuation contract.
+  continuation semantics remain deterministic. A body-file `conversation` or
+  `LLM_RESPONSES_CONVERSATION` selects Conversation state instead, and cannot be
+  combined with `LLM_PREVIOUS_RESPONSE_ID`. Shellm requires its dedicated
+  `SHELLM_RESPONSES_CONVERSATION` setting rather than a body-file Conversation.
 - Every create requests `reasoning.encrypted_content`, preserving exact
   reasoning-item replay for stateless and Zero Data Retention paths while
   retaining any other caller-supplied `include` values.
@@ -61,19 +64,21 @@ terminal response from `response.completed`, `response.incomplete`, or
 Incomplete responses warn with their reason. Failed responses and `error`
 events fail the call.
 
-Retries remain legal only before protocol output is emitted. A terminal output
-item counts as output even when it is a function call with no visible text.
-After a text, reasoning, or output-item event, a truncated or failed stream is
-never replayed automatically.
+**HTTP hardening contract:** Responses
+CREATE is not automatically retried after uncertain failure. No emitted output
+does not prove no generation began; unknown results fail with
+`error.code=outcome_unknown`. Chat retry policy is unchanged. Known background
+responses may be retrieved/resumed, not recreated. Immediate, polled, and
+streamed terminal objects share validation; cancelled, failed, malformed, or
+embedded-error replies cannot be reported as successful completions.
 
-The shared stream retry loop keeps its pre-existing rule for every protocol:
-any failure before output is retried, whatever the handler's exit status (an
-Anthropic overloaded error arrives as an in-stream event and exits 1). The one
-exception is a rejected `previous_response_id`, which is deterministic. The
-Responses handler reports it through a private exit code (`die_permanent`) so
-the loop stops at once and `shellm` can fall back to its replay chain without
-waiting through retries. That decision is made on the error body alone and
-does not depend on `LLM_RESPONSE_FILE` being set.
+One absolute `LLM_MAX_TIME` budget covers create, polling, reconnects, and
+backoff, plus up to five additional seconds for best-effort cancellation.
+Confirmation requires the same response ID and a terminal status; otherwise
+the unknown-outcome sidecar and known ID remain available for reconciliation.
+See [the lifecycle contract](responses-lifecycle.md#background-responses-binllm).
+A deterministic rejection of `previous_response_id` still allows shellm's
+explicit replay fallback; an uncertain create outcome does not.
 
 `LLM_STOP_AFTER_CODE_BLOCK` keeps its contract in Responses mode: the stream
 is cut when the first fenced block closes and the cut is a clean finish. The
@@ -83,7 +88,8 @@ continuation needs the terminal object.
 
 ## shellm continuation
 
-Responses mode keeps completion state only for the current `shellm` process:
+Without Conversation mode, Responses keeps completion state only for the current
+`shellm` process:
 
 1. The first call sends the trajectory-derived context in full.
 2. Later calls send only newly appended user-side context plus the stable
@@ -106,13 +112,22 @@ Responses mode keeps completion state only for the current `shellm` process:
 5. A resumed process starts a new chain from the durable trajectory. Remote
    response IDs are not persisted as durable trajectory state.
 
+Conversation mode instead restores local atomic mode-0600 sent-step checkpoints
+and holds a local exclusive lock for the whole run. Ambiguous delivery and
+stale locks fail closed without automatic stealing; this is not fsync-backed
+power-loss durability or distributed coordination. See
+[Conversations](responses-lifecycle.md#conversations) for resume and ownership.
+
 `SHELLM_RESPONSES_BODY_FILE` is mounted read-only into the Docker sandbox at
 its host path, so nested `llm` and `shellm` calls inside the container read
 the same file.
 
-OpenRouter's Responses endpoint is stateless and therefore starts directly in
-replay mode. Native OpenAI and generic compatible endpoints use automatic
-stateful continuation with the safe replay fallback.
+OpenRouter's Responses endpoint and explicit `store:false` start directly in
+replay mode. Otherwise native OpenAI and generic compatible endpoints use
+automatic stateful continuation with the safe replay fallback. Compaction
+capability is independent: native OpenAI supports server compaction with
+stateless replay; see [compaction](responses-lifecycle.md#compaction) for
+`SHELLM_RESPONSES_COMPACT_MODE=auto|server|standalone`.
 
 The existing thinking-text empty-response workaround remains the Chat
 Completions behavior. In Responses mode, an incomplete reasoning-only Response

--- a/design/responses-api.md
+++ b/design/responses-api.md
@@ -29,7 +29,11 @@ background responses, and WebSocket mode are separate lifecycle work.
 - `LLM_RESPONSES_BODY_FILE` may name a JSON object containing other synchronous
   create fields. `bin/llm` owns and overwrites `model`, `input`, `instructions`,
   `max_output_tokens`, `stream`, and `previous_response_id` so command-line and
-  continuation semantics remain deterministic.
+  continuation semantics remain deterministic. Conversation state is rejected
+  because it conflicts with this continuation contract.
+- Every create requests `reasoning.encrypted_content`, preserving exact
+  reasoning-item replay for stateless and Zero Data Retention paths while
+  retaining any other caller-supplied `include` values.
 - `LLM_PREVIOUS_RESPONSE_ID` adds stateful continuation.
 - `LLM_RESPONSE_FILE`, when set, receives the complete terminal Response object
   or provider error envelope through an atomic mode-0600 write. It is the

--- a/design/responses-api.md
+++ b/design/responses-api.md
@@ -18,8 +18,11 @@ background responses, and WebSocket mode are separate lifecycle work.
 ## Wire contract
 
 - Native OpenAI defaults to `https://api.openai.com/v1/responses` in Responses
-  mode. OpenRouter defaults to `https://openrouter.ai/api/v1/responses`.
-  `openai-compatible` still requires the exact `LLM_API_URL` endpoint.
+  mode. OpenRouter defaults to `https://openrouter.ai/api/v1/responses`, and
+  the `LLM_OR_*` routing and privacy constraints ride the Responses payload
+  exactly as they ride chat (merged into any caller-supplied `provider`
+  object). `openai-compatible` still requires the exact `LLM_API_URL`
+  endpoint.
 - The existing messages input is passed as the Responses `input` array without
   reshaping. This preserves typed input/output items, images, files, assistant
   phases, reasoning items, function calls, and `function_call_output` items.
@@ -38,7 +41,9 @@ background responses, and WebSocket mode are separate lifecycle work.
 - `LLM_RESPONSE_FILE`, when set, receives the complete terminal Response object
   or provider error envelope through an atomic mode-0600 write. It is the
   machine-readable channel for response IDs, all output items, function calls,
-  encrypted reasoning, status, errors, and usage.
+  encrypted reasoning, status, errors, and usage. Its directory is checked
+  before the request is sent, and a write that fails after a streamed reply
+  fails the call rather than returning text without the promised artifact.
 
 The human-output contract does not change: visible `output_text` is stdout,
 reasoning summaries are stderr, and `--raw` prints the buffered API object.
@@ -79,15 +84,28 @@ Responses mode keeps completion state only for the current `shellm` process:
 
 1. The first call sends the trajectory-derived context in full.
 2. Later calls send only newly appended user-side context plus the stable
-   instructions and the previous response ID.
+   instructions and the previous response ID. New rows are told apart from
+   re-rendered ones by trajectory step id (`context --ids --no-merge`, one
+   row per message), never by comparing rendered bytes: the render shrinks a
+   row as it ages out of the newest block and slides its window, so byte
+   prefixes drift while the rows themselves have not changed. Assistant rows
+   are the model's own turns, already held by the response ID or the replay
+   chain, and are never resent. Ids are stripped before anything reaches the
+   provider.
 3. In parallel, shellm retains the original input and every terminal output
    item. This exact replay chain preserves encrypted reasoning and assistant
    `phase` values for stateless endpoints and Zero Data Retention accounts.
 4. If a continuation is rejected specifically because the previous response
    cannot be referenced, before any output is emitted, shellm retries once with
-   the replay chain and remains stateless for the rest of the run.
+   the replay chain and remains stateless for the rest of the run. A call that
+   already emitted text is not a rejection whatever its error says: the text
+   is discarded and the run fails.
 5. A resumed process starts a new chain from the durable trajectory. Remote
    response IDs are not persisted as durable trajectory state.
+
+`SHELLM_RESPONSES_BODY_FILE` is mounted read-only into the Docker sandbox at
+its host path, so nested `llm` and `shellm` calls inside the container read
+the same file.
 
 OpenRouter's Responses endpoint is stateless and therefore starts directly in
 replay mode. Native OpenAI and generic compatible endpoints use automatic

--- a/design/responses-api.md
+++ b/design/responses-api.md
@@ -58,6 +58,21 @@ item counts as output even when it is a function call with no visible text.
 After a text, reasoning, or output-item event, a truncated or failed stream is
 never replayed automatically.
 
+The shared stream retry loop keeps its pre-existing rule for every protocol:
+any failure before output is retried, whatever the handler's exit status (an
+Anthropic overloaded error arrives as an in-stream event and exits 1). The one
+exception is a rejected `previous_response_id`, which is deterministic. The
+Responses handler reports it through a private exit code (`die_permanent`) so
+the loop stops at once and `shellm` can fall back to its replay chain without
+waiting through retries. That decision is made on the error body alone and
+does not depend on `LLM_RESPONSE_FILE` being set.
+
+`LLM_STOP_AFTER_CODE_BLOCK` keeps its contract in Responses mode: the stream
+is cut when the first fenced block closes and the cut is a clean finish. The
+terminal event never arrives, so no sidecar is written and usage is estimated.
+`shellm` therefore does not request the cut in Responses mode, because its
+continuation needs the terminal object.
+
 ## shellm continuation
 
 Responses mode keeps completion state only for the current `shellm` process:

--- a/design/responses-api.md
+++ b/design/responses-api.md
@@ -1,0 +1,89 @@
+# OpenAI Responses completion protocol
+
+Status: implemented 2026-09-01.
+
+## Scope
+
+Headlong's completion boundary remains `bin/llm`. Chat Completions remains the
+default. Operators opt into the OpenAI Responses create protocol with
+`LLM_API_FORMAT=responses` for the `openai`, `openrouter`, or
+`openai-compatible` providers.
+
+This change covers synchronous buffered and SSE response creation, including
+reasoning summaries, function call items and outputs, structured and
+multimodal input items, terminal status and errors, usage, and continuation.
+Response retrieval/deletion/cancellation, input-item listing, Conversations,
+background responses, and WebSocket mode are separate lifecycle work.
+
+## Wire contract
+
+- Native OpenAI defaults to `https://api.openai.com/v1/responses` in Responses
+  mode. OpenRouter defaults to `https://openrouter.ai/api/v1/responses`.
+  `openai-compatible` still requires the exact `LLM_API_URL` endpoint.
+- The existing messages input is passed as the Responses `input` array without
+  reshaping. This preserves typed input/output items, images, files, assistant
+  phases, reasoning items, function calls, and `function_call_output` items.
+- The system prompt maps to `instructions`, the token cap maps to
+  `max_output_tokens`, and an explicit thinking level maps to
+  `reasoning.effort` with an automatic summary.
+- `LLM_RESPONSES_BODY_FILE` may name a JSON object containing other synchronous
+  create fields. `bin/llm` owns and overwrites `model`, `input`, `instructions`,
+  `max_output_tokens`, `stream`, and `previous_response_id` so command-line and
+  continuation semantics remain deterministic.
+- `LLM_PREVIOUS_RESPONSE_ID` adds stateful continuation.
+- `LLM_RESPONSE_FILE`, when set, receives the complete terminal Response object
+  or provider error envelope through an atomic mode-0600 write. It is the
+  machine-readable channel for response IDs, all output items, function calls,
+  encrypted reasoning, status, errors, and usage.
+
+The human-output contract does not change: visible `output_text` is stdout,
+reasoning summaries are stderr, and `--raw` prints the buffered API object.
+A function-only response is a successful protocol response even though stdout
+is empty; callers consume its items from `LLM_RESPONSE_FILE`.
+
+## Streaming and failure semantics
+
+The SSE handler emits text and reasoning deltas as they arrive, records the
+terminal response from `response.completed`, `response.incomplete`, or
+`response.failed`, and maps Responses usage into the existing usage record.
+Incomplete responses warn with their reason. Failed responses and `error`
+events fail the call.
+
+Retries remain legal only before protocol output is emitted. A terminal output
+item counts as output even when it is a function call with no visible text.
+After a text, reasoning, or output-item event, a truncated or failed stream is
+never replayed automatically.
+
+## shellm continuation
+
+Responses mode keeps completion state only for the current `shellm` process:
+
+1. The first call sends the trajectory-derived context in full.
+2. Later calls send only newly appended user-side context plus the stable
+   instructions and the previous response ID.
+3. In parallel, shellm retains the original input and every terminal output
+   item. This exact replay chain preserves encrypted reasoning and assistant
+   `phase` values for stateless endpoints and Zero Data Retention accounts.
+4. If a continuation is rejected specifically because the previous response
+   cannot be referenced, before any output is emitted, shellm retries once with
+   the replay chain and remains stateless for the rest of the run.
+5. A resumed process starts a new chain from the durable trajectory. Remote
+   response IDs are not persisted as durable trajectory state.
+
+OpenRouter's Responses endpoint is stateless and therefore starts directly in
+replay mode. Native OpenAI and generic compatible endpoints use automatic
+stateful continuation with the safe replay fallback.
+
+The existing thinking-text empty-response workaround remains the Chat
+Completions behavior. In Responses mode, an incomplete reasoning-only Response
+continues through its response ID or exact output-item replay instead of
+turning a reasoning summary into an invented assistant message.
+
+## Verification
+
+Hermetic tests pin request JSON, endpoint selection, pass-through input,
+extra-body validation and precedence, buffered extraction, terminal sidecar
+permissions, response status and usage, SSE event classes, function-only
+success, stateful shellm deltas, stateless replay, continuation fallback, and
+unchanged Chat behavior. The implementation is additionally smoke-tested
+against native OpenAI and an independent OpenAI-compatible Responses endpoint.

--- a/design/responses-lifecycle.md
+++ b/design/responses-lifecycle.md
@@ -71,9 +71,13 @@ the error contract, and that keys never appear on argv. Runs under bash 3.2.
 
 ## Background responses (bin/llm)
 
+Status: implemented (`tests/test_llm_responses_background.sh`).
+
 Opt in with `LLM_RESPONSES_BACKGROUND=1`, or `background: true` in the body
-file (no longer rejected). `store` is left to the caller; the API keeps the
-data it needs for polling either way.
+file (no longer rejected); `0` forces foreground over the body file. `store`
+is left to the caller; the API keeps the data it needs for polling either way.
+The retrieve and cancel URLs are derived from the create URL by stripping its
+`/responses` suffix, so the create endpoint must end that way.
 
 - Streaming create: `background: true, stream: true`. The handler remembers
   the response id from the first event carrying `.response.id` and the

--- a/design/responses-lifecycle.md
+++ b/design/responses-lifecycle.md
@@ -104,6 +104,11 @@ duplicated text; TERM during a job records a cancel POST.
 
 ## Conversations
 
+Status: implemented (`tests/test_llm_responses.sh`,
+`tests/test_shellm_responses_continuation.sh`). One addition to the sketch
+below: the WebSocket adapter puts `conversation` on its `response.create` too,
+so the choice of transport does not change which state a run carries.
+
 `bin/llm` accepts `conversation` from the body file, or
 `LLM_RESPONSES_CONVERSATION=<conv id>`, when `LLM_PREVIOUS_RESPONSE_ID` is
 empty; both at once is still an error, because the API rejects the pair.

--- a/design/responses-lifecycle.md
+++ b/design/responses-lifecycle.md
@@ -139,6 +139,14 @@ compacted window and later requests begin with the compaction item; llm adds
 
 ## WebSocket mode
 
+Status: implemented. Two notes where the build differs from the sketch below.
+The guide describes the mode against `/v1/responses` without spelling the
+scheme out, so the endpoint is `RESPONSES_WS_URL` with
+`wss://api.openai.com/v1/responses` as its default rather than a constant. And
+`store` is not a field the adapter owns: it passes through from
+`LLM_RESPONSES_BODY_FILE` untouched, exactly as it does on the HTTPS path, so
+the same body file produces the same request on either transport.
+
 An adapter, not core: `tools/responses-ws`, a Python script (`uv run`, PEP 723
 metadata, `websockets`), following the adapter contract in
 design/providers.md plus the Responses environment (`LLM_RESPONSE_FILE`,

--- a/design/responses-lifecycle.md
+++ b/design/responses-lifecycle.md
@@ -1,8 +1,12 @@
 # OpenAI Responses lifecycle operations
 
-Status: fork-only work on 24601/headlong, stacked on the Responses completion
-protocol (design/responses-api.md, upstream PR #101). Nothing here is proposed
-upstream until that PR lands and the pieces have run for a while.
+Status: implemented on the 24601/headlong fork (2026-09-05), stacked on the
+Responses completion protocol (design/responses-api.md, upstream PR #101).
+Each section below names its tests and any place the build departed from the
+sketch. Nothing here is proposed upstream until that PR lands and the pieces
+have run for a while. Landed as fork PRs #2 (bin/responses), #3 (background),
+#4 (WebSocket), #5 (compaction) and #6 (Conversations) on the integration
+branch `feat/responses-lifecycle` (PR #1).
 
 ## Why a second surface
 
@@ -21,6 +25,11 @@ case it, the endpoint's own 404 is the answer. `openai-compatible` endpoints
 get the same paths relative to their configured base.
 
 ## bin/responses
+
+Status: implemented (`tests/test_responses_cli.sh`). Two notes: each
+subcommand rejects flags that belong to another subcommand (exit 2) rather
+than ignoring them, and `include` arrays are sent as repeated `include[]=`
+query parameters, the encoding the official SDKs use.
 
 One bash tool, curl and jq only, sharing `bin/llm`'s environment: the vendor
 keys, `LLM_PROVIDER` / `--provider` (default `openai`), `LLM_API_URL` (when set
@@ -129,6 +138,11 @@ resume, and dies cleanly on a rejected conversation.
 
 ## Compaction
 
+Status: implemented (`tests/test_llm_responses.sh`,
+`tests/test_shellm_responses_continuation.sh`). The compact reply's window is
+its `output` array, passed on as is; a failed compact call warns and keeps the
+chain, and the next crossing tries again.
+
 - `bin/llm`: `LLM_RESPONSES_COMPACT_THRESHOLD=N` adds
   `context_management: [{type: "compaction", compact_threshold: N}]` to the
   create body (owned when the variable is set, otherwise the body file's value
@@ -185,6 +199,6 @@ prints one skip line and exits 0, like the Docker-gated tests.
 
 ## Line budget
 
-`cloc bin/ thinkers/` is capped by CI. These pieces add roughly 700 lines to
-bin/; the cap moves to 11,500 on this fork in the first slice that crosses it,
-which is the number the README already quotes.
+`cloc bin/ thinkers/` is capped by CI. These pieces added about 900 lines to
+bin/ (the tree stands near 11,560), so the cap on this fork is 12,000 and the
+README quotes that number. Upstream's cap of 11,000 is untouched by PR #101.

--- a/design/responses-lifecycle.md
+++ b/design/responses-lifecycle.md
@@ -165,8 +165,11 @@ Sent trajectory step IDs are checkpointed in
 `$SHELLM_TRAJ_DIR/.responses-conversations/<conv_id>.json` (under the effective
 trajectory directory). These versioned files are atomically replaced at mode
 0600 in a mode-0700 directory, bound to the trajectory path, Conversation,
-underlying provider, and endpoint. A local exclusive `mkdir` lock is held for
-the whole run. Before dispatch the checkpoint becomes `in_flight`; only a
+underlying provider, and effective endpoint. A local exclusive `mkdir` lock,
+keyed by provider, effective endpoint, and Conversation ID under the canonical
+state home's `run/responses-conversations/`, is held for the whole run. It is
+independent of `SHELLM_TRAJ_DIR`, so two trajectory roots cannot become two
+local owners of the same remote Conversation. Before dispatch the checkpoint becomes `in_flight`; only a
 validated successful terminal response advances the sent-step acknowledgement
 and returns it to `ready`. Resume restores that acknowledgement, preserving
 genuinely unsent execution output rather than resending historical rows.
@@ -191,8 +194,10 @@ resume, and dies cleanly on a rejected conversation.
 
 Status: implemented (`tests/test_llm_responses.sh`,
 `tests/test_shellm_responses_continuation.sh`). The compact reply's window is
-its `output` array, passed on as is. A failed or invalid standalone compact
-reply warns, keeps the chain, and disables standalone upkeep for that run.
+its `output` array, passed on as is after its compaction items carry non-empty
+opaque `encrypted_content`. A failed or invalid standalone compact reply warns,
+keeps the chain, and disables standalone upkeep for that run. An unusable
+server-produced marker likewise cannot prune the known-good replay chain.
 
 - `bin/llm`: `LLM_RESPONSES_COMPACT_THRESHOLD=N` adds
   `context_management: [{type: "compaction", compact_threshold: N}]` to the
@@ -245,9 +250,12 @@ object in the sidecar, usage in `LLM_USAGE_FILE`, exit non-zero on failure.
 
 Two roles in one file. `serve` holds one connection to
 the resolved endpoint (rotating idle connections older than 55 minutes), listens
-on a unix socket, multiplexes callers onto `stream_id` lanes (16 in flight, 32
-named per connection), and exits when idle for `RESPONSES_WS_IDLE` minutes or
-told `stop`. The default role is the per-call adapter: when
+on a unix socket, and multiplexes callers onto `stream_id` lanes. A generation
+admits at most 16 live lanes and assigns each of at most 32 stream names once;
+when the name budget is exhausted, it drains the remaining live lanes and
+rotates the connection before reusing a name. Admission waits are bounded and
+cancellable when the broker shuts down. The broker exits when idle for
+`RESPONSES_WS_IDLE` minutes or told `stop`. The default role is the per-call adapter: when
 `RESPONSES_WS_SOCKET` is set it forwards through that broker; missing or failed
 brokers fail the call with no blind one-shot fallback. Only an unset socket
 selects one-shot mode. shellm's `SHELLM_API_TRANSPORT=websocket` starts

--- a/design/responses-lifecycle.md
+++ b/design/responses-lifecycle.md
@@ -8,6 +8,12 @@ have run for a while. Landed as fork PRs #2 (bin/responses), #3 (background),
 #4 (WebSocket), #5 (compaction) and #6 (Conversations) on the integration
 branch `feat/responses-lifecycle` (PR #1).
 
+The PR #1 hardening contracts below distinguish local recovery safeguards from
+server guarantees. The HTTP completion changes are specified under
+**Background responses**; the Conversation,
+compaction, lifecycle CLI, and WebSocket descriptions reflect the current
+implementation.
+
 ## Why a second surface
 
 `bin/llm` is the completion boundary: one request, one terminal object. The
@@ -64,13 +70,20 @@ developers.openai.com/api/docs/api-reference before pinning a test):
 | cancel | `POST /responses/{id}/cancel` (background responses only; idempotent) |
 | delete | `DELETE /responses/{id}` returns `{id, object:"response", deleted:true}` |
 | input-items | `GET /responses/{id}/input_items` with `after`, `limit` (1-100, default 20), `order` (default desc), `include[]`; list object with `data`, `first_id`, `last_id`, `has_more` |
-| compact | `POST /responses/compact` with `model`, `input` or `previous_response_id`, `instructions`; the reply's output window starts with a `compaction` item carrying `encrypted_content` |
+| compact | `POST /responses/compact` with `model`, `input` or `previous_response_id`, `instructions`; the reply's `output` is the canonical next window, preserved as-is |
 | conversations create | `POST /conversations` with `items` (max 20), `metadata` |
 | conversations get / update / delete | `GET`, `POST` (`metadata` only), `DELETE /conversations/{cid}` |
 | conversations items / add / item / remove | `GET`, `POST` (`items`, max 20), `GET`, `DELETE` under `/conversations/{cid}/items` |
 
 `--all` follows `has_more` with `after=<last id>` and prints one merged list
-object. `--stream` on `get` prints each SSE `data:` payload as one JSON line
+object only after verified exhaustion. Malformed pages, empty continuing pages,
+cursor cycles, duplicate item IDs, or continuing past 500 pages fail rather
+than claiming `has_more:false`. List transfers and the aggregate are bounded
+to 64 MiB. This is not a snapshot guarantee during concurrent server changes.
+Temporary auth, body, and response files live in one private command directory,
+removed on normal/error exit and handled signals after the owned curl child is
+stopped and reaped; SIGKILL or power loss cannot run that cleanup.
+`--stream` on `get` prints each SSE `data:` payload as one JSON line
 and exits 0 only after a terminal event (`response.completed`, `.incomplete`,
 `.failed`, `.cancelled`); this is the resume channel for background streams.
 
@@ -80,7 +93,9 @@ the error contract, and that keys never appear on argv. Runs under bash 3.2.
 
 ## Background responses (bin/llm)
 
-Status: implemented (`tests/test_llm_responses_background.sh`).
+Status: background support is implemented; the following HTTP hardening
+contract is being integrated and still needs verification against the final
+`bin/llm` changes (`tests/test_llm_responses_background.sh`).
 
 Opt in with `LLM_RESPONSES_BACKGROUND=1`, or `background: true` in the body
 file (no longer rejected); `0` forces foreground over the body file. `store`
@@ -93,17 +108,29 @@ The retrieve and cancel URLs are derived from the create URL by stripping its
   `sequence_number` of every event. If the stream drops before a terminal
   event (curl error, or EOF without one), llm does not re-create: it resumes
   with `GET /responses/{id}?stream=true&starting_after=N`, up to `LLM_RETRIES`
-  times, and nothing already emitted is emitted twice. Only a drop before any
-  id is known falls back to the ordinary retry.
+  times, and nothing already emitted is emitted twice. A drop before an ID is
+  known is an unknown create outcome, not permission to create again.
 - Non-streaming create: the reply is `queued` or `in_progress`; llm polls
   `GET /responses/{id}` every `LLM_RESPONSES_POLL_INTERVAL` seconds (default 2,
-  backing off to 10) until a terminal status or `LLM_MAX_TIME`, then treats the
-  object exactly like a buffered terminal reply (sidecar, usage, text).
+  backing off to 10) until a terminal status or the deadline, then treats the
+  object exactly like an immediate buffered or streamed terminal reply. All
+  three paths share terminal validation: failed/cancelled states, embedded
+  errors, malformed envelopes, and unknown statuses cannot become success.
+- Retry and deadline: Responses CREATE is not automatically retried after an
+  uncertain failure, even if nothing reached stdout. Unknown outcomes fail
+  with `error.code=outcome_unknown`; Chat Completions retry policy is unchanged.
+  One absolute `LLM_MAX_TIME` deadline starts before create and covers polling,
+  reconnects, network waits, and backoff; waits are clamped to remaining time
+  and late completion is not accepted as timely success.
 - Cancel: while a background response is in flight, SIGINT, SIGTERM, and the
-  `LLM_MAX_TIME` deadline POST `/responses/{id}/cancel` best effort (short
-  timeout) before exiting non-zero, so a killed run does not leave a billable
-  job behind. `cancelled` is a terminal status: no text, warning on stderr,
-  sidecar written, exit non-zero.
+  `LLM_MAX_TIME` deadline POST `/responses/{id}/cancel` best effort, with up to
+  five additional seconds beyond the operation budget. A cancellation request
+  does not guarantee the job stopped. Only a terminal response for the same
+  response ID confirms settlement; only its `cancelled` status confirms
+  cancellation (a concurrent completion may win). Otherwise the nonzero exit
+  retains an unknown-outcome sidecar and the known ID for reconciliation.
+  `cancelled` is terminal: warning on stderr, sidecar written, exit non-zero,
+  and no fresh generation. Text already streamed cannot be withdrawn.
 - shellm: `SHELLM_RESPONSES_BACKGROUND=1` passes through. Its continuation
   contract is unchanged because a terminal object still arrives.
 
@@ -126,11 +153,35 @@ empty; both at once is still an error, because the API rejects the pair.
 state instead of the process-local chain. `new` creates a conversation at run
 start (`responses conversations create`). The id is recorded in the
 `shellm-run` header row as `conversation`; unlike response ids, this is
-durable on purpose (Conversations never expire) and a `--resume` of that run
-reuses it. Each call sends only the new items with `conversation` set and
+durable on purpose (Conversations do not expire automatically). `--resume` or
+`--traj` reuses the latest header's ID when the setting is `new` or empty/unset;
+a different literal ID intentionally redirects the run. Each call sends only
+the new items with `conversation` set and
 never `previous_response_id`; the replay chain is not kept. A missing or
 rejected conversation fails closed with a clear error: the operator chose
 durable server state, so there is nothing safe to fall back to.
+
+Sent trajectory step IDs are checkpointed in
+`$SHELLM_TRAJ_DIR/.responses-conversations/<conv_id>.json` (under the effective
+trajectory directory). These versioned files are atomically replaced at mode
+0600 in a mode-0700 directory, bound to the trajectory path, Conversation,
+underlying provider, and endpoint. A local exclusive `mkdir` lock is held for
+the whole run. Before dispatch the checkpoint becomes `in_flight`; only a
+validated successful terminal response advances the sent-step acknowledgement
+and returns it to `ready`. Resume restores that acknowledgement, preserving
+genuinely unsent execution output rather than resending historical rows.
+
+An in-flight/invalid/mismatched checkpoint, missing acknowledgement for an
+already-recorded Conversation, or an existing lock fails closed. Locks are
+never automatically stolen, including stale locks after crashes. Reconcile
+server state and local ownership before reuse; deleting a lock alone does not
+resolve ambiguous delivery. This is local atomic replacement and exclusive
+ownership, not fsync-backed power-loss durability, distributed coordination,
+or an exactly-once server-delivery guarantee. A new/different Conversation
+without local history starts with an empty acknowledgement, not inferred server
+acknowledgements. Body-file Conversations are rejected by shellm before any
+request; use `SHELLM_RESPONSES_CONVERSATION`. Generated child calls and summaries
+do not inherit the parent's Conversation.
 
 Tests: llm rejects the pair and sends `conversation` alone; shellm creates on
 `new`, carries the id on every delta, records it in the header, reuses it on
@@ -140,21 +191,30 @@ resume, and dies cleanly on a rejected conversation.
 
 Status: implemented (`tests/test_llm_responses.sh`,
 `tests/test_shellm_responses_continuation.sh`). The compact reply's window is
-its `output` array, passed on as is; a failed compact call warns and keeps the
-chain, and the next crossing tries again.
+its `output` array, passed on as is. A failed or invalid standalone compact
+reply warns, keeps the chain, and disables standalone upkeep for that run.
 
 - `bin/llm`: `LLM_RESPONSES_COMPACT_THRESHOLD=N` adds
   `context_management: [{type: "compaction", compact_threshold: N}]` to the
   create body (owned when the variable is set, otherwise the body file's value
   stands). Server-side compaction then happens inside a normal turn.
-- `bin/shellm`: `SHELLM_RESPONSES_COMPACT_THRESHOLD=N` (tokens). In stateful
-  mode it passes through to llm. In replay mode (OpenRouter, ZDR, after a
-  continuation fallback) shellm compacts itself: after a terminal response
-  whose `usage.input_tokens` is at or above N, it runs `responses compact
-  --model $SHELLM_MODEL --input-file <replay chain>` and replaces the chain
-  with the returned window. In either mode, when a terminal `output` contains
-  a `compaction` item, the replay chain is truncated to start at that item,
-  which is what the API says to send next.
+- `bin/shellm`: `SHELLM_RESPONSES_COMPACT_THRESHOLD=N` (tokens) opts into upkeep;
+  it is a trigger, not a hard context-size limit. Choose
+  `SHELLM_RESPONSES_COMPACT_MODE=auto|server|standalone`. `auto` selects server
+  compaction for the native OpenAI provider at `api.openai.com` (or its default
+  URL), including input-array replay with `store=false`; other configurations
+  select standalone. Retention and continuation do not determine compaction
+  capability. Explicit `server` declares that the chosen endpoint supports
+  `context_management`; it passes the threshold through to llm even in replay.
+- `standalone` with a threshold forces replay. After a terminal response whose
+  `usage.input_tokens` reaches N, shellm calls `responses compact` with the
+  underlying provider (not the WebSocket adapter), model, current instructions,
+  and replay chain, then adopts the returned `output` array without pruning or
+  reordering it. Endpoint support is not guaranteed merely by selecting auto.
+  Conversation mode plus a threshold requires server compaction.
+- A server-produced compaction item prunes replay to the **newest** marker.
+  That turn does not also trigger standalone compaction from pre-compaction
+  usage. This pruning rule does not apply to standalone compact output.
 
 Tests: the threshold fires once per crossing, the replay file shrinks to the
 compacted window and later requests begin with the compaction item; llm adds
@@ -162,16 +222,19 @@ compacted window and later requests begin with the compaction item; llm adds
 
 ## WebSocket mode
 
-Status: implemented. Two notes where the build differs from the sketch below.
-The guide describes the mode against `/v1/responses` without spelling the
-scheme out, so the endpoint is `RESPONSES_WS_URL` with
-`wss://api.openai.com/v1/responses` as its default rather than a constant. And
-`store` is not a field the adapter owns: it passes through from
-`LLM_RESPONSES_BODY_FILE` untouched, exactly as it does on the HTTPS path, so
-the same body file produces the same request on either transport.
+Status: implemented. Endpoint and credentials follow the underlying provider:
+`openai` uses `OPENAI_API_KEY`, `openai-compatible` uses `LLM_API_KEY` and an
+explicit URL. HTTP(S) URLs become WS(S) without changing path or query. Shellm
+uses its resolved `SHELLM_API_URL` / `LLM_API_URL` for both lifecycle operations
+and completions and rejects `RESPONSES_WS_URL`; the standalone adapter permits
+that override. Native OpenAI defaults to `wss://api.openai.com/v1/responses`.
+Unsupported providers, OpenRouter routing/privacy settings, and background,
+`provider`, or `stream_options` body settings are rejected rather than silently
+discarded. `store` passes through unchanged; instructions, previous-response
+ID removal, and server-compaction thresholds follow the HTTP field ownership.
 
 An adapter, not core: `tools/responses-ws`, a Python script (`uv run`, PEP 723
-metadata, `websockets`), following the adapter contract in
+metadata, Python >=3.10 and `websockets==17.1`), following the adapter contract in
 design/providers.md plus the Responses environment (`LLM_RESPONSE_FILE`,
 `LLM_PREVIOUS_RESPONSE_ID`, `LLM_RESPONSES_BODY_FILE`). `bin/llm` allows
 `--provider adapter` with `LLM_API_FORMAT=responses` and adds `--api-format
@@ -181,24 +244,45 @@ text on stdout as it streams, reasoning summaries on stderr, the terminal
 object in the sidecar, usage in `LLM_USAGE_FILE`, exit non-zero on failure.
 
 Two roles in one file. `serve` holds one connection to
-`wss://api.openai.com/v1/responses` (60-minute lifetime, reconnects), listens
+the resolved endpoint (rotating idle connections older than 55 minutes), listens
 on a unix socket, multiplexes callers onto `stream_id` lanes (16 in flight, 32
 named per connection), and exits when idle for `RESPONSES_WS_IDLE` minutes or
 told `stop`. The default role is the per-call adapter: when
-`RESPONSES_WS_SOCKET` names a live broker it forwards through it, otherwise it
-opens a one-shot connection. shellm's `SHELLM_API_TRANSPORT=websocket` starts
+`RESPONSES_WS_SOCKET` is set it forwards through that broker; missing or failed
+brokers fail the call with no blind one-shot fallback. Only an unset socket
+selects one-shot mode. shellm's `SHELLM_API_TRANSPORT=websocket` starts
 the broker at run start (socket in rundir), points llm at the adapter, and
 stops it at cleanup. Continuation via `previous_response_id` works through the
-connection-local cache even with `store: false`; a
+connection-local cache even with `store: false` for direct adapter callers;
+shellm explicitly uses replay for `store:false`. A
 `previous_response_not_found` error takes the existing replay fallback.
+
+The broker owns lanes within a connection generation and checks response IDs.
+Abandoning an unsettled request retires the connection instead of recycling its
+lane while old events can still arrive. Other unsettled callers on that
+connection may fail with `error.code=outcome_unknown`; retirement does not
+confirm server cancellation. A later caller may open a new connection, but
+abandoned creates are not replayed. Connection-scoped errors are fanned out.
+Local JSON frames are bounded at 16 MiB of UTF-8 bytes (excluding the newline),
+including framing overhead; upstream messages are also bounded at 16 MiB.
+Per-lane queues allow at most 64 events / 16 MiB, local admission at most 32
+clients, and initial local request reads and writes are bounded at 30 seconds. Oversize frames
+and slow consumers fail rather than grow memory without bound. These are
+transport bounds, not the HTTP whole-operation deadline contract.
+
+The installer includes `responses-ws` in copy and symlink installs; uninstall
+removes it. Selecting WebSocket mode requires `uv`; HTTPS does not.
 
 Tests: a fake WebSocket server in the test itself (same library) checks the
 `response.create` payload, streamed text order, the sidecar, an error event,
-and broker multiplexing of two concurrent callers. If `uv` is absent the test
-prints one skip line and exits 0, like the Docker-gated tests.
+and broker multiplexing of two concurrent callers. The fault suite covers
+abandonment, cross-talk, large frames, bounded queues, connection retirement,
+and transport parity. Missing `uv` fails the test rather than silently leaving
+the transport untested.
 
 ## Line budget
 
-`cloc bin/ thinkers/` is capped by CI. These pieces added about 900 lines to
-bin/ (the tree stands near 11,560), so the cap on this fork is 12,000 and the
-README quotes that number. Upstream's cap of 11,000 is untouched by PR #101.
+`cloc bin/ thinkers/` is capped by CI. The hardened fork stands near 11,900
+code lines, under the unchanged fork cap of 12,000. Upstream's cap of 11,000
+is untouched by PR #101. Python transport, tests and documentation are outside
+that core count, not free complexity; they have their own verification.

--- a/design/responses-lifecycle.md
+++ b/design/responses-lifecycle.md
@@ -1,0 +1,173 @@
+# OpenAI Responses lifecycle operations
+
+Status: fork-only work on 24601/headlong, stacked on the Responses completion
+protocol (design/responses-api.md, upstream PR #101). Nothing here is proposed
+upstream until that PR lands and the pieces have run for a while.
+
+## Why a second surface
+
+`bin/llm` is the completion boundary: one request, one terminal object. The
+Responses API also has server-side state with its own life: a stored response
+can be fetched, cancelled, deleted, and its input items listed; a Conversation
+is a durable container that never expires; a background response runs after
+the request returns; compaction rewrites a long window into an opaque item;
+WebSocket mode keeps a connection open across turns. Those are operations on
+state, not completions, so they get their own tool, `bin/responses`, and the
+completion path learns only what it needs to cooperate with them.
+
+Provider scope is native OpenAI first. OpenRouter's `/responses` is stateless
+(no retrieve, cancel, delete, conversations); `bin/responses` does not special
+case it, the endpoint's own 404 is the answer. `openai-compatible` endpoints
+get the same paths relative to their configured base.
+
+## bin/responses
+
+One bash tool, curl and jq only, sharing `bin/llm`'s environment: the vendor
+keys, `LLM_PROVIDER` / `--provider` (default `openai`), `LLM_API_URL` (when set
+its `/responses` suffix is stripped and the rest is the API base), and the net
+guards `LLM_CONNECT_TIMEOUT` and `LLM_MAX_TIME`. Stdout is the machine channel:
+the API object exactly as returned, one JSON document per command (compact,
+`--pretty` for humans). A non-2xx reply prints `responses: error: <message>` on
+stderr, writes nothing to stdout, and exits 1. Exit 2 is a usage error.
+
+```
+responses get ID [--include V]... [--stream] [--starting-after N]
+responses cancel ID
+responses delete ID
+responses input-items ID [--after ID] [--limit N] [--order asc|desc] [--include V]... [--all]
+responses compact --model M (--input-file F | --previous-response-id ID) [--instructions S] [--body-file F]
+responses conversations create [--items-file F] [--metadata JSON]
+responses conversations get CID
+responses conversations update CID --metadata JSON
+responses conversations delete CID
+responses conversations items CID [--after ID] [--limit N] [--order asc|desc] [--include V]... [--all]
+responses conversations add CID --items-file F [--include V]...
+responses conversations item CID ITEM_ID
+responses conversations remove CID ITEM_ID
+```
+
+Paths and verbs, from the API reference (verify against
+developers.openai.com/api/docs/api-reference before pinning a test):
+
+| command | request |
+|---|---|
+| get | `GET /responses/{id}` with `include[]`, `stream`, `starting_after` |
+| cancel | `POST /responses/{id}/cancel` (background responses only; idempotent) |
+| delete | `DELETE /responses/{id}` returns `{id, object:"response", deleted:true}` |
+| input-items | `GET /responses/{id}/input_items` with `after`, `limit` (1-100, default 20), `order` (default desc), `include[]`; list object with `data`, `first_id`, `last_id`, `has_more` |
+| compact | `POST /responses/compact` with `model`, `input` or `previous_response_id`, `instructions`; the reply's output window starts with a `compaction` item carrying `encrypted_content` |
+| conversations create | `POST /conversations` with `items` (max 20), `metadata` |
+| conversations get / update / delete | `GET`, `POST` (`metadata` only), `DELETE /conversations/{cid}` |
+| conversations items / add / item / remove | `GET`, `POST` (`items`, max 20), `GET`, `DELETE` under `/conversations/{cid}/items` |
+
+`--all` follows `has_more` with `after=<last id>` and prints one merged list
+object. `--stream` on `get` prints each SSE `data:` payload as one JSON line
+and exits 0 only after a terminal event (`response.completed`, `.incomplete`,
+`.failed`, `.cancelled`); this is the resume channel for background streams.
+
+Tests (`tests/test_responses_cli.sh`): a curl stub records method, URL, and
+body; pin each path, query encoding of repeated `include`, `--all` pagination,
+the error contract, and that keys never appear on argv. Runs under bash 3.2.
+
+## Background responses (bin/llm)
+
+Opt in with `LLM_RESPONSES_BACKGROUND=1`, or `background: true` in the body
+file (no longer rejected). `store` is left to the caller; the API keeps the
+data it needs for polling either way.
+
+- Streaming create: `background: true, stream: true`. The handler remembers
+  the response id from the first event carrying `.response.id` and the
+  `sequence_number` of every event. If the stream drops before a terminal
+  event (curl error, or EOF without one), llm does not re-create: it resumes
+  with `GET /responses/{id}?stream=true&starting_after=N`, up to `LLM_RETRIES`
+  times, and nothing already emitted is emitted twice. Only a drop before any
+  id is known falls back to the ordinary retry.
+- Non-streaming create: the reply is `queued` or `in_progress`; llm polls
+  `GET /responses/{id}` every `LLM_RESPONSES_POLL_INTERVAL` seconds (default 2,
+  backing off to 10) until a terminal status or `LLM_MAX_TIME`, then treats the
+  object exactly like a buffered terminal reply (sidecar, usage, text).
+- Cancel: while a background response is in flight, SIGINT, SIGTERM, and the
+  `LLM_MAX_TIME` deadline POST `/responses/{id}/cancel` best effort (short
+  timeout) before exiting non-zero, so a killed run does not leave a billable
+  job behind. `cancelled` is a terminal status: no text, warning on stderr,
+  sidecar written, exit non-zero.
+- shellm: `SHELLM_RESPONSES_BACKGROUND=1` passes through. Its continuation
+  contract is unchanged because a terminal object still arrives.
+
+Tests extend `tests/test_llm_responses.sh`: queued then in_progress then
+completed by polling; a dropped stream resumed with `starting_after` and no
+duplicated text; TERM during a job records a cancel POST.
+
+## Conversations
+
+`bin/llm` accepts `conversation` from the body file, or
+`LLM_RESPONSES_CONVERSATION=<conv id>`, when `LLM_PREVIOUS_RESPONSE_ID` is
+empty; both at once is still an error, because the API rejects the pair.
+
+`bin/shellm`: `SHELLM_RESPONSES_CONVERSATION=new|conv_...` chooses server-held
+state instead of the process-local chain. `new` creates a conversation at run
+start (`responses conversations create`). The id is recorded in the
+`shellm-run` header row as `conversation`; unlike response ids, this is
+durable on purpose (Conversations never expire) and a `--resume` of that run
+reuses it. Each call sends only the new items with `conversation` set and
+never `previous_response_id`; the replay chain is not kept. A missing or
+rejected conversation fails closed with a clear error: the operator chose
+durable server state, so there is nothing safe to fall back to.
+
+Tests: llm rejects the pair and sends `conversation` alone; shellm creates on
+`new`, carries the id on every delta, records it in the header, reuses it on
+resume, and dies cleanly on a rejected conversation.
+
+## Compaction
+
+- `bin/llm`: `LLM_RESPONSES_COMPACT_THRESHOLD=N` adds
+  `context_management: [{type: "compaction", compact_threshold: N}]` to the
+  create body (owned when the variable is set, otherwise the body file's value
+  stands). Server-side compaction then happens inside a normal turn.
+- `bin/shellm`: `SHELLM_RESPONSES_COMPACT_THRESHOLD=N` (tokens). In stateful
+  mode it passes through to llm. In replay mode (OpenRouter, ZDR, after a
+  continuation fallback) shellm compacts itself: after a terminal response
+  whose `usage.input_tokens` is at or above N, it runs `responses compact
+  --model $SHELLM_MODEL --input-file <replay chain>` and replaces the chain
+  with the returned window. In either mode, when a terminal `output` contains
+  a `compaction` item, the replay chain is truncated to start at that item,
+  which is what the API says to send next.
+
+Tests: the threshold fires once per crossing, the replay file shrinks to the
+compacted window and later requests begin with the compaction item; llm adds
+`context_management` only when asked.
+
+## WebSocket mode
+
+An adapter, not core: `tools/responses-ws`, a Python script (`uv run`, PEP 723
+metadata, `websockets`), following the adapter contract in
+design/providers.md plus the Responses environment (`LLM_RESPONSE_FILE`,
+`LLM_PREVIOUS_RESPONSE_ID`, `LLM_RESPONSES_BODY_FILE`). `bin/llm` allows
+`--provider adapter` with `LLM_API_FORMAT=responses` and adds `--api-format
+responses` to the adapter argv so the adapter knows the stdin JSON is typed
+Responses input. The adapter's output contract is llm's Responses contract:
+text on stdout as it streams, reasoning summaries on stderr, the terminal
+object in the sidecar, usage in `LLM_USAGE_FILE`, exit non-zero on failure.
+
+Two roles in one file. `serve` holds one connection to
+`wss://api.openai.com/v1/responses` (60-minute lifetime, reconnects), listens
+on a unix socket, multiplexes callers onto `stream_id` lanes (16 in flight, 32
+named per connection), and exits when idle for `RESPONSES_WS_IDLE` minutes or
+told `stop`. The default role is the per-call adapter: when
+`RESPONSES_WS_SOCKET` names a live broker it forwards through it, otherwise it
+opens a one-shot connection. shellm's `SHELLM_API_TRANSPORT=websocket` starts
+the broker at run start (socket in rundir), points llm at the adapter, and
+stops it at cleanup. Continuation via `previous_response_id` works through the
+connection-local cache even with `store: false`; a
+`previous_response_not_found` error takes the existing replay fallback.
+
+Tests: a fake WebSocket server in the test itself (same library) checks the
+`response.create` payload, streamed text order, the sidecar, an error event,
+and broker multiplexing of two concurrent callers. If `uv` is absent the test
+prints one skip line and exits 0, like the Docker-gated tests.
+
+## Line budget
+
+`cloc bin/ thinkers/` is capped by CI. These pieces add roughly 700 lines to
+bin/; the cap moves to 11,500 on this fork in the first slice that crosses it,
+which is the number the README already quotes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,9 @@ Reference documentation.
 - [install.md](install.md) covers every install variant, including
   non-interactive/CI installs and the long-lived Docker container.
 - [shellm.md](shellm.md) is the shellm engine reference: the loop,
-  context passing, Docker sandboxing, envs, the `llm` tool, and options.
+  context passing, Docker sandboxing, envs, the `llm` tool, the OpenAI
+  Responses protocol and its lifecycle operations (`responses`, background,
+  Conversations, compaction, WebSocket mode), and options.
 - [RELEASING.md](RELEASING.md) is the playbook for tagging a release on
   GitHub before an announcement: checklist, commands, pinned install line.
 

--- a/docs/durable-jobs.md
+++ b/docs/durable-jobs.md
@@ -1,0 +1,175 @@
+# Durable identity jobs
+
+`thinkers start --jobs-only` selects the persistent identity's exclusive
+application-job dispatcher. This mode owns application model turns and child
+execution. It does not start responder, monolith, subscriptions, or trajectory
+tailers. An application action enters exactly one admitted job. A model CLI
+belongs inside that job's registered handler, never in a competing application
+scheduler.
+
+This is a local POSIX implementation using Python 3.8+ and SQLite. Keep the
+identity on persistent local storage. SQLite WAL with `synchronous=FULL`,
+transactions, and directory fsync establish admission custody; `run/` contains
+only a disposable PID hint. Network filesystems and multi-host dispatchers are
+not supported. Model/provider credentials and policy remain operator choices.
+
+## Register and admit
+
+Run registration from trusted deployment code, not from a client-authored
+envelope. The executable must be absolute. The registry pins argv, declared
+version, and the executable's SHA-256. The declared version must identify its
+whole deployment, including any imported modules or interpreter arguments.
+Admission snapshots the registration, so registering a later version cannot
+silently redirect existing jobs. If the admitted executable's bytes change,
+execution stops with `unknown`; deploy immutable executable paths.
+
+```sh
+export IDENTITY_DIR=/persistent/identities/example
+thinkers jobs register application-turn < handler.json
+# handler.json: {"version":"deployment-sha","argv":["/immutable/application-handler"]}
+# => {"handler":"application-turn","handler_hash":"..."}
+thinkers jobs admit < admission.json
+thinkers start --jobs-only
+```
+
+The admission schema is:
+
+```json
+{
+  "version": 1,
+  "job_id": "canonical-job-id",
+  "trigger_step": "canonical-subject-id",
+  "parent_job_id": null,
+  "kind": "application-action",
+  "handler": "application-turn",
+  "handler_hash": "hash-returned-by-registration",
+  "admitted": {
+    "subject_ref": "opaque-subject",
+    "actor_ref": "opaque-verified-principal",
+    "delegation_refs": ["opaque-grant"],
+    "context_ref": "opaque-authorized-snapshot"
+  }
+}
+```
+
+`parent_job_id` is optional. `admitted` is an opaque object: Headlong preserves
+every value, array, actor/delegation/roster/runtime field, and reference into
+the actual handler's stdin. It applies no human-only reply filter. Use
+references and revocable application capabilities; do not persist bearer
+credentials in an envelope. Headlong does not authenticate these references or
+turn historical provenance into rights.
+
+Admission returns only after durable commit. The receipt includes `custody:
+"durable"`, job ID, immutable envelope/handler hashes, state, execution ID and
+result. Repeating the same job ID and JSON values returns existing custody;
+different values under that ID fail. Queue capacity limits concurrent execution,
+not admission retention: no capped pending queue, drop-oldest policy, or
+start/stop clearing applies. `HEADLONG_JOBS_MAX_CONCURRENT` defaults to 4.
+
+An application should commit its authorized canonical event before admission,
+then mark its outbox delivered only from this receipt. Recovery may resubmit
+the same envelope safely. The application still owns current resource rights,
+tool/effect/cancellation fences, and final publication/promotion.
+
+## Handler contract
+
+The registered argv executes without shell interpretation. Stdin receives the
+complete admission JSON. These environment variables identify its custody:
+
+- `HEADLONG_JOB_ID` and `HEADLONG_JOB_EXECUTION_ID`.
+- `HEADLONG_JOB_DIR`: persistent private evidence directory.
+- `HEADLONG_JOB_RESULT_FILE`: write a JSON terminal receipt here.
+- `HEADLONG_JOB_EXECUTION_TOKEN`: private process-custody token; never log it.
+
+Write `{ "outcome": "completed"|"cancelled"|"unknown", "result": ... }` to the
+result file and exit. Stdout/stderr are evidence files, not canonical replies.
+The supervisor fsyncs and records the terminal receipt after stopping the whole
+owned process group. A missing, malformed, or unconfirmed result stays unknown.
+A handler's completed result cannot hide an unsettled model attempt. A late
+completion after the durable cancellation fence is retained as unknown evidence.
+
+A child commission is another admission with the exact parent job ID. The
+registered handler executes the worker/task command and returns its candidate
+and evidence. It cannot grant Room/customer membership, commit application
+effects, approve its own output, or promote its candidate. Those remain the
+application's authenticated effect boundary.
+
+## Model attempts
+
+Inside the admitted handler, run the typed Responses primitive through:
+
+```sh
+thinkers jobs attempt "$HEADLONG_JOB_ID" "settle/turn-2/tool-continuation-1" -- llm ... < input.json
+```
+
+Attempts retain the same job process group. This command refuses callers
+outside that exact live job, wrong job IDs, and cancellation-fenced jobs. A
+transaction commits the stable attempt ID before spawning. Its fingerprint
+binds argv, stdin, LLM/SHELLM environment controls, optional
+`HEADLONG_JOB_ATTEMPT_CONTEXT`, and the Responses body-file bytes. Only the
+fingerprint is logged, not credentials. Use that optional context for immutable
+phase/model-policy receipts. The wrapper snapshots the Responses body file so
+the primitive consumes the exact bytes fingerprinted. Other files referenced by
+the executable/argv remain deployment-owned immutable inputs.
+
+The wrapper sets `HEADLONG_JOB_ATTEMPT_ID` and a persistent
+`LLM_RESPONSE_FILE`. PR1's typed response sidecar establishes completed or
+cancelled provider outcomes; stdout or a zero exit alone does not. Duplicate
+successful attempts replay their durable stdout. Duplicate started or unknown
+attempts return exit 75 and never CREATE again. Distinct stable phase and tool
+continuation IDs permit legitimate multiple completions inside one job.
+
+`thinkers jobs attempts JOB_ID` exposes typed attempt evidence for reconciliation.
+After custody loss, a valid terminal sidecar can settle an attempt, but partial
+stdout is never advertised as a replayable completed response. This operation
+does not poll a provider, issue a new CREATE, or infer job completion from a
+single model phase.
+
+## Cancellation, restart, and recovery
+
+`thinkers jobs cancel JOB_ID` atomically fences that job and its current child
+tree. Subsequent child admissions are refused. A queued job becomes cancelled;
+a running supervisor requests TERM, then stops the entire owned group. The
+group leader remains unreaped until after killpg, reserving its PID/PGID so
+cancellation cannot target a recycled unrelated process. A control-pipe EOF
+stops descendants if the supervisor crashes. Process-group escape (`setsid`,
+daemonization into another session) is outside this handler contract; run such
+workers in a separately enforced process/container boundary before adopting
+them. Remote cancellation remains unconfirmed until a typed terminal receipt.
+
+`thinkers stop` (or `thinkers jobs stop`) pauses the jobs dispatcher, preserves
+queued admissions, and lets supervised running jobs finish. It is not job
+cancellation. `thinkers start --jobs-only` restarts dispatch; a concurrent start
+fails closed. Legacy `thinkers start` is refused once an identity has selected
+jobs-only mode, including after deletion of `run/`.
+
+Startup reconciles existing custody before scheduling queued work. Live
+supervisor locks remain authoritative after dispatcher death. A started job
+whose supervisor and terminal execution receipt are both gone becomes unknown,
+never requeued. SQLite's private events are projected to
+`IDENTITY_DIR/jobs/trajectory.jsonl` with stable event IDs; that identity
+trajectory survives runtime cleanup and is regenerable from the ledger.
+
+Inspect with `thinkers jobs get JOB_ID` and `thinkers jobs list`. After actual
+provider/worker evidence has been reconciled, trusted operator code may settle
+an unknown job explicitly:
+
+```sh
+thinkers jobs recover JOB_ID < verified-recovery.json
+```
+
+The evidence object requires the exact `execution_id`, `outcome` of completed
+or cancelled, a `receipt_ref`, and its lowercase 64-character `receipt_sha256`.
+This is an operator attestation, not automatic verification of that referenced
+receipt. It never reruns a handler, repeats a CREATE, clears cancellation,
+expands admitted authority, or authorizes application promotion. Unknown jobs
+with live supervisors cannot be settled this way. Additional authorized work
+uses a new job with explicit causation after external outcome reconciliation.
+
+The offline test is `tests/test_durable_jobs.sh`. It exercises concurrent
+admission/dedupe, more than 16 queued jobs, actual handler context, dispatcher
+and supervisor crashes, runtime-directory deletion, descendant cancellation,
+independent concurrent jobs, child fences, typed attempt dedupe, and explicit
+unknown reconciliation. It uses real local processes and synthetic typed
+Responses receipts; it does not claim live provider or application effect-door
+verification.

--- a/docs/durable-jobs.md
+++ b/docs/durable-jobs.md
@@ -84,15 +84,45 @@ complete admission JSON. These environment variables identify its custody:
 Write `{ "outcome": "completed"|"cancelled"|"unknown", "result": ... }` to the
 result file and exit. Stdout/stderr are evidence files, not canonical replies.
 The supervisor fsyncs and records the terminal receipt after stopping the whole
-owned process group. A missing, malformed, or unconfirmed result stays unknown.
+owned process group. Completion also requires a successful handler exit. A
+missing, malformed, or unconfirmed result stays unknown.
 A handler's completed result cannot hide an unsettled model attempt. A late
 completion after the durable cancellation fence is retained as unknown evidence.
+If settle completed while a speculative attempt remains unknown, the job result
+is `{ "outcome": "unknown", "reason": "unsettled_model_attempts", "evidence":
+<the handler's completed result> }`. The full typed attempt sidecars remain
+available through `jobs attempts`. Explicit disposition of an unused speculative
+attempt requires a future application effect-reconciliation contract; this
+implementation does not infer that acceptance or claim the parent completed.
 
 A child commission is another admission with the exact parent job ID. The
 registered handler executes the worker/task command and returns its candidate
 and evidence. It cannot grant Room/customer membership, commit application
 effects, approve its own output, or promote its candidate. Those remain the
 application's authenticated effect boundary.
+
+When a handler needs its child result synchronously, use:
+
+```sh
+thinkers jobs wait-child "$HEADLONG_JOB_ID" "$CHILD_JOB_ID"
+```
+
+This requires the actual live parent process group and the exact admitted
+parent/child relationship. Finish active model attempts before yielding. The
+parent stays supervised and cancellable in durable `waiting` state; it releases
+its execution slot without restarting its handler. The sole dispatcher gives
+queued awaited children priority and resumes the parent only after a terminal
+child receipt and reacquisition of an execution slot. The command then prints
+that receipt. A FIFO notification wakes the waiting process; the ledger remains
+authoritative across lost notifications or dispatcher restart. Cancellation
+wakes the wait as a refusal and stops the same admitted child tree.
+
+Use this API instead of keeping a running parent in an application polling
+loop. Four running parents otherwise occupy the default four slots needed by
+their children. Nested child waits follow the same contract. Active execution
+remains bounded by `HEADLONG_JOBS_MAX_CONCURRENT`; the separate bound for
+supervised waiting parents is `HEADLONG_JOBS_MAX_WAITING` (default 32). A full
+waiting budget refuses a new yield without dropping the admitted child.
 
 ## Model attempts
 
@@ -119,6 +149,15 @@ successful attempts replay their durable stdout. Duplicate started or unknown
 attempts return exit 75 and never CREATE again. Distinct stable phase and tool
 continuation IDs permit legitimate multiple completions inside one job.
 
+The attempt controller and bundled `llm` stay in the job group. Adapter
+execution uses an attempt-owned subgroup recorded in the same durable ledger,
+with a reserved group leader and a control-pipe guardian. An adapter deadline
+stops only that attempt's subgroup and returns cancelled/unknown evidence to
+the same handler. Sibling phases and child commissions remain independent.
+Whole-job cancellation or supervisor death closes the guardian's control pipe
+and sweeps the subgroup. A job cannot become terminal while a subgroup still
+holds custody. Standalone `llm` retains its existing deadline behavior.
+
 `thinkers jobs attempts JOB_ID` exposes typed attempt evidence for reconciliation.
 After custody loss, a valid terminal sidecar can settle an attempt, but partial
 stdout is never advertised as a replayable completed response. This operation
@@ -129,7 +168,10 @@ single model phase.
 
 `thinkers jobs cancel JOB_ID` atomically fences that job and its current child
 tree. Subsequent child admissions are refused. A queued job becomes cancelled;
-a running supervisor requests TERM, then stops the entire owned group. The
+a running supervisor requests TERM, then stops the entire owned group after a
+six-second grace for the primitive's remote cancellation receipt. The local
+grace is configurable with `HEADLONG_JOB_CANCEL_GRACE` (0–60 seconds); shortening
+it can leave more remote outcomes unknown. The
 group leader remains unreaped until after killpg, reserving its PID/PGID so
 cancellation cannot target a recycled unrelated process. A control-pipe EOF
 stops descendants if the supervisor crashes. Process-group escape (`setsid`,
@@ -142,6 +184,26 @@ queued admissions, and lets supervised running jobs finish. It is not job
 cancellation. `thinkers start --jobs-only` restarts dispatch; a concurrent start
 fails closed. Legacy `thinkers start` is refused once an identity has selected
 jobs-only mode, including after deletion of `run/`.
+
+Legacy execution needs an explicit migration fence. Before any legacy start,
+Headlong records a durable execution epoch outside `run/`. Pre-upgrade
+identities with an `info.txt` or `thinkers/` directory also receive an untracked
+epoch: absence of old bookkeeping cannot prove they have stopped. Jobs-only
+adoption refuses until trusted operator code verifies that legacy processes and
+effects are quiescent and records evidence for that exact current epoch:
+
+```sh
+thinkers jobs legacy-status
+# => {"legacy_execution":"current-epoch"}
+thinkers jobs retire-legacy < verified-quiescence.json
+# {"legacy_execution":"current-epoch","quiescent":true,
+#  "receipt_ref":"process-and-effect-inventory","receipt_sha256":"...64 lowercase hex..."}
+```
+
+This is a trusted operator attestation, not automatic verification of legacy
+process death. Stale-epoch evidence is refused; a later legacy start invalidates
+the prior retirement. Never fabricate this receipt to work around a lost
+`run/` directory. The application deployment owns the actual migration proof.
 
 Startup reconciles existing custody before scheduling queued work. Live
 supervisor locks remain authoritative after dispatcher death. A started job
@@ -170,6 +232,9 @@ The offline test is `tests/test_durable_jobs.sh`. It exercises concurrent
 admission/dedupe, more than 16 queued jobs, actual handler context, dispatcher
 and supervisor crashes, runtime-directory deletion, descendant cancellation,
 independent concurrent jobs, child fences, typed attempt dedupe, and explicit
-unknown reconciliation. It uses real local processes and synthetic typed
+unknown reconciliation. It also checks the actual `llm` adapter's phase-local
+deadline, sibling settle/commission survival, four parent waits through two
+child levels, and restart/cancellation while waiting. It uses real local
+processes and synthetic typed
 Responses receipts; it does not claim live provider or application effect-door
 verification.

--- a/docs/examples/responses-request.sh
+++ b/docs/examples/responses-request.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# A subordinate completion worker, not a retry queue or a shell-code executor.
+set -uo pipefail
+if [[ "$#" -lt 2 || "$#" -gt 3 || "${1:-}" == --help ]]; then
+    echo 'Usage: responses-request.sh NEW_OUTPUT_DIR INPUT_ITEMS_JSON [CREATE_BODY_JSON]'
+    echo 'Makes one paid inference request when given arguments. Configure provider/key/model in the environment.'
+    exit 0
+fi
+command -v llm >/dev/null || { echo 'Put Headlong bin/ on PATH first' >&2; exit 2; }
+jq -e 'type == "array"' "$2" >/dev/null || exit 2
+if [[ "$#" == 3 ]]; then
+    jq -e 'type == "object"' "$3" >/dev/null || exit 2
+    export LLM_RESPONSES_BODY_FILE="$3"
+fi
+umask 077
+mkdir -- "$1" || { echo 'Use a new output directory; existing evidence is not overwritten' >&2; exit 2; }
+out=$(cd "$1" && pwd)
+export LLM_API_FORMAT=responses LLM_RESPONSE_FILE="$out/response.json"
+export LLM_USAGE_FILE="$out/usage.json"
+child=""; interrupted=0
+trap 'interrupted=1; [[ -z "$child" ]] || kill -TERM "$child" 2>/dev/null || true' INT TERM
+llm -m "${LLM_MODEL:-gpt-5.4-mini}" --no-stream --messages-file "$2" \
+    > "$out/stdout.txt" 2> "$out/stderr.txt" &
+child=$!
+rc=0
+wait "$child" || rc=$?
+if [[ "$interrupted" == 1 ]]; then
+    wait "$child" 2>/dev/null || true
+    rc=1
+fi
+child=""
+trap - INT TERM
+# Exit success is not sufficient: require a complete application result.
+if [[ "$rc" == 0 ]] && jq -e '.status == "completed" and .error == null
+    and (.id | type == "string" and length > 0) and (.output | type == "array")' \
+    "$out/response.json" >/dev/null 2>&1; then
+    outcome=completed
+else
+    outcome=needs_review
+    [[ "$rc" != 0 ]] || rc=1
+fi
+jq -n --arg outcome "$outcome" --argjson exit_code "$rc" \
+    '{outcome:$outcome,exit_code:$exit_code}' > "$out/outcome.json"
+cat "$out/outcome.json"
+exit "$rc"

--- a/docs/operating-headlong.md
+++ b/docs/operating-headlong.md
@@ -16,8 +16,10 @@ Use `llm` for extraction, classification, rewriting, or a single answer. Use
 `shellm` for standalone exploration, repository analysis, or data work where
 the model needs a shell. Use an identity for a user-facing assistant or a
 subordinate worker whose ongoing tasks, permissions, and lifecycle are owned by
-the application around it. Persistence does not replace authorization, job
-state, idempotency, approval, or retry logic in that application.
+the application around it. For application-owned actions, use the exclusive
+[durable identity jobs](durable-jobs.md) dispatcher for admission, model attempt
+dedupe, child execution and recovery. The application retains authorization,
+canonical effects and publication approval.
 
 The complete installation choices are in [Installing Headlong](install.md).
 The engine, sandbox, run explorer, and direct `llm` interface are documented in

--- a/docs/operating-headlong.md
+++ b/docs/operating-headlong.md
@@ -138,22 +138,24 @@ Use `chat --help` for bridge metadata, threaded history, files, and follow-ups.
 
 ## Memory, trajectory, context, and skills
 
-Run these inside `ada shell` (or another correctly activated environment):
+Run these inside `ada shell` (or another correctly activated environment).
+Replace `MEMORY_ID`, `STEP_OR_TRAJECTORY_ID`, and `SKILL_NAME` with values
+returned by the corresponding inspection commands:
 
 ```bash
 mem add --type fact "The deployment window is Tuesday."
 mem list --type fact -s
-mem show <id>
+mem show MEMORY_ID
 mem search "deployment window"     # model-assisted; costs a call
 
 traj tail -n 20
 traj search "deployment" -i
-traj show <step-or-trajectory-id>
+traj show STEP_OR_TRAJECTORY_ID
 traj check                         # read-only validation
 
 context --head 1 --tail 30         # JSON model-message view
 skills list
-skills show <name>
+skills show SKILL_NAME
 ```
 
 Use `mem edit <id> ...` to correct and `mem forget <id>` to delete only after

--- a/docs/operating-headlong.md
+++ b/docs/operating-headlong.md
@@ -1,0 +1,214 @@
+# Operating Headlong
+
+Headlong provides persistent identities, background thinkers, a trajectory,
+memory, skills, chat, and a dashboard. `shellm` is one execution tool inside
+Headlong: it lets a model inspect data and run bounded shell commands.
+
+## Choose the smallest runtime that fits
+
+| Need | Use | Why |
+|---|---|---|
+| One completion, with no command execution | `llm` | A direct model call with the least machinery |
+| A bounded investigation that may run code | `shellm` | A run with a work directory and run record; choose an actual sandbox separately |
+| A continuing assistant or background worker | A Headlong identity | Durable trajectory, memory, skills, messaging, and dispatcher |
+
+Use `llm` for extraction, classification, rewriting, or a single answer. Use
+`shellm` for standalone exploration, repository analysis, or data work where
+the model needs a shell. Use an identity for a user-facing assistant or a
+subordinate worker whose ongoing tasks, permissions, and lifecycle are owned by
+the application around it. Persistence does not replace authorization, job
+state, idempotency, approval, or retry logic in that application.
+
+The complete installation choices are in [Installing Headlong](install.md).
+The engine, sandbox, run explorer, and direct `llm` interface are documented in
+[the shellm guide](shellm.md).
+
+## Everyday identity workflow
+
+The installer normally creates a command named after the identity. If that
+name collides with another command, use `persona <name>` instead.
+
+```bash
+ada status                 # read-only health summary
+ada hello                  # send one message and wait briefly
+ada say "review this plan" # explicit one-message form
+ada                        # interactive chat
+ada stop                   # pause mind and dashboard
+ada start                  # resume monolith, responder, and dashboard
+ada dash                   # print/open the dashboard URL
+ada shell                  # advanced: identity-aware subshell
+```
+
+`persona <name> status` and the other forms work from any directory. Prefer
+them over manually activating an identity: `persona` locates the checkout,
+loads configuration in the right order, activates the identity, and ensures
+chat has a sender.
+
+`status` checks the live dispatcher PID and dashboard PID, then prints thinker
+status. The install-time `status.json` is only a snapshot. Its named PID files
+are the live source of truth. After `stop`, finish any external work before
+assuming it completed: stopping drains in-flight thinker work for a bounded
+period and may then terminate it.
+
+Do not have a thinker stop and restart its own dispatcher. The stop also kills
+the caller, so the restart cannot run. Perform lifecycle operations from an
+operator process outside that identity's dispatcher tree. The CLI refuses an
+unsafe self-stop unless explicitly overridden.
+
+## State, configuration, and ownership
+
+`HEADLONG_HOME` selects the state home; legacy `SHELLM_HOME` is the next
+explicit override. Otherwise Headlong uses `~/.headlong`, except that an older
+installation with only `~/.shellm` continues using that directory. The state
+home contains `.env`, `status.json`, `logs/`, `run/`, and `app_dir` (the
+recorded checkout path). A one-line `app_dir` file is the reliable way for an
+installed tool or skill to find source documentation.
+
+The current `persona` wrapper defaults directly to `~/.headlong`; on a legacy
+installation explicitly set `HEADLONG_HOME="$HOME/.shellm"` so its state path
+matches the other tools. Its checkout resolution prefers an explicit app-dir
+override, then its own source checkout, then the recorded `app_dir` and `app/`.
+
+The checkout owns `.identities/<name>/`. Important identity state includes:
+
+```text
+info.txt                  identity metadata and root trajectory
+activate                  generated environment setup
+.env                      optional identity-specific configuration
+memories/                 durable memory Markdown files
+skills/ and kernel/       available and always-loaded skills
+trajectories/             authoritative JSONL event history and blobs
+chat/.chatrc              operator sender name
+run/dispatcher.pid        live mind PID
+run/logs/                 thinker logs
+.shellm/ and workdir/     execution state and working files
+```
+
+The trajectory is the authoritative interaction and thought history. Derived
+message or deferral indexes can be rebuilt and are not the source of truth.
+Memories are curated durable facts, preferences, objectives, and notes; they
+should not be used as a job ledger. Skills are procedures presented to the
+mind, with kernel skills loaded on every wake and other eligible skills loaded
+on demand. The application integrating an identity remains responsible for
+requests, permissions, side-effect policy, and externally durable outcomes.
+
+Treat all of these as sensitive user data. Back them up together when
+persistence matters, restrict filesystem access, and never commit `.env`,
+identity state, trajectories, or bug-report archives.
+
+## Environment loading
+
+For routine use, use `persona <name> shell`. Direct `identity shell <name>`
+sets identity paths but does not preload checkout/state-home configuration;
+use it only when those defaults are already loaded. If automation must
+source `activate`, first load the checkout `.env`, then the state-home `.env`,
+without overriding variables already supplied by the process; only then source
+the identity's generated `activate` file. The activation script subsequently
+loads the identity `.env`. Sourcing `activate` alone can select an unintended
+model or omit credentials.
+
+```bash
+persona ada shell
+# work with chat, mem, traj, context, and skills
+exit
+```
+
+Do not nest identity shells. Exit the current one first. Explicit process
+environment values take precedence over file defaults. For thinker steps, the
+fallback sequence is identity `.env`, working-directory `.env`, the Headlong
+state-home `.env`, then legacy `~/.shellm/.env`; existing values still win.
+Keep model choice and credentials deliberate rather than relying on fallback.
+
+## Chat and sender identity
+
+`chat` requires an activated identity. Messages always append to the root
+trajectory, even when sent from a fork. A human/operator send needs a sender:
+
+```bash
+chat send --from operator "please summarize the latest findings"
+chat history 20
+```
+
+Persona commands that activate the identity (such as `say` and `status`) seed
+`default_send_from=operator` when absent. Direct `chat send`
+fails rather than inventing a sender. Use `--from` and `--to` when attribution
+must be explicit. An identity responding to another participant should use
+`chat reply`; self-addressed `chat send` is rejected to prevent reply loops.
+Use `chat --help` for bridge metadata, threaded history, files, and follow-ups.
+
+## Memory, trajectory, context, and skills
+
+Run these inside `ada shell` (or another correctly activated environment):
+
+```bash
+mem add --type fact "The deployment window is Tuesday."
+mem list --type fact -s
+mem show <id>
+mem search "deployment window"     # model-assisted; costs a call
+
+traj tail -n 20
+traj search "deployment" -i
+traj show <step-or-trajectory-id>
+traj check                         # read-only validation
+
+context --head 1 --tail 30         # JSON model-message view
+skills list
+skills show <name>
+```
+
+Use `mem edit <id> ...` to correct and `mem forget <id>` to delete only after
+confirming the target. `mem prefilter <query>` is a no-model candidate check;
+`mem search` asks a model to rank candidates. Memory files are Markdown with
+frontmatter, but use `mem` so IDs and metadata stay valid.
+
+Use `traj tail`, `search`, `show`, and `path` for inspection. `traj append`,
+`fork`, `merge`, and `check --fix` mutate history; reserve them for deliberate
+maintenance or application code. Large step fields may live in trajectory
+blob storage. `context` renders selected trajectory rows into model messages;
+it does not own the underlying history.
+
+`skills list` shows eligible skills; `skills list --all` also shows skills
+whose requirements are unmet. `skills show` can execute explicitly marked
+evaluation blocks in a skill, so review unfamiliar skill source before loading
+it. Installation and promotion operations change what the mind can do; use
+`headlong-skills --help`, review the source and requirements, and make those
+changes as an operator rather than from untrusted model output.
+
+## Failure triage
+
+1. Run `<name> status`. Distinguish a stopped dispatcher from a failed model
+   call or dashboard-only failure.
+2. Read the state-home `logs/init.log` and `logs/web.log`, then the identity's
+   `run/logs/`. Do not paste logs publicly without checking for user data.
+3. Confirm the checkout with `cat "$HEADLONG_HOME/app_dir"` (using the resolved
+   state home), and inspect `.identities/<name>/run/dispatcher.pid` with
+   `kill -0 <pid>` rather than trusting stale snapshots.
+4. Check model, endpoint, key presence, quota, and rate limits without printing
+   secrets. `persona status` reports the last recorded LLM health failure.
+5. Validate history with `traj check`; do not use `--fix` until a backup exists.
+6. If the dashboard alone failed, inspect `web.log`; identity messaging can
+   still work. If the mind is stopped, restart it externally with `<name> start`.
+7. For a shareable diagnostic archive, use `<name> bugreport`, inspect its
+   contents locally, and disclose only what is appropriate. Scrubbing reduces
+   risk but is not a substitute for review.
+
+## Safety and cost boundaries
+
+- Headlong and `shellm` can execute model-generated commands. Prefer Docker or
+  another sandbox; never weaken isolation merely to get a run unstuck.
+- A container that can reach a host model endpoint may also reach other host
+  services. Limit network paths and require authentication on sensitive APIs.
+- Give identities least-privilege credentials and filesystem access. Keep
+  production side effects behind application-owned authorization and approval.
+- Use dedicated, revocable, spend-capped model keys. Persistent thinkers call
+  models continuously; `mem search` and other helpers may make additional calls.
+- Avoid exposing host Docker control to generated code. It effectively grants
+  host-level power.
+- Stop the identity before maintenance that assumes a quiescent state, and back
+  up durable state before repair, import, deletion, or bulk edits.
+
+For installation, upgrades, exports, bug reports, and uninstall procedures,
+continue with [Installing Headlong](install.md). For bounded code execution,
+provider options, run summaries, and sandbox details, use
+[shellm — the RLM engine](shellm.md). The command's `--help` and current source
+remain authoritative when a checked-out version differs from these guides.

--- a/docs/responses-guide.md
+++ b/docs/responses-guide.md
@@ -185,8 +185,13 @@ expecting `new` on an old trajectory to discard its Conversation.
 Acknowledgements live at
 `$SHELLM_TRAJ_DIR/.responses-conversations/<conv_id>.json`, bound to canonical
 trajectory, provider and endpoint. The directory is 0700, files 0600, replacement
-atomic, and a local exclusive lock lasts for the whole run. Before dispatch the
-checkpoint becomes `in_flight`; terminal validation advances it to `ready`.
+atomic, and a local exclusive lock lasts for the whole run. That lock is keyed
+by provider, effective endpoint, and Conversation ID under
+`$HEADLONG_HOME/run/responses-conversations/` (or the selected legacy state
+home), independent of the trajectory root. Before dispatch the checkpoint
+becomes `in_flight`; terminal validation advances it to `ready`. A failed
+Conversation context render stops before dispatch and leaves the ready
+acknowledgement unchanged.
 Resume sends genuinely unsent rows, not old prompts and outputs a second time.
 Generated child calls and summaries do not inherit the parent's Conversation.
 
@@ -230,9 +235,11 @@ can overflow before upkeep. There is no universal threshold across models.
 `SHELLM_RESPONSES_COMPACT_MODE=auto` chooses server compaction for native OpenAI
 and standalone for other endpoints. `server` explicitly declares support for
 `context_management`; `standalone` forces replay and calls `/responses/compact`.
-Server output prunes replay to its **newest** compaction marker. Standalone output
-replaces the window **as-is**, including items before any marker. A failed
-standalone compact preserves the chain and disables upkeep for that run.
+Server output prunes replay to its **newest usable** compaction marker. A marker
+without non-empty opaque `encrypted_content` cannot prune or enter the replay.
+Standalone output replaces the window **as-is**, including items before any
+marker, after the same payload check. A failed standalone compact preserves the
+chain and disables upkeep for that run.
 Standalone upkeep only receives the completion's remaining time budget; its
 reported usage enters the shared ledger as `operation:"responses.compact"`.
 
@@ -251,7 +258,8 @@ Retention; background execution can require temporary provider storage.
 ## What changed, and how it is checked
 
 PR #1 hardening fixes abandoned WebSocket ownership, realistic frame sizes,
-provider/body parity, connection errors and age rotation; secret temp cleanup;
+provider/body parity, connection errors, age rotation, and drain-before-reuse
+rotation after each generation's 32 unique stream names; secret temp cleanup;
 unknown-create and terminal-state handling; absolute deadlines and truthful
 cancellation; Conversation resume and body-mode validation; repeated compaction,
 provider preservation and accounting; pagination completeness; and copy installs.

--- a/docs/responses-guide.md
+++ b/docs/responses-guide.md
@@ -171,7 +171,8 @@ Conversation mode is for a persistent session with one owner:
 SHELLM_API_FORMAT=responses SHELLM_MODEL=gpt-5.4-mini \
 SHELLM_RESPONSES_CONVERSATION=new shellm "Investigate the test failure in this sandbox"
 # In the same trajectory context, after the first run has stopped:
-SHELLM_API_FORMAT=responses shellm --resume "Continue with the next test"
+SHELLM_API_FORMAT=responses SHELLM_MODEL=gpt-5.4-mini \
+  shellm --resume "Continue with the next test"
 ```
 
 These commands execute model-generated Bash: do not run them unsandboxed on
@@ -236,7 +237,8 @@ Standalone upkeep only receives the completion's remaining time budget; its
 reported usage enters the shared ledger as `operation:"responses.compact"`.
 
 ```bash
-SHELLM_API_FORMAT=responses SHELLM_RESPONSES_COMPACT_MODE=server \
+SHELLM_API_FORMAT=responses SHELLM_MODEL=gpt-5.4-mini \
+SHELLM_RESPONSES_COMPACT_MODE=server \
 SHELLM_RESPONSES_COMPACT_THRESHOLD=20000 \
   shellm "Analyze these synthetic logs in the sandbox"
 ```

--- a/docs/responses-guide.md
+++ b/docs/responses-guide.md
@@ -1,0 +1,263 @@
+# Using Responses in Headlong
+
+Use Responses when a plain string completion is not enough: typed tool or
+multimodal output, recoverable long-running inference, a resumable conversation,
+or explicit control over a growing context window. These features remain
+optional. Chat Completions and the ordinary shellm loop still work without them.
+
+For the framework itself, start with [Operating Headlong](operating-headlong.md).
+For every flag, use `llm --help`, `responses --help`, and `shellm --help`;
+[the engine reference](shellm.md) and the
+[lifecycle contract](../design/responses-lifecycle.md) explain implementation details.
+Agents should load `skills show operating-headlong-responses`.
+
+## Choose the smallest surface
+
+| Need and intent | Use | Ownership and limitation |
+|---|---|---|
+| Classify, extract, draft, or inspect typed output without executing shell commands | `LLM_API_FORMAT=responses llm` | One completion; your caller validates and uses the result |
+| Let a model investigate files and execute Bash iteratively | `SHELLM_API_FORMAT=responses shellm` | A code-executing loop, not a passive completion API; use a sandbox |
+| Wait for slow inference without recreating it after a connection drop | Background `llm` over HTTPS | llm owns the wait/cancel attempt; your application owns durable jobs |
+| Recover, inspect, cancel, or delete remote objects | `responses` | Explicit lifecycle operations; use the original provider/account/endpoint |
+| Resume an interactive shellm session without resending old turns | Conversation mode | Server history plus local sent-step checkpoints; one local owner |
+| Reduce connection setup across repeated calls | WebSocket adapter/broker | Optional Python/uv transport; not an independent scheduler |
+| Control repeated context growth | Server or standalone compaction | Context optimization, not a factual database or deletion guarantee |
+
+Headlong does **not** supply application authorization, tenant isolation,
+exactly-once publication, durable task leases, or a business event store. A
+service can use `llm` as a subordinate worker while keeping those decisions in
+one application-owned coordinator. Treat model output and uploaded tool/document
+content as untrusted data; metadata is not authority.
+
+## Before making a request
+
+- Use a dedicated, spend-capped key. Native OpenAI reads `OPENAI_API_KEY`;
+  `openai-compatible` reads `LLM_API_KEY` with an explicit `LLM_API_URL`.
+  Never put a key in a command argument, prompt, committed file, or example.
+- Check `.env` files as well as the process environment. Explicit environment
+  settings win; `llm` also reads the working directory and state-home `.env`.
+  Isolate HOME/state and working directory for a service worker.
+- Choose a model the endpoint supports. Examples use `gpt-5.4-mini`; this is
+  illustrative, not a claim that every account or compatible provider has it.
+- Keep stdout, stderr, and the JSON sidecar separate. A partial streamed answer
+  is not a successful operation. Protect all three as potentially sensitive.
+- Set `LLM_MAX_TIME` and an output cap. These are latency/token controls, not
+  a provider dollar-spend guarantee. Hosted tools may have additional charges.
+
+### Capability and configuration matrix
+
+| Combination | Behavior |
+|---|---|
+| Native OpenAI + HTTPS | Completion, continuation, background and lifecycle paths; check account/model availability |
+| OpenRouter + HTTPS | Responses completion starts in exact replay; lifecycle paths are not promised |
+| Other OpenAI-compatible endpoint + HTTPS | Exact configured URL, compatible key; lifecycle/compaction support is endpoint-specific |
+| WebSocket | Only underlying `openai` or `openai-compatible`; uv and pinned `websockets==17.1` required |
+| Background + WebSocket | Rejected before dispatch; explicit background `0` overrides body `true` just as on HTTPS |
+| Conversation + previous response ID | Rejected; choose one state mechanism |
+| Shellm body-file Conversation | Rejected at startup; use `SHELLM_RESPONSES_CONVERSATION` |
+| `store:false` + shellm | Exact input/output-item replay; not a blanket no-retention promise |
+| Native server compaction + `store:false` | Supported; compaction and retention are independent choices |
+| Conversation + compaction threshold | Requires server compaction support, not standalone compaction |
+
+An HTTP(S) WebSocket endpoint is translated to WS(S) without changing its host,
+path or query. Shellm rejects a separate `RESPONSES_WS_URL` to prevent completion
+and lifecycle calls from silently targeting different servers. OpenRouter
+privacy/routing options are rejected by the WebSocket adapter, not ignored.
+
+## 1. A completion as a service worker
+
+From a checkout, put `bin/` and `tools/` on PATH. With an installed copy they are
+already in the installation prefix. The following commands **spend inference
+credits when run**; no live inference is needed to read or test this guide.
+
+```bash
+umask 077
+mkdir -p private-input
+printf '%s\n' '[{"role":"user","content":"Summarize these synthetic observations: A passed; B failed."}]' \
+  > private-input/input.json
+printf '%s\n' '{"store":false}' > private-input/body.json
+
+LLM_MODEL=gpt-5.4-mini LLM_MAX_TIME=60 LLM_MAX_TOKENS=800 \
+  bash docs/examples/responses-request.sh private-run-001 \
+  private-input/input.json private-input/body.json
+```
+
+The [executable example](examples/responses-request.sh) requires a new output
+directory and retains `response.json`, `stdout.txt`, `stderr.txt`, and
+`outcome.json`. It never retries a create or executes generated text. Exit 0
+requires a completed terminal object; incomplete is retained but not accepted
+as a complete application answer. Preserve failures for reconciliation, then
+apply your own retention policy. Do not put these directories in a public repo.
+
+Other typed input items can go into the JSON input array unchanged: input images
+or files, function-call outputs, and opaque reasoning items. Put additional
+supported create fields in the body file—for example `tools`, `include`,
+`text.format`, or `metadata`. llm owns `model`, `input`, `instructions`,
+`stream`, `max_output_tokens`, and `previous_response_id`; stale body values
+cannot override those controls. Supply instructions with `--system-prompt` in a
+direct llm call. For large input, prefer `--messages-file` over JSON on argv.
+
+For structured extraction, a body can request a schema:
+
+```json
+{"store":false,"text":{"format":{"type":"json_schema","name":"assessment","strict":true,"schema":{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"],"additionalProperties":false}}}}
+```
+
+Still validate the returned JSON against the application's schema and policy.
+Refusals, incomplete output, or tool-only results need explicit handling.
+`llm` preserves function calls in the sidecar; it does not execute your function.
+Shellm cannot dispatch Responses-native function calls without visible shellm
+output and fails closed instead of treating them as another empty turn.
+
+## 2. Long operations, interruption, and recovery
+
+Use the same example with `LLM_RESPONSES_BACKGROUND=1 LLM_MAX_TIME=300` when a
+provider supports background work. HTTPS streaming resumes a known response
+using its last sequence number; `--no-stream` uses polling. Direct example:
+
+```bash
+LLM_API_FORMAT=responses LLM_RESPONSES_BACKGROUND=1 \
+LLM_RESPONSE_FILE="$PWD/private-response.json" LLM_MAX_TIME=300 \
+  llm --provider openai -m gpt-5.4-mini --no-stream --messages-file private-input/input.json
+```
+
+`LLM_RETRIES` bounds GET retries/resumes, **not CREATE retries**. A lost create
+acknowledgement may mean the provider is already working. Do not wrap llm in a
+generic retry loop. `error.code=outcome_unknown` means reconcile; it does not
+mean “nothing happened.” Without a response ID, Headlong cannot discover the
+accepted operation for you. Keep your own operation/attempt correlation and
+provider request tracing; tracing alone does not make a create idempotent.
+
+One deadline covers create, polls, resumes and backoff. SIGINT/SIGTERM, deadline
+expiry, exhausted resumes and an intentional stream cut attempt cancellation
+when a background ID is known. Cancellation gets up to five additional seconds.
+Only a terminal object for that ID confirms settlement. `completed` may win the
+race; only `cancelled` confirms cancellation. A failed cancel preserves the ID
+and unknown outcome, rather than asserting the job stopped.
+
+```bash
+# Use the same provider, endpoint and account that created the object.
+responses get resp_example --include reasoning.encrypted_content
+responses input-items resp_example --all --order asc
+responses get resp_example --stream --starting-after 42
+# Mutation: run only when cancellation is intended and authorized.
+responses cancel resp_example
+```
+
+`responses get --stream` is an event-retrieval command: successful delivery of
+a **failed or cancelled** terminal event still exits 0. This differs from llm's
+completion-success contract. Inspect the event, not just the retrieval exit code.
+`--all` emits a merged list only after verified exhaustion; malformed or cyclic
+pagination, duplicates, 500 continuing pages, or a 64 MiB bound fail visibly.
+It cannot promise a consistent snapshot during concurrent edits.
+
+Deleting a Response or Conversation is explicit (`responses delete ID`,
+`responses conversations delete CID`). Do not make deletion a blind cleanup
+trap: it can remove recovery evidence or shared history, and is not proof that
+all provider retention or billing has ended.
+
+## 3. Stateful sessions and shellm continuation
+
+Ordinary Responses shellm uses a previous response ID and retains exact typed
+replay in its private run directory. OpenRouter and explicit `store:false`
+start with replay. A structured pre-generation continuation rejection can
+trigger one replay fallback; unknown outcomes and terminal failures cannot.
+After exit these process-local IDs/replay items disappear; a new process rebuilds
+from the durable trajectory. That is not exact typed replay across restarts.
+
+Conversation mode is for a persistent session with one owner:
+
+```bash
+SHELLM_API_FORMAT=responses SHELLM_MODEL=gpt-5.4-mini \
+SHELLM_RESPONSES_CONVERSATION=new shellm "Investigate the test failure in this sandbox"
+# In the same trajectory context, after the first run has stopped:
+SHELLM_API_FORMAT=responses shellm --resume "Continue with the next test"
+```
+
+These commands execute model-generated Bash: do not run them unsandboxed on
+sensitive work. Set a concrete `SHELLM_TRAJ_DIR`/trajectory when multiple sessions
+exist; do not guess which run `--resume` will select. `new` or empty/unset reuses
+the latest resumed header's Conversation; a different literal `conv_...` starts
+a different history window. To start fresh, start a new trajectory rather than
+expecting `new` on an old trajectory to discard its Conversation.
+
+Acknowledgements live at
+`$SHELLM_TRAJ_DIR/.responses-conversations/<conv_id>.json`, bound to canonical
+trajectory, provider and endpoint. The directory is 0700, files 0600, replacement
+atomic, and a local exclusive lock lasts for the whole run. Before dispatch the
+checkpoint becomes `in_flight`; terminal validation advances it to `ready`.
+Resume sends genuinely unsent rows, not old prompts and outputs a second time.
+Generated child calls and summaries do not inherit the parent's Conversation.
+
+On an ambiguous checkpoint, missing acknowledgement, mismatched binding, or stale
+lock: stop dispatch, inspect remote items and local trajectory, and reconcile
+ownership/delivery. There is no automatic repair command and no safe “delete the
+lock and retry” rule. Without proof, use a new explicit session and retain the
+old evidence. Atomic rename is not fsync-backed power-loss durability, a
+distributed lock, or coordination with other API clients sharing the Conversation.
+
+## 4. Low-latency repeated calls
+
+```bash
+SHELLM_API_FORMAT=responses SHELLM_API_TRANSPORT=websocket \
+SHELLM_MODEL=gpt-5.4-mini shellm "Inspect this sandbox and run its targeted tests"
+```
+
+Shellm owns a private broker socket and one provider connection. Direct llm
+callers can run `responses-ws serve --socket /private/path/broker.sock`, then set
+`LLM_PROVIDER=adapter`, `LLM_ADAPTER` to the executable path,
+`RESPONSES_WS_PROVIDER=openai` and `RESPONSES_WS_SOCKET` for each llm call. Use a
+supervisor to own that broker and `responses-ws stop --socket ...` to stop it.
+With no socket configured, the adapter is one-shot. A configured dead broker
+does **not** fall back to an independent create.
+
+Limits: 16 in-flight responses, 32 admitted local clients, 32 reusable stream
+names per connection; 16 MiB UTF-8 JSON frames; 64 events/16 MiB per-lane queues.
+Idle connections rotate after 55 minutes. These are transport limits, not a
+claim of unlimited parallelism or a durable queue. Slow consumers and oversize
+frames fail. If a caller disappears with an unsettled request, the connection
+is retired so late events cannot become someone else's answer. Other unsettled
+callers may also fail with unknown outcomes. Closure is not server cancellation.
+
+## 5. Context growth and evidence
+
+Set `SHELLM_RESPONSES_COMPACT_THRESHOLD` below the endpoint's context limit,
+reserving room for the next tool/document result and model output/reasoning.
+The threshold is a trigger, not a hard ceiling; input arriving in one large turn
+can overflow before upkeep. There is no universal threshold across models.
+
+`SHELLM_RESPONSES_COMPACT_MODE=auto` chooses server compaction for native OpenAI
+and standalone for other endpoints. `server` explicitly declares support for
+`context_management`; `standalone` forces replay and calls `/responses/compact`.
+Server output prunes replay to its **newest** compaction marker. Standalone output
+replaces the window **as-is**, including items before any marker. A failed
+standalone compact preserves the chain and disables upkeep for that run.
+Standalone upkeep only receives the completion's remaining time budget; its
+reported usage enters the shared ledger as `operation:"responses.compact"`.
+
+```bash
+SHELLM_API_FORMAT=responses SHELLM_RESPONSES_COMPACT_MODE=server \
+SHELLM_RESPONSES_COMPACT_THRESHOLD=20000 \
+  shellm "Analyze these synthetic logs in the sandbox"
+```
+
+Keep authoritative constraints, provenance and application decisions outside
+opaque compaction. Test recall of late-relevant constraints and superseded
+instructions—not only token savings. `store:false` does not imply Zero Data
+Retention; background execution can require temporary provider storage.
+
+## What changed, and how it is checked
+
+PR #1 hardening fixes abandoned WebSocket ownership, realistic frame sizes,
+provider/body parity, connection errors and age rotation; secret temp cleanup;
+unknown-create and terminal-state handling; absolute deadlines and truthful
+cancellation; Conversation resume and body-mode validation; repeated compaction,
+provider preservation and accounting; pagination completeness; and copy installs.
+
+Run `tests/run-all.sh responses` for focused protocol tests and
+`tests/run-all.sh` for the full harness. The executable example is covered by
+`tests/test_responses_examples.sh`; packaging by `tests/test_responses_install.sh`
+and `tests/smoke_install.sh`. Fault suites use curl stubs or local servers and
+synthetic data, not paid inference. A green hermetic suite is not a live-provider
+conformance certificate. Test your exact provider/model/policy combination with
+synthetic inputs and an explicitly approved spend bound before production use.

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -288,6 +288,39 @@ LLM_API_URL=http://localhost:11434/v1/chat/completions \
 llm -m qwen3:8b "hello"
 ```
 
+OpenAI's Responses completion protocol is opt-in. Native OpenAI and
+OpenRouter choose their `/responses` endpoint automatically;
+`openai-compatible` uses the exact configured URL without appending a path:
+
+```bash
+# Native OpenAI Responses, with the complete terminal object kept for tools,
+# typed output items, response IDs, status, and usage.
+LLM_API_FORMAT=responses \
+LLM_RESPONSE_FILE=/tmp/response.json \
+llm --provider openai -m gpt-5.5 --thinking high "solve carefully"
+
+# A compatible Responses endpoint.
+LLM_API_FORMAT=responses \
+LLM_PROVIDER=openai-compatible \
+LLM_API_URL=https://router.example/v1/responses \
+LLM_API_KEY=... \
+llm -m routed-model "hello"
+```
+
+`LLM_RESPONSES_BODY_FILE` may name a JSON object with other synchronous
+Responses create fields, including `tools`, `include`, `store`, `metadata`,
+`text.format`, `truncation`, and provider-specific extensions. `llm` owns the
+fields coupled to its CLI (`model`, `input`, `instructions`,
+`previous_response_id`, `max_output_tokens`, `stream`, and command-line
+reasoning settings). Typed message, image, file, reasoning, function-call, and
+function-output items in `--messages-file` pass through unchanged.
+
+Visible output text remains stdout; reasoning summaries go to stderr. The
+mode-0600 `LLM_RESPONSE_FILE` sidecar is the machine channel for the complete
+terminal Response or error envelope, including function-only results. Retrieval,
+cancellation, deletion, Conversations, background mode, and WebSocket sessions
+are lifecycle APIs and are not completion operations in this CLI.
+
 Set `LLM_API_KEY` if the endpoint wants a bearer token. The policy for
 which providers live in core is in
 [design/providers.md](../design/providers.md).
@@ -310,13 +343,21 @@ shellm "what os is this?"
 nested shellm runs the same way the vendor keys are, so `llm` calls
 inside generated code reach the endpoint too.
 
+To run shellm itself on Responses, set `SHELLM_API_FORMAT=responses` (and
+`SHELLM_RESPONSES_BODY_FILE` for extra create fields). Native OpenAI and generic
+compatible endpoints use `previous_response_id` while retaining an exact
+process-local replay chain. If an endpoint rejects continuation, shellm retries
+once with that chain and stays stateless for the rest of the run. OpenRouter's
+documented stateless Responses endpoint uses exact replay from the first turn.
+Remote response IDs and replay items are removed when the shellm process exits.
+
 A provider that can't speak this protocol (an SDK, a vendor CLI,
 signed requests) runs outside core as an adapter: set
 `LLM_PROVIDER=adapter` and `LLM_ADAPTER=/path/to/executable`, and
 `llm` runs that executable in place of curl. The adapter contract is
 in [design/providers.md](../design/providers.md).
 
-**Output contract:** stdout = text response, stderr = thinking tokens (Anthropic only), exit 0 = success. This makes it composable with pipes and subshells.
+**Output contract:** stdout = text response, stderr = thinking/reasoning output, exit 0 = success. This makes it composable with pipes and subshells.
 
 ## mem and skills
 

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -318,8 +318,9 @@ function-output items in `--messages-file` pass through unchanged.
 Visible output text remains stdout; reasoning summaries go to stderr. The
 mode-0600 `LLM_RESPONSE_FILE` sidecar is the machine channel for the complete
 terminal Response or error envelope, including function-only results. Retrieval,
-cancellation, deletion, Conversations, background mode, and WebSocket sessions
-are lifecycle APIs and are not completion operations in this CLI.
+cancellation, deletion, Conversations, and background mode are lifecycle APIs
+and are not completion operations in this CLI. WebSocket mode is a transport for
+the same completion, and rides the adapter seam described below.
 
 Set `LLM_API_KEY` if the endpoint wants a bearer token. The policy for
 which providers live in core is in
@@ -351,6 +352,59 @@ process-local replay chain. If an endpoint rejects continuation, shellm retries
 once with that chain and stays stateless for the rest of the run. OpenRouter's
 documented stateless Responses endpoint uses exact replay from the first turn.
 Remote response IDs and replay items are removed when the shellm process exits.
+
+### WebSocket mode
+
+Responses also has a WebSocket transport, where one connection carries every
+turn of a run instead of a fresh handshake per turn. It pays off for long,
+tool-heavy rollouts. Turn it on with `SHELLM_API_TRANSPORT=websocket`, which
+requires `SHELLM_API_FORMAT=responses`:
+
+```bash
+SHELLM_API_FORMAT=responses \
+SHELLM_API_TRANSPORT=websocket \
+SHELLM_MODEL=gpt-5.5 \
+shellm "audit this repo"
+```
+
+shellm starts `tools/responses-ws` as a broker at run start, with its unix
+socket inside the run's private directory, and stops it at cleanup. The broker
+holds the connection, reconnects when the server closes it (connections last up
+to 60 minutes), and multiplexes callers onto `stream_id` lanes within the
+documented limits of 16 in flight and 32 named lanes. `llm` reaches it through
+the adapter seam (`LLM_PROVIDER=adapter`), so nothing in the completion path
+gains a Python dependency.
+
+`tools/responses-ws` is a `uv` PEP 723 script whose only dependency is
+`websockets`; a machine without `uv` loses this transport and nothing else. It
+can also be used on its own:
+
+```bash
+# One-shot: no broker, one connection for one completion.
+LLM_API_FORMAT=responses LLM_PROVIDER=adapter \
+LLM_ADAPTER=$PWD/tools/responses-ws \
+LLM_RESPONSE_FILE=/tmp/response.json \
+llm -m gpt-5.5 "hello"
+
+# A broker several callers share, stopped by hand.
+tools/responses-ws serve --socket /tmp/ws.sock --idle 10 &
+RESPONSES_WS_SOCKET=/tmp/ws.sock LLM_PROVIDER=adapter ... llm -m gpt-5.5 "hello"
+tools/responses-ws stop --socket /tmp/ws.sock
+```
+
+| Variable | Meaning |
+|---|---|
+| `RESPONSES_WS_URL` | Endpoint, default `wss://api.openai.com/v1/responses` |
+| `RESPONSES_WS_SOCKET` | Broker socket; without a live one the adapter opens a one-shot connection |
+| `RESPONSES_WS_IDLE` | Broker idle minutes before it exits (default 10, `--idle` overrides) |
+
+The transport does not change any contract: text still streams to stdout,
+reasoning summaries to stderr, and the terminal object to `LLM_RESPONSE_FILE`.
+Continuation still rides `previous_response_id`, and a rejection still lands in
+the sidecar so shellm falls back to its replay chain. Nothing WebSocket-specific
+is forwarded into the Docker sandbox, because a container cannot reach a socket
+on the host: nested `llm` and `shellm` calls inside the sandbox take the
+ordinary HTTPS Responses path.
 
 A provider that can't speak this protocol (an SDK, a vendor CLI,
 signed requests) runs outside core as an adapter: set

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -393,6 +393,17 @@ once with that chain and stays stateless for the rest of the run. OpenRouter's
 documented stateless Responses endpoint uses exact replay from the first turn.
 Remote response IDs and replay items are removed when the shellm process exits.
 
+`SHELLM_RESPONSES_COMPACT_THRESHOLD=N` bounds how large that window gets. On a
+stateful run the number rides through to `llm` as the Responses
+`context_management` field and the server compacts inside the turn. On a
+replaying run (OpenRouter, a ZDR endpoint, or after a continuation fallback)
+nobody is compacting on shellm's behalf, so once a terminal response reports at
+least N input tokens shellm calls `responses compact` itself and swaps the
+replay chain for the window that comes back. Either way, a compaction item in a
+terminal output cuts the chain back to that item, which is where the API says
+the next window begins. A failed compact call is a warning, not an error: the
+chain stands and the next crossing tries again.
+
 ### WebSocket mode
 
 Responses also has a WebSocket transport, where one connection carries every

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -419,11 +419,13 @@ threshold, not a hard window-size limit. Select the method with
 - `standalone`: with a threshold, forces replay and calls `responses compact`
   when a terminal response reports at least N input tokens. The underlying
   provider, endpoint, and current instructions are retained even with WebSocket
-  transport. The returned `output` array replaces the chain **as-is**.
+  transport. Once its compaction item carries non-empty opaque
+  `encrypted_content`, the returned `output` array replaces the chain **as-is**.
 
 Server-produced compaction prunes replay to the **newest** marker and skips a
-second standalone compact on that turn. A failed/invalid standalone compact
-warns, preserves the chain, and disables standalone upkeep for the run.
+second standalone compact on that turn. An unusable server marker cannot prune
+known-good replay. A failed/invalid standalone compact warns, preserves the
+chain, and disables standalone upkeep for the run.
 Conversation mode with a threshold requires server compaction.
 
 `SHELLM_RESPONSES_CONVERSATION` moves that state to the server instead.
@@ -440,7 +442,10 @@ asked for and nothing local is a safe substitute.
 
 Shellm persists sent-step acknowledgements under the effective trajectory
 directory (`$SHELLM_TRAJ_DIR/.responses-conversations/`), using atomic mode-0600
-checkpoints and a local exclusive lock held for the whole run. Resume restores
+checkpoints. A local exclusive lock keyed by provider, effective endpoint, and
+Conversation ID lives under the canonical state home's
+`run/responses-conversations/` and is held for the whole run, regardless of the
+selected trajectory directory. Resume restores
 acknowledged step IDs, not text matching, so unsent execution output is still
 sent. Dispatch marks the checkpoint `in_flight`; successful terminal validation
 advances it to `ready`. Ambiguous/missing/mismatched checkpoints and stale locks
@@ -468,9 +473,10 @@ shellm "audit this repo"
 shellm starts `tools/responses-ws` as a broker at run start, with its unix
 socket inside the run's private directory, and stops it at cleanup. The broker
 holds the connection, opens a new connection for later calls after retirement,
-rotates idle connections older than 55 minutes, and multiplexes callers within
-the
-documented limits of 16 in flight and 32 named lanes. `llm` reaches it through
+rotates idle connections older than 55 minutes, and multiplexes at most 16 live
+lanes. Each connection generation assigns at most 32 stream names once, then
+drains its live lanes and rotates before reusing a name. Admission waits are
+bounded and stop when broker shutdown cancels them. `llm` reaches it through
 the adapter seam (`LLM_PROVIDER=adapter`), so nothing in the completion path
 gains a Python dependency.
 

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -321,6 +321,32 @@ terminal Response or error envelope, including function-only results. Retrieval,
 cancellation, deletion, Conversations, background mode, and WebSocket sessions
 are lifecycle APIs and are not completion operations in this CLI.
 
+### Lifecycle operations
+
+Stored Responses state has its own tool, `responses`. It shares `llm`'s
+provider resolution, keys, `LLM_API_URL` (its `/responses` suffix is stripped
+to find the API base), and net guards. Stdout is the API object and nothing
+else, one JSON document per command; a non-2xx prints
+`responses: error: <message>` on stderr and exits 1, and a usage error exits 2.
+
+```bash
+responses get resp_123 --include reasoning.encrypted_content
+responses cancel resp_123                  # background responses only
+responses input-items resp_123 --all       # follows has_more, merged output
+responses get resp_123 --stream --starting-after 42   # resume a background stream
+
+cid=$(responses conversations create --metadata '{"run":"r1"}' | jq -r .id)
+responses conversations add "$cid" --items-file items.json   # 20 items at a time
+responses conversations items "$cid" --all
+```
+
+`responses compact --model M --input-file chain.json` rewrites a long window
+into an opaque compaction item. The full command list is `responses --help`
+and the contract is in
+[design/responses-lifecycle.md](../design/responses-lifecycle.md).
+OpenRouter's `/responses` is stateless, so these paths return its own 404
+there.
+
 Set `LLM_API_KEY` if the endpoint wants a bearer token. The policy for
 which providers live in core is in
 [design/providers.md](../design/providers.md).

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -393,6 +393,17 @@ once with that chain and stays stateless for the rest of the run. OpenRouter's
 documented stateless Responses endpoint uses exact replay from the first turn.
 Remote response IDs and replay items are removed when the shellm process exits.
 
+`SHELLM_RESPONSES_CONVERSATION` moves that state to the server instead.
+`new` creates a Conversation at run start through `responses conversations
+create`, a `conv_...` id joins an existing one, and either way every call sends
+only the new rows with that conversation set and no `previous_response_id`. The
+id is recorded in the run's `shellm-run` header row, which is deliberate:
+Conversations do not expire, so `--resume` of that run with `new` picks the
+same one back up, while a literal id given on the resume wins over it. There is
+no replay chain and no fallback here. A conversation the provider refuses ends
+the run with its message, because durable server state is what the operator
+asked for and nothing local is a safe substitute.
+
 ### WebSocket mode
 
 Responses also has a WebSocket transport, where one connection carries every

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -318,8 +318,22 @@ function-output items in `--messages-file` pass through unchanged.
 Visible output text remains stdout; reasoning summaries go to stderr. The
 mode-0600 `LLM_RESPONSE_FILE` sidecar is the machine channel for the complete
 terminal Response or error envelope, including function-only results. Retrieval,
-cancellation, deletion, Conversations, background mode, and WebSocket sessions
-are lifecycle APIs and are not completion operations in this CLI.
+deletion, Conversations, and WebSocket sessions are lifecycle APIs and are not
+completion operations in this CLI.
+
+Background responses are the one lifecycle feature the completion CLI carries,
+because the caller still gets one terminal object per call. Set
+`LLM_RESPONSES_BACKGROUND=1` (or `background: true` in the body file; the
+variable wins when set). With `--no-stream`, llm polls the response by id every
+`LLM_RESPONSES_POLL_INTERVAL` seconds (default 2, doubling to 10) until it is
+terminal, within `LLM_MAX_TIME` overall. When streaming, a stream that drops
+after the response id is known is resumed from its last `sequence_number`
+instead of being recreated, up to `LLM_RETRIES` times, and text already
+printed is never printed twice. A killed llm (SIGINT, SIGTERM), an expired
+`LLM_MAX_TIME`, exhausted resumes, and a `--stop-after-code-block` cut all
+cancel the job on the way out, so nothing keeps generating for nobody.
+`cancelled` is terminal: the sidecar is written, nothing is printed, and llm
+exits non-zero. Under shellm, `SHELLM_RESPONSES_BACKGROUND=1` passes through.
 
 Set `LLM_API_KEY` if the endpoint wants a bearer token. The policy for
 which providers live in core is in

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -327,14 +327,24 @@ because the caller still gets one terminal object per call. Set
 `LLM_RESPONSES_BACKGROUND=1` (or `background: true` in the body file; the
 variable wins when set). With `--no-stream`, llm polls the response by id every
 `LLM_RESPONSES_POLL_INTERVAL` seconds (default 2, doubling to 10) until it is
-terminal, within `LLM_MAX_TIME` overall. When streaming, a stream that drops
+terminal. When streaming, a stream that drops
 after the response id is known is resumed from its last `sequence_number`
 instead of being recreated, up to `LLM_RETRIES` times, and text already
-printed is never printed twice. A killed llm (SIGINT, SIGTERM), an expired
-`LLM_MAX_TIME`, exhausted resumes, and a `--stop-after-code-block` cut all
-cancel the job on the way out, so nothing keeps generating for nobody.
-`cancelled` is terminal: the sidecar is written, nothing is printed, and llm
-exits non-zero. Under shellm, `SHELLM_RESPONSES_BACKGROUND=1` passes through.
+printed is never printed twice. Under shellm,
+`SHELLM_RESPONSES_BACKGROUND=1` passes through.
+
+**HTTP hardening contract (pending integration verification):** no automatic
+Responses CREATE retry after uncertain dispatch, even before the first token;
+unknown results fail with `error.code=outcome_unknown`. Chat retry policy is
+unchanged. Immediate, polled, and streamed replies share terminal validation.
+One absolute `LLM_MAX_TIME` deadline covers create, polling, reconnects, and
+backoff, with up to five additional seconds for best-effort cancellation.
+Cancellation on interruption or timeout is not a guarantee that generation
+stopped: only a terminal reply for the same response ID confirms settlement,
+and only `cancelled` confirms cancellation. Otherwise retain the unknown-outcome
+sidecar and known ID for reconciliation. Failed/cancelled terminal results exit
+nonzero without recreating the request; text already streamed cannot be
+withdrawn. See the [lifecycle contract](../design/responses-lifecycle.md#background-responses-binllm).
 
 ### Lifecycle operations
 
@@ -343,6 +353,10 @@ provider resolution, keys, `LLM_API_URL` (its `/responses` suffix is stripped
 to find the API base), and net guards. Stdout is the API object and nothing
 else, one JSON document per command; a non-2xx prints
 `responses: error: <message>` on stderr and exits 1, and a usage error exits 2.
+Temporary request/auth files are private and cleaned up on exit and handled
+signals. `--all` fails on malformed or non-progressing pagination, duplicate
+IDs, or continuing past 500 pages / 64 MiB, rather than returning an incomplete
+list as exhausted. It does not promise a snapshot during concurrent changes.
 
 ```bash
 responses get resp_123 --include reasoning.encrypted_content
@@ -393,27 +407,49 @@ once with that chain and stays stateless for the rest of the run. OpenRouter's
 documented stateless Responses endpoint uses exact replay from the first turn.
 Remote response IDs and replay items are removed when the shellm process exits.
 
-`SHELLM_RESPONSES_COMPACT_THRESHOLD=N` bounds how large that window gets. On a
-stateful run the number rides through to `llm` as the Responses
-`context_management` field and the server compacts inside the turn. On a
-replaying run (OpenRouter, a ZDR endpoint, or after a continuation fallback)
-nobody is compacting on shellm's behalf, so once a terminal response reports at
-least N input tokens shellm calls `responses compact` itself and swaps the
-replay chain for the window that comes back. Either way, a compaction item in a
-terminal output cuts the chain back to that item, which is where the API says
-the next window begins. A failed compact call is a warning, not an error: the
-chain stands and the next crossing tries again.
+`SHELLM_RESPONSES_COMPACT_THRESHOLD=N` opts into compaction at an input-token
+threshold, not a hard window-size limit. Select the method with
+`SHELLM_RESPONSES_COMPACT_MODE=auto|server|standalone`:
+
+- `auto` (default): the native OpenAI provider at its default URL or
+  `api.openai.com` uses server compaction, including replay with `store:false`.
+  Other configurations use standalone compact; endpoint support may vary.
+- `server`: explicitly declares endpoint support for `context_management`.
+  The threshold passes to llm independently of continuation or retention.
+- `standalone`: with a threshold, forces replay and calls `responses compact`
+  when a terminal response reports at least N input tokens. The underlying
+  provider, endpoint, and current instructions are retained even with WebSocket
+  transport. The returned `output` array replaces the chain **as-is**.
+
+Server-produced compaction prunes replay to the **newest** marker and skips a
+second standalone compact on that turn. A failed/invalid standalone compact
+warns, preserves the chain, and disables standalone upkeep for the run.
+Conversation mode with a threshold requires server compaction.
 
 `SHELLM_RESPONSES_CONVERSATION` moves that state to the server instead.
 `new` creates a Conversation at run start through `responses conversations
 create`, a `conv_...` id joins an existing one, and either way every call sends
 only the new rows with that conversation set and no `previous_response_id`. The
 id is recorded in the run's `shellm-run` header row, which is deliberate:
-Conversations do not expire, so `--resume` of that run with `new` picks the
-same one back up, while a literal id given on the resume wins over it. There is
+Conversations do not expire automatically, so `--resume` or `--traj` with `new`
+or an empty/unset setting picks the same one back up. A different literal ID
+redirects the run. There is
 no replay chain and no fallback here. A conversation the provider refuses ends
 the run with its message, because durable server state is what the operator
 asked for and nothing local is a safe substitute.
+
+Shellm persists sent-step acknowledgements under the effective trajectory
+directory (`$SHELLM_TRAJ_DIR/.responses-conversations/`), using atomic mode-0600
+checkpoints and a local exclusive lock held for the whole run. Resume restores
+acknowledged step IDs, not text matching, so unsent execution output is still
+sent. Dispatch marks the checkpoint `in_flight`; successful terminal validation
+advances it to `ready`. Ambiguous/missing/mismatched checkpoints and stale locks
+fail closed and require reconciliation; locks are never automatically stolen.
+This is not fsync/power-loss durability, distributed coordination, or an
+exactly-once delivery guarantee. Do not remove a lock and assume delivery is
+resolved. A fresh/different Conversation starts without local acknowledgements.
+Use the dedicated setting: shellm rejects `conversation` in its body file.
+Generated child calls and summaries do not inherit the parent's Conversation.
 
 ### WebSocket mode
 
@@ -431,15 +467,17 @@ shellm "audit this repo"
 
 shellm starts `tools/responses-ws` as a broker at run start, with its unix
 socket inside the run's private directory, and stops it at cleanup. The broker
-holds the connection, reconnects when the server closes it (connections last up
-to 60 minutes), and multiplexes callers onto `stream_id` lanes within the
+holds the connection, opens a new connection for later calls after retirement,
+rotates idle connections older than 55 minutes, and multiplexes callers within
+the
 documented limits of 16 in flight and 32 named lanes. `llm` reaches it through
 the adapter seam (`LLM_PROVIDER=adapter`), so nothing in the completion path
 gains a Python dependency.
 
 `tools/responses-ws` is a `uv` PEP 723 script whose only dependency is
-`websockets`; a machine without `uv` loses this transport and nothing else. It
-can also be used on its own:
+`websockets==17.1` (Python >=3.10). Copy and symlink installs include
+`responses-ws`; a machine without `uv` loses this transport and nothing else.
+It can also be used on its own:
 
 ```bash
 # One-shot: no broker, one connection for one completion.
@@ -456,14 +494,33 @@ tools/responses-ws stop --socket /tmp/ws.sock
 
 | Variable | Meaning |
 |---|---|
-| `RESPONSES_WS_URL` | Endpoint, default `wss://api.openai.com/v1/responses` |
-| `RESPONSES_WS_SOCKET` | Broker socket; without a live one the adapter opens a one-shot connection |
+| `RESPONSES_WS_PROVIDER` | Underlying `openai` or `openai-compatible` provider; shellm resolves it before selecting the adapter |
+| `LLM_API_URL` | Exact endpoint; HTTP(S) becomes WS(S), retaining path and query. Shellm uses its resolved `SHELLM_API_URL` / `LLM_API_URL` for lifecycle and completion alike |
+| `RESPONSES_WS_URL` | Direct-adapter endpoint override; rejected by shellm to prevent destination drift. Native OpenAI defaults to `wss://api.openai.com/v1/responses` |
+| `RESPONSES_WS_SOCKET` | Authoritative broker socket when set; unavailable or failed brokers fail the call. Only an unset value selects one-shot mode |
 | `RESPONSES_WS_IDLE` | Broker idle minutes before it exits (default 10, `--idle` overrides) |
 
-The transport does not change any contract: text still streams to stdout,
+Native OpenAI uses `OPENAI_API_KEY`; compatible endpoints use `LLM_API_KEY` and
+require an explicit URL. Direct adapter use with a configured `LLM_API_URL`
+and no underlying provider defaults to `openai-compatible`. Unsupported
+providers, OpenRouter routing/privacy settings, background execution, and
+`provider` / `stream_options` body settings fail before dispatch instead of
+being silently dropped. `store` passes through, while instructions,
+previous-response ID removal, and compaction thresholds follow HTTP ownership.
+
+JSON frames are bounded at 16 MiB of UTF-8 bytes (local framing overhead counts);
+per-lane queues at 64 events / 16 MiB; local clients at 32. Initial local request
+reads and writes have 30-second limits. Oversize frames and slow consumers fail.
+If a caller abandons an unsettled request, the broker retires that connection
+rather than reusing its lane. Other unsettled callers can also fail with
+`error.code=outcome_unknown`; closing the connection does not confirm server
+cancellation. There is no blind replay or fallback to a fresh one-shot create.
+
+Text still streams to stdout,
 reasoning summaries to stderr, and the terminal object to `LLM_RESPONSE_FILE`.
 Continuation still rides `previous_response_id`, and a rejection still lands in
-the sidecar so shellm falls back to its replay chain. Nothing WebSocket-specific
+the sidecar so shellm falls back to its replay chain; shellm uses replay from
+the outset with `store:false`. Nothing WebSocket-specific
 is forwarded into the Docker sandbox, because a container cannot reach a socket
 on the host: nested `llm` and `shellm` calls inside the sandbox take the
 ordinary HTTPS Responses path.

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ PREFIX="${PREFIX:-$HOME/.local/bin}"
 SYMLINKS="${SYMLINKS:-0}"
 RUN_INIT=0
 # Core agent tools (bin/) and the management/aux CLIs around them (tools/).
-BIN_TOOLS=(shellm shellm-docker skills mem llm context traj thinkers chat recap)
+BIN_TOOLS=(shellm shellm-docker skills mem llm responses context traj thinkers chat recap)
 AUX_TOOLS=(shellm-docker-broker identity shellm-explore headlong-skills headlong-init headlong-killall persona headlong-web headlong-slack-bridge headlong-telegram-bridge)
 TOOLS=("${BIN_TOOLS[@]}" "${AUX_TOOLS[@]}")
 

--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,7 @@ RUN_INIT=0
 # Core agent tools (bin/) and the management/aux CLIs around them (tools/).
 BIN_TOOLS=(shellm shellm-docker skills mem llm responses context traj thinkers chat recap)
 # responses-ws is optional at runtime: copying it does not require uv.
-AUX_TOOLS=(shellm-docker-broker identity shellm-explore headlong-skills headlong-init headlong-killall persona headlong-web headlong-slack-bridge headlong-telegram-bridge responses-ws)
+AUX_TOOLS=(shellm-docker-broker identity shellm-explore headlong-skills headlong-init headlong-killall persona headlong-web headlong-slack-bridge headlong-telegram-bridge responses-ws headlong-jobs)
 TOOLS=("${BIN_TOOLS[@]}" "${AUX_TOOLS[@]}")
 
 # ---------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,8 @@ SYMLINKS="${SYMLINKS:-0}"
 RUN_INIT=0
 # Core agent tools (bin/) and the management/aux CLIs around them (tools/).
 BIN_TOOLS=(shellm shellm-docker skills mem llm responses context traj thinkers chat recap)
-AUX_TOOLS=(shellm-docker-broker identity shellm-explore headlong-skills headlong-init headlong-killall persona headlong-web headlong-slack-bridge headlong-telegram-bridge)
+# responses-ws is optional at runtime: copying it does not require uv.
+AUX_TOOLS=(shellm-docker-broker identity shellm-explore headlong-skills headlong-init headlong-killall persona headlong-web headlong-slack-bridge headlong-telegram-bridge responses-ws)
 TOOLS=("${BIN_TOOLS[@]}" "${AUX_TOOLS[@]}")
 
 # ---------------------------------------------------------------------------

--- a/philosophy.md
+++ b/philosophy.md
@@ -205,7 +205,7 @@ or `./install.sh` from a checkout. The core needs nothing but bash, curl, jq, an
 
 Here's how I think about whether an agent architecture is on the right track. I call it the Thompson test, after Ken:
 
-1. **Can you understand every component in an afternoon?** Each of these tools is a single bash script. The whole core — the executables the mind runs plus the thinkers — is about 11K lines, and shellm, the largest, is a few thousand. You can read every line of code that comprises the entire agent.
+1. **Can you understand every component in an afternoon?** Each of these tools is a single bash script. The whole core — the executables the mind runs plus the thinkers — is about 10K lines, and shellm, the largest, is under 3K. You can read every line of code that comprises the entire agent.
 
 2. **Can you compose the pieces in ways the author didn't anticipate?** mem is just a CLI that manages files. You can pipe its output into anything. Skills are markdown files — editable, greppable, version-controllable. shellm can call itself. None of these composition patterns were "designed in" — they fall out of the Unix interface naturally.
 

--- a/philosophy.md
+++ b/philosophy.md
@@ -205,7 +205,7 @@ or `./install.sh` from a checkout. The core needs nothing but bash, curl, jq, an
 
 Here's how I think about whether an agent architecture is on the right track. I call it the Thompson test, after Ken:
 
-1. **Can you understand every component in an afternoon?** Each of these tools is a single bash script. The whole core — the executables the mind runs plus the thinkers — is about 10K lines, and shellm, the largest, is under 3K. You can read every line of code that comprises the entire agent.
+1. **Can you understand every component in an afternoon?** Each of these tools is a single bash script. The whole core — the executables the mind runs plus the thinkers — is about 11K lines, and shellm, the largest, is a few thousand. You can read every line of code that comprises the entire agent.
 
 2. **Can you compose the pieces in ways the author didn't anticipate?** mem is just a CLI that manages files. You can pipe its output into anything. Skills are markdown files — editable, greppable, version-controllable. shellm can call itself. None of these composition patterns were "designed in" — they fall out of the Unix interface naturally.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,3 +9,21 @@ one.
 
 An agent's own learned skills are data and live in its `.skills/`
 directory, which is gitignored.
+
+## Operating this framework
+
+- [operating-headlong](operating-headlong/SKILL.md) — choose between a
+  completion, shellm run, and persistent identity; operate chat, memory,
+  trajectory, context, skills, and dispatcher state safely.
+- [operating-headlong-responses](operating-headlong-responses/SKILL.md) —
+  typed completion workers, background recovery, Conversations, compaction,
+  WebSocket transport, and unknown-outcome handling.
+- [shellm](shellm/SKILL.md) — compatibility entry for the older skill name;
+  distinguishes the execution engine from the Headlong framework.
+
+The installer copies these alongside other bundled skills. Inside an identity,
+use `skills show operating-headlong` or `skills show operating-headlong-responses`.
+Coding agents discover the same source through `.agents/skills/` symlinks;
+edit the originals here, not a second copy. Human guides and runnable examples
+are in [docs/operating-headlong.md](../docs/operating-headlong.md) and
+[docs/responses-guide.md](../docs/responses-guide.md).

--- a/skills/operating-headlong-responses/SKILL.md
+++ b/skills/operating-headlong-responses/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: operating-headlong-responses
+description: Operates Headlong Responses completions, lifecycle state, Conversations, compaction and WebSocket transport. Use for typed inference workers, long operations, resumable sessions, or recovery from uncertain delivery.
+---
+
+# Operating Headlong Responses
+
+Choose an explicit execution/state mode, validate terminal results, and preserve
+uncertainty instead of replaying possibly accepted work.
+
+## Choose the boundary
+
+- `llm`: one completion. Use for extraction, classification, drafts, typed
+  function-call output, and inference subordinate to an application coordinator.
+- `shellm`: executes model-generated Bash in a loop. Use for sandboxed code or
+  file investigations, not merely to get a completion string.
+- `responses`: inspect or mutate existing remote lifecycle state.
+- `responses-ws`: optional uv transport; a broker amortizes connections, but is
+  not a durable job queue, authorization service, or server cancellation API.
+
+The embedding application owns authorization, tenant scoping, task leases,
+result publication and business state. Metadata and model output do not grant
+authority. This skill grants no permission to spend, publish, delete, or cancel.
+
+## Preflight
+
+1. Confirm the authorized task, model/provider, input scope and spend bound.
+   Use a sandbox for shellm and a dedicated capped key. Do not print secrets.
+2. Read `llm --help`, `responses --help`, `shellm --help` for installed behavior.
+   Inspect process environment and relevant `.env` configuration without dumping
+   values. Explicit environment wins. Avoid an ambient endpoint/key reroute.
+3. Native OpenAI uses `OPENAI_API_KEY`; compatible endpoints use `LLM_API_KEY`
+   and `LLM_API_URL`. Lifecycle operations must use the original account/provider/
+   endpoint. OpenRouter completion support does not imply lifecycle support.
+4. Set `LLM_MAX_TIME`, output-token cap and a private result directory. Reserve
+   a distinct `LLM_RESPONSE_FILE` and `LLM_USAGE_FILE` per concurrent call. Keep
+   stdout, stderr and sidecar separate; never execute streamed partial text.
+5. Pick exactly one state owner: process-local continuation/replay, or a
+   Conversation. Reject incompatible combinations before dispatch.
+
+## Make one call and classify its result
+
+```bash
+# Paid request: only after task/spend authorization; input is a JSON item array.
+LLM_API_FORMAT=responses LLM_RESPONSE_FILE=/private/run/response.json \
+LLM_USAGE_FILE=/private/run/usage.json LLM_MAX_TIME=60 \
+  llm --provider openai -m gpt-5.4-mini --no-stream --messages-file /private/input.json
+```
+
+- Successful protocol completion requires completed/incomplete status, a
+  nonempty ID, output array and no error. Incomplete is partial, not a complete
+  application answer. Validate schema/refusal/tool results before publication.
+- llm preserves typed function calls but does not execute your functions.
+  Shellm cannot dispatch native function-only results as shell commands.
+- Responses CREATE is never automatically retried by llm. Lost acknowledgements,
+  missing terminal events and malformed success bodies can be `outcome_unknown`.
+  Stop and reconcile; do not turn absence of text into permission to retry.
+- A structured, pre-generation previous-ID rejection permits shellm's one replay
+  fallback. Known response IDs, terminal failures and unknown outcomes do not.
+
+## Long-running inference and recovery
+
+Use `LLM_RESPONSES_BACKGROUND=1` over HTTPS only when the endpoint supports it.
+Known IDs can be polled/resumed; `LLM_RETRIES` bounds retrieval/resume attempts,
+not new creates. One deadline covers create, poll, resume and backoff.
+
+Interruption/deadline/exhaustion triggers best-effort cancellation with up to
+five extra seconds. Only a same-ID terminal result confirms settlement; only
+`cancelled` confirms cancellation. A completed result may win the race. Preserve
+unknown outcomes and IDs. Without an ID, automatic reconciliation is unavailable.
+
+Authorized inspection: `responses get ID`, `responses input-items ID --all`,
+`responses conversations items CID --all`. Stream retrieval exits 0 on delivery
+of any terminal event, including failed/cancelled; inspect the event's status.
+`--all` fails on incomplete/broken pagination rather than certifying exhaustion.
+Cancel/delete/add/update/remove mutate remote state; obtain appropriate authority.
+Never automatically delete recovery evidence after an error.
+
+## Sessions, transport, and context
+
+- `SHELLM_RESPONSES_CONVERSATION=new` creates server state; `--resume`/`--traj`
+  reuses the latest Conversation when the setting is new or empty/unset. A
+  different literal ID redirects the session. For fresh state use a new
+  trajectory. Reject body-file Conversations; use the dedicated setting.
+- Sent-step checkpoints are in the effective trajectory directory's
+  `.responses-conversations/`, private and atomically replaced, with a local
+  exclusive whole-run lock. In-flight, missing, mismatched checkpoints and stale
+  locks fail closed. Reconcile server items and trajectory before reuse. Do not
+  delete a lock and guess. This is not fsync/power-loss or distributed durability.
+- Ordinary non-Conversation replay/IDs disappear with the process; resumed
+  shellm rebuilds from trajectory, not persisted exact typed output. Child calls
+  and summaries do not inherit the parent's Conversation.
+- WebSocket uses uv plus pinned websockets, supports only underlying OpenAI or
+  compatible providers, and rejects background/privacy-policy combinations it
+  cannot honor. Shellm retains provider/key/endpoint semantics and rejects a
+  transport-only URL. A configured dead broker never falls back to one-shot.
+- Broker bounds: 16 active requests, 32 local clients, 16 MiB frames, 64 events/
+  16 MiB per lane. Abandonment retires the connection; other unsettled calls may
+  also fail unknown. Never assume a closed connection cancelled provider work.
+- Compaction mode `auto` uses native OpenAI server compaction, otherwise
+  standalone; `server` declares support; `standalone` forces replay. Retention
+  and capability are independent; native server compaction supports store=false.
+  Conversation compaction requires server support. Keep newest server marker,
+  but standalone output **as-is**. Standalone failure disables upkeep for the
+  run; upkeep uses remaining completion time and records reported usage.
+- Choose a compaction threshold with headroom for future input/output. Keep
+  constraints, provenance and application decisions outside opaque compaction.
+  store=false is not a ZDR or deletion guarantee.
+
+## Learn more and verify
+
+In a checkout read `docs/responses-guide.md`, its executable example
+`docs/examples/responses-request.sh`, and `design/responses-lifecycle.md`.
+For an installed copy, find the checkout in the state home's `app_dir`; if it is
+gone, rely on installed `--help` and this skill rather than assuming docs exist.
+Load `operating-headlong` for identity/dispatcher/core operations.
+
+Run `tests/run-all.sh responses` from a checkout for synthetic protocol faults;
+run the full harness before changing shared core behavior. Distinguish local
+stub/server evidence from live-provider conformance. Never run paid smoke tests
+without an approved provider/model/input/spend scope.

--- a/skills/operating-headlong/SKILL.md
+++ b/skills/operating-headlong/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: operating-headlong
+description: Operates Headlong identities, dispatchers, chat, memory, trajectories, context, and skills safely. Use for choosing between llm, shellm, and a persistent identity; routine identity work; state inspection; or failure triage.
+---
+
+# Operating Headlong
+
+Operate the persistent identity framework safely; use `shellm` only for its
+bounded recursive shell-execution role.
+
+## Choose a runtime
+
+- Use `llm` for one completion with no command execution.
+- Use `shellm` for bounded exploration or analysis that needs shell commands.
+- Use a Headlong identity for an ongoing assistant or worker that needs chat,
+  memory, skills, a trajectory, and a dispatcher.
+- Keep job state, authorization, idempotency, approvals, and external outcomes
+  in the integrating application. Identity persistence does not provide them.
+
+## Locate the installation
+
+Use `HEADLONG_HOME`, then legacy `SHELLM_HOME`, when explicitly set. Otherwise
+use `~/.headlong`, falling back to `~/.shellm` only when the former is absent
+and the latter exists. The current `persona` wrapper does not make that legacy
+fallback automatically: set `HEADLONG_HOME` explicitly for a legacy install.
+Resolve the checkout from `HEADLONG_APP_DIR`, then `SHELLM_APP_DIR`, then the
+wrapper's own source checkout, `$state_home/app_dir`, or `$state_home/app`.
+Never print `.env` or secret values.
+
+When available, read `$checkout/docs/operating-headlong.md` for the full human
+guide, `$checkout/docs/install.md` for lifecycle and recovery, and
+`$checkout/docs/shellm.md` for the execution engine. This procedure remains
+usable without those files.
+
+## Prefer the persona interface
+
+Use the installed identity-name command or `persona <name>` from any directory:
+
+```bash
+persona <name> status
+persona <name> say "message"
+persona <name> stop
+persona <name> start
+persona <name> dash
+persona <name> shell
+```
+
+Start with `status`; it checks live PIDs and thinker state. `status.json` is an
+install snapshot, not live authority. `start` starts the monolith and responder
+and queues their wakeups. Run stop/restart externally, never from inside the
+identity's own dispatcher tree.
+
+## Enter an identity safely
+
+Prefer `persona <name> shell`, then `exit`. Direct `identity shell <name>` does
+not preload checkout/state-home `.env`; use only with those defaults already
+loaded. Do not nest identity shells. Do not source `activate` bare: model and key
+defaults may be wrong. Automation that must activate manually must preserve
+existing environment values, load checkout `.env`, then state-home `.env`, then
+source `.identities/<name>/activate`; activation loads identity `.env`.
+
+The activated environment selects `MEM_DIR`, `SKILLS_DIR`, kernel skills,
+`TRAJ_DIR`, root `TRAJ_ID`, thinker directories, chat config, and model.
+
+## Inspect and operate durable state
+
+The checkout's `.identities/<name>/` owns the identity. Treat it as sensitive.
+Key sources are:
+
+- `trajectories/`: authoritative JSONL history and blobs. Derived indexes are
+  rebuildable. Inspect with `traj tail -n 20`, `traj search`, `traj show`, and
+  `traj check`. Avoid append/fork/merge/`check --fix` unless mutation is intended.
+- `memories/`: curated durable knowledge, not a job ledger. Use `mem list`,
+  `mem show`, `mem add --type TYPE`, `mem edit`, and `mem forget`. Prefer
+  `mem prefilter` for a no-model candidate check; `mem search` costs a call.
+- `skills/` and `kernel/`: on-demand and always-loaded procedures. Use
+  `skills list`, `skills list --all`, and `skills show`. Review unfamiliar
+  skills before showing them because marked evaluation blocks may execute.
+- `run/dispatcher.pid` and `run/logs/`: live process evidence and thinker logs.
+- `chat/.chatrc`: operator sender config. `chat send` requires `--from` or
+  `default_send_from`; `persona` seeds `operator` when absent.
+
+Messages append to the root trajectory. Human sends use `chat send`; identity
+responses use `chat reply`. Self-addressed sends are rejected to prevent loops.
+`context --head 1 --tail 30` renders history as model messages but does not own
+or alter the trajectory.
+
+## Triage failures
+
+1. Run `persona <name> status` and separate mind, model, and dashboard failures.
+2. Inspect state-home `logs/init.log` and `logs/web.log`, then identity
+   `run/logs/`; redact user data before sharing.
+3. Validate a PID with `kill -0`, and confirm checkout via state-home `app_dir`.
+4. Check model, endpoint, credential presence, quota, and rate limit without
+   revealing secrets. The persona status reports recorded LLM health failures.
+5. Run `traj check`; back up state before any repair.
+6. Restart a stopped mind externally with `persona <name> start`. A dashboard
+   failure need not mean messaging failed.
+7. `persona <name> bugreport` creates a scrubbed archive; inspect it before
+   disclosure because trajectories and memories contain user data.
+
+## Enforce boundaries
+
+- Prefer Docker or equivalent isolation for model-generated commands.
+- Do not expose host Docker control or broad host services to generated code.
+- Use least-privilege, revocable, spend-capped credentials.
+- Persistent thinkers and model-assisted searches incur ongoing cost.
+- Put side effects behind application-owned permission and approval checks.
+- Back up identity state before import, deletion, repair, or bulk edits.
+- Consult each command's `--help` and current source before uncommon or
+  destructive operations; do not infer flags.

--- a/skills/shellm/SKILL.md
+++ b/skills/shellm/SKILL.md
@@ -1,164 +1,31 @@
 ---
 name: shellm
-description: Reference for the shellm system — recursive LLM shell, identity management, memory, skills, trajectory, and all CLI tools. Use when working on shellm itself, debugging agent behavior, or understanding how the pieces fit together.
+description: Uses the legacy shellm skill name as a compatibility entry. Use when a request says shellm, then distinguish the bounded shellm execution engine from the Headlong identity framework and load operating-headlong for identity operations.
 ---
 
-# shellm
+# shellm compatibility entry
 
-> **This skill may be out of date.** The source of truth is always the code in `bin/`. If you find discrepancies, use the `skill-author` skill to update this file and open a PR.
+The name `shellm` now means the bounded Recursive Language Model execution
+engine (`bin/shellm`), not the whole framework. Headlong is the framework for
+identities, thinkers, chat, memory, trajectories, skills, and the dashboard.
 
-## Architecture overview
+First classify the request:
 
-shellm is a set of composable bash scripts that turn an LLM into an autonomous agent living in a shell. The stack, bottom to top:
+- For one completion without command execution, use `llm`.
+- For bounded exploration that executes model-generated shell code, use
+  `shellm` and consult `docs/shellm.md` in the installed checkout.
+- For identity, dispatcher, chat, memory, trajectory, context, skill, state, or
+  lifecycle work, load the `operating-headlong` skill and follow it instead.
 
-```
-llm              raw LLM calls (Anthropic, OpenAI, Gemini)
-shellm           recursive execute-in-shell loop on top of llm
-traj / context   step log (DAG) + message assembly for multi-turn
-mem / skills     persistent memory + learnable capabilities
-identity         isolated agent identities (own mem, skills, traj)
-think / chat     autonomous thinking + human conversation
-focus            goal tracking
-```
+Do not source an identity's generated `activate` file by itself. Prefer
+`persona <name> shell`; direct `identity shell` requires preloaded model/key
+configuration. Correct manual activation
+must load checkout and state-home configuration first. Do not rely on the old
+think-cycle, thought-process, directory-layout, or global-config claims that
+previous versions of this compatibility skill contained.
 
-An agent activates an identity (`source .identities/<name>/activate`), which sets env vars. All tools read from those env vars — no global config files.
-
-## bin/ reference
-
-### Core engine
-
-| Script | Purpose |
-|--------|---------|
-| `shellm` | Recursive LLM-in-bash loop. Sends a prompt to the LLM, executes returned bash code blocks, feeds output back, repeats until `FINAL` is set. The heart of the system. |
-| `llm` | Multi-provider LLM CLI. `llm [options] prompt` or stdin. Supports Anthropic, OpenAI, Gemini. Key flags: `-m MODEL`, `-s SYSTEM`, `-M MESSAGES_JSON`, `--stream`, `--thinking`. |
-
-### Identity & activation
-
-| Script | Purpose |
-|--------|---------|
-| `identity` | Manage isolated identities. Each has its own memories, skills, kernel, traj. Subcommands: `new`, `list`, `info`, `switch`, `delete`, `shell`, `prompt`. |
-
-Activate an identity to set env vars for all other tools:
-```bash
-source .identities/myagent/activate   # activate in current shell
-deactivate_identity                    # undo
-identity shell myagent                 # or: start a subshell
-```
-
-### Thinking & conversation
-
-| Script | Purpose |
-|--------|---------|
-| `think` | One autonomous think cycle. Reads traj + memories, calls shellm with think prompt, writes thought/action to traj, dispatches thought processes. `think step [--dry-run]`. |
-| `chat` | Send messages into the thought stream. `chat send <msg>` appends a human-msg step. `chat repl` gives a readline loop. |
-| `focus` | Goal management. `focus set <goal>`, `focus show`, `focus done <query>`. Stores goals as mem entries with type=goal. |
-
-### Memory & skills
-
-| Script | Purpose |
-|--------|---------|
-| `mem` | File-based memory store (markdown + YAML frontmatter). `mem add --type TYPE <text>`, `mem search <query>`, `mem list`, `mem show <name>`, `mem forget <name>`, `mem edit <name> <text>`. |
-| `skills` | Skill management. `skills install <src>`, `skills show <name>`, `skills promote <name>` (to kernel), `skills search <query>`, `skills remote add <path>`. |
-
-### Trajectory & context
-
-| Script | Purpose |
-|--------|---------|
-| `traj` | Trajectory operations (single-file and tree). Uses `TRAJ_DIR` + `TRAJ_ID`. `traj new`, `traj append`, `traj tail`, `traj cat`, `traj fork`, `traj merge`, `traj show`, `traj list`, `traj root`. `show` is unified: pass any ID (trajectory or step) and it searches all files in traj_dir. |
-| `context` | Reads traj, outputs a JSON messages array for `llm -M`. Maps step types to assistant/user roles. Key flags: `--traj_dir`, `--tail N`, `--head N`, `--max-bytes`, `--pin <step_id>`. |
-
-### File utilities
-
-| Script | Purpose |
-|--------|---------|
-| `view` | Read files with line numbers. `view FILE [START[:END]]`. |
-| `glob` | Git-aware glob matching sorted by mtime. `glob PATTERN [DIR] [--limit N]`. |
-| `sub` | Exact-string substitution in files. `sub FILE OLD NEW [--replace-all]`. |
-| `put` | Atomic file write from stdin. `echo content \| put FILE [--force]`. |
-
-### Docker sandboxing
-
-| Script | Purpose |
-|--------|---------|
-| `shellm-docker` | Constrained Docker facade for sandboxed execution. `run`, `build`, `ps`, `logs`, `rm`. |
-| `shellm-docker-broker` | Host-side broker that manages Docker containers for sandboxed shellm envs. |
-| `shellm-explore` | (Not covered here — run exploration tool.) |
-
-## Key environment variables
-
-These are set by `source .identities/<name>/activate`:
-
-| Variable | Points to |
-|----------|-----------|
-| `IDENTITY_NAME` | Identity name (e.g. "andy") |
-| `IDENTITY_DIR` | Identity root dir (e.g. `.identities/andy`) |
-| `MEM_DIR` | `$IDENTITY_DIR/memories` |
-| `SKILLS_DIR` | `$IDENTITY_DIR/skills` |
-| `SKILLS_KERNEL_DIR` | `$IDENTITY_DIR/kernel` |
-| `TRAJ_DIR` | `$IDENTITY_DIR/trajectories` |
-| `TRAJ_ID` | UUID of root trajectory |
-| `SHELLM_TRAJ_DIR` | Trajectory directory (default `$HOME/.shellm/trajectories`) |
-| `SHELLM_ENVS_DIR` | Env/container state directory |
-| `SHELLM_WORKDIRS_DIR` | Working directories base |
-| `SHELLM_BROKER_DIR` | Docker broker state directory |
-| `THINK_MODEL` | Model for think cycles |
-| `THINK_TICK_INTERVAL` | Seconds between autonomous ticks |
-
-Other important vars (not identity-scoped):
-
-| Variable | Purpose |
-|----------|---------|
-| `SHELLM_MODEL` | Default model for shellm |
-| `ANTHROPIC_API_KEY` | Anthropic API key for llm |
-| `OPENAI_API_KEY` | OpenAI API key for llm |
-
-## Identity directory layout
-
-```
-.identities/<name>/
-  info.txt              name=, cwd=, created=, think_model=, interval=
-  activate              source-able activation script
-  core_identity_prompt.md  (optional) custom system prompt
-  .env                  (optional) identity-specific env vars
-  memories/             mem entries (markdown files)
-  skills/               installed skills
-    .skillsrc           skill remotes config
-  kernel/               kernel skills (always loaded)
-    mem/SKILL.md        bootstrapped mem skill
-  .trajectories/        trajectory files
-    trajectory.jsonl          main consciousness stream
-    blobs/              spilled large fields
-  .shellm/              shellm working state
-  workdir/              working directory for think cycles
-```
-
-## How a think cycle works
-
-1. `think step` loads the think prompt template from `$IDENTITY_DIR/prompts/think.md`
-2. Replaces `{{identity_name}}` and `{{goals}}` in the template
-3. Appends recent traj context (last N steps via `traj tail`)
-4. Calls `shellm` with this prompt — shellm executes bash, loops until FINAL
-5. Writes the resulting thought or action to traj
-6. If it was an action, forks a child branch, executes via shellm, merges back
-7. Dispatches thought processes (TPs) — each TP gets recent thoughts and can write to traj/mem
-
-## Thinkers
-
-Thinkers live in `thinkers/`. Each has a `step` script, `prompt.md`, and `subscriptions.jsonl`. They subscribe to trajectory events and run autonomously via `thinkers start`:
-
-- **main** — core thought generator, produces stream-of-consciousness thoughts and actions
-- **intentions-goals-creator** — notices emerging goals, stores via mem
-- **intentions-goals-enforcer** — redirects when the stream drifts from goals
-- **learning** — extracts lessons from action/observation pairs
-- **mind-wandering** — surfaces associative memories
-- **system-architecture** — meta-cognitive self-modification
-- **values-beliefs-creator** — crystallizes values and beliefs
-- **values-beliefs-enforcer** — flags misalignment between behavior and values
-
-## Tips
-
-- All tools are designed to be composed via pipes and env vars
-- `shellm` is the only script that calls the LLM directly (via `llm`); everything else builds prompts and calls `shellm`
-- The `context` script is the bridge between traj (step log) and llm (messages array)
-- Skills are loaded on-demand via `skills show <name>`; kernel skills are always in context
-- To understand any script's full interface, run it with `--help` or read the source in `bin/`
+If repository docs are not adjacent to this installed skill, resolve state home
+from `HEADLONG_HOME`, legacy `SHELLM_HOME`, `~/.headlong`, or an existing legacy
+`~/.shellm`, in that order. Read its `app_dir` file and use
+`<checkout>/docs/shellm.md`. Check current command `--help` and source before
+uncommon or destructive operations.

--- a/tests/smoke_install.sh
+++ b/tests/smoke_install.sh
@@ -42,7 +42,7 @@ section() { printf '\n--- %s\n' "$1"; }
 # The tool list is install.sh's source of truth; pull the two arrays out of it.
 eval "$(grep -E '^(BIN|AUX)_TOOLS=' "$REPO/install.sh")"
 TOOLS=("${BIN_TOOLS[@]}" "${AUX_TOOLS[@]}")
-PY_TOOLS=(headlong-web headlong-slack-bridge headlong-telegram-bridge)
+PY_TOOLS=(headlong-web headlong-slack-bridge headlong-telegram-bridge responses-ws)
 
 is_py_tool() { local t; for t in "${PY_TOOLS[@]}"; do [[ "$t" == "$1" ]] && return 0; done; return 1; }
 

--- a/tests/test_context.sh
+++ b/tests/test_context.sh
@@ -114,6 +114,33 @@ else
     bad "invariant/alternating-roles"
 fi
 
+# 1b. --ids tags every message with the rows it renders. Unmerged, a row is
+# one message with its own step_id and an elision marker carries none; merged
+# (the default), a message carries every row it merged. The content is the
+# same either way once the tags are stripped, and without the flag no key
+# appears.
+# shellcheck disable=SC2086
+if run_case basic --tail 5 $PROD --ids --no-merge | jq -e '
+        type == "array"
+        and all(.[]; has("step_ids") and (.step_ids | type == "array"))
+        and all(.[] | select(.content | test("steps elided")); .step_ids == [])
+        and all(.[] | select(.content | test("steps elided") | not);
+                (.step_ids | length == 1) and (.step_ids[0] | type == "string" and length > 0))
+    ' >/dev/null 2>&1 \
+   && run_case basic --tail 5 $PROD --ids | jq -e '
+        any(.[]; .step_ids | length > 1)
+        and ([.[] | .step_ids[]] | length) == ([.[] | .step_ids[]] | unique | length)
+    ' >/dev/null 2>&1 \
+   && diff -q <(run_case basic --tail 5 $PROD --ids | jq -c 'map(del(.step_ids))') \
+              <(run_case basic --tail 5 $PROD | jq -c .) >/dev/null 2>&1 \
+   && diff -q <(run_case basic --tail 5 $PROD --ids --no-merge | jq -r '.[].content' ) \
+              <(run_case basic --tail 5 $PROD --no-merge | jq -r '.[].content') >/dev/null 2>&1 \
+   && run_case basic $PROD | jq -e 'all(.[]; has("step_ids") | not)' >/dev/null 2>&1; then
+    ok "invariant/ids-tag-rows"
+else
+    bad "invariant/ids-tag-rows"
+fi
+
 # 2. Output is valid UTF-8 even when truncation hits multibyte characters.
 # shellcheck disable=SC2086
 if run_case multibyte --prompt-limit 100 $PROD 2>/dev/null | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; then

--- a/tests/test_durable_jobs.py
+++ b/tests/test_durable_jobs.py
@@ -106,7 +106,7 @@ class DurableJobs(unittest.TestCase):
         self.env = dict(os.environ, IDENTITY_DIR=str(self.identity), JOB_TEST_TOOL=str(JOBS),
                         PATH=str(REPO / "bin") + os.pathsep + os.environ["PATH"], HEADLONG_JOBS_MAX_CONCURRENT="4",
                         HEADLONG_JOB_CANCEL_GRACE="0.2", HEADLONG_HOME=str(self.identity / "framework-home"),
-                        LLM_USAGE_LEDGER=str(self.identity / "usage.jsonl"))
+                        LLM_USAGE_LEDGER=str(self.identity / "usage.jsonl"), TMPDIR=self.temp.name)
         self.handler = Path(self.temp.name) / "handler"
         self.handler.write_text(HANDLER)
         self.handler.chmod(0o700)

--- a/tests/test_durable_jobs.py
+++ b/tests/test_durable_jobs.py
@@ -45,6 +45,32 @@ if mode=='uncertain':
     while not directory.joinpath('release').exists(): time.sleep(.03)
 if mode=='slowattempt':
     subprocess.run([os.environ['JOB_TEST_TOOL'],'attempt',envelope['job_id'],'fast/1','--',envelope['admitted']['stub']],input=b'hello')
+if mode=='adapter':
+    env=dict(os.environ,LLM_ADAPTER=envelope['admitted']['stub'],LLM_MAX_TIME=envelope['admitted'].get('deadline','600'),LLM_API_FORMAT='responses')
+    subprocess.run([os.environ['JOB_TEST_TOOL'],'attempt',envelope['job_id'],'fast/1','--',envelope['admitted']['llm'],'--provider','adapter','--model','fixture-model'],input=b'hello',env=env)
+if mode=='parallel-adapters':
+    commands=[]
+    for phase,deadline in [('fast/1','1'),('settle/1','10')]:
+        env=dict(os.environ,LLM_ADAPTER=envelope['admitted']['stub'],LLM_MAX_TIME=deadline,LLM_API_FORMAT='responses')
+        command=[os.environ['JOB_TEST_TOOL'],'attempt',envelope['job_id'],phase,'--',envelope['admitted']['llm'],'--provider','adapter','--model','fixture-model']
+        command_process=subprocess.Popen(command,stdin=subprocess.PIPE,env=env)
+        command_process.stdin.write(b'hello'); command_process.stdin.close()
+        commands.append(command_process)
+    directory.joinpath('phases-running').touch()
+    outcomes=[process.wait() for process in commands]
+    directory.joinpath('phase-exits.json').write_text(json.dumps(outcomes))
+if mode=='await-child':
+    directory.joinpath('parent-ready').touch()
+    if envelope['admitted'].get('barrier'):
+        while not Path(os.environ['IDENTITY_DIR']).joinpath('begin-waits').exists(): time.sleep(.03)
+    depth=envelope['admitted']['depth']
+    child=dict(envelope,job_id=envelope['job_id']+'/child',parent_job_id=envelope['job_id'])
+    child['admitted']={'mode':'await-child' if depth>1 else ('hold' if envelope['admitted'].get('leaf_hold') else 'complete'),'depth':depth-1}
+    admitted=subprocess.run([os.environ['JOB_TEST_TOOL'],'admit'],input=json.dumps(child).encode(),capture_output=True)
+    if admitted.returncode: raise RuntimeError(admitted.stderr.decode())
+    receipt=subprocess.run([os.environ['JOB_TEST_TOOL'],'wait-child',envelope['job_id'],child['job_id']],capture_output=True)
+    if receipt.returncode: raise RuntimeError(receipt.stderr.decode())
+    directory.joinpath('child-receipt.json').write_bytes(receipt.stdout)
 if mode=='cooperative':
     def cancel(*_):
         Path(os.environ['HEADLONG_JOB_RESULT_FILE']).write_text(json.dumps({'outcome':'cancelled','evidence':'cooperative local stop'}))
@@ -53,6 +79,7 @@ if mode=='cooperative':
     directory.joinpath('ready').touch()
     while True: time.sleep(.03)
 Path(os.environ['HEADLONG_JOB_RESULT_FILE']).write_text(json.dumps({'outcome':'completed','result':{'subject':envelope['trigger_step']}}))
+if mode=='failed-after-result': sys.exit(1)
 '''
 
 
@@ -77,7 +104,9 @@ class DurableJobs(unittest.TestCase):
         self.identity = Path(self.temp.name) / "identity"
         self.identity.mkdir()
         self.env = dict(os.environ, IDENTITY_DIR=str(self.identity), JOB_TEST_TOOL=str(JOBS),
-                        PATH=str(REPO / "bin") + os.pathsep + os.environ["PATH"], HEADLONG_JOBS_MAX_CONCURRENT="4")
+                        PATH=str(REPO / "bin") + os.pathsep + os.environ["PATH"], HEADLONG_JOBS_MAX_CONCURRENT="4",
+                        HEADLONG_JOB_CANCEL_GRACE="0.2", HEADLONG_HOME=str(self.identity / "framework-home"),
+                        LLM_USAGE_LEDGER=str(self.identity / "usage.jsonl"))
         self.handler = Path(self.temp.name) / "handler"
         self.handler.write_text(HANDLER)
         self.handler.chmod(0o700)
@@ -273,10 +302,10 @@ time.sleep(120)
         self.state("queued", "completed")
         self.assertFalse((self.directory("fenced") / "received.json").exists())
 
-    def test_legacy_start_still_dispatches_in_non_job_identity(self):
+    def test_legacy_dispatch_works_but_custody_loss_refuses_jobs_migration(self):
         thinker = self.identity / "thinkers" / "fixture"
         thinker.mkdir(parents=True)
-        (thinker / "step").write_text('#!/usr/bin/env bash\ncat > "$IDENTITY_DIR/legacy-received"\n')
+        (thinker / "step").write_text('#!/usr/bin/env bash\ncat > "$IDENTITY_DIR/legacy-received"\necho $$ > "$IDENTITY_DIR/legacy-child"\nexec sleep 120\n')
         (thinker / "step").chmod(0o700)
         (thinker / "subscriptions.jsonl").write_text('{"types":["action"]}\n')
         trajectory = self.identity / "trajectories" / "fixture"
@@ -293,9 +322,157 @@ time.sleep(120)
             with (trajectory / "trajectory.jsonl").open("a") as out:
                 out.write('{"type":"action","content":"legacy"}\n')
             wait_for(lambda: (self.identity / "legacy-received").exists())
+            wait_for(lambda: (self.identity / "legacy-child").exists())
+            legacy_child = int((self.identity / "legacy-child").read_text())
+            shutil.rmtree(self.identity / "run")
+            denied = subprocess.run([str(CLI), "start", "--jobs-only"], env=self.env, capture_output=True, text=True, timeout=15)
+            self.assertNotEqual(denied.returncode, 0)
+            self.assertIn("legacy execution has not been reconciled", denied.stderr)
+            self.assertTrue(is_running(legacy_child))
+            os.kill(legacy_child, signal.SIGTERM)
+            wait_for(lambda: not is_running(legacy_child) and not is_running(pid))
+            epoch = self.call("legacy-status")["legacy_execution"]
+            evidence = {"quiescent": True, "receipt_ref": "local-process-inventory", "receipt_sha256": "b" * 64}
+            self.call("retire-legacy", data=dict(evidence, legacy_execution="stale-epoch"), success=False)
+            self.call("retire-legacy", data=dict(evidence, legacy_execution=epoch))
+            self.start()
         finally:
-            stopped = subprocess.run([str(CLI), "stop", "--force"], env=env, capture_output=True, text=True, timeout=15)
+            stop_args = ["stop"] if (self.identity / "jobs" / "mode.json").exists() else ["stop", "--force"]
+            stopped = subprocess.run([str(CLI), *stop_args], env=env, capture_output=True, text=True, timeout=15)
             self.assertEqual(stopped.returncode, 0, stopped.stderr)
+
+    def test_real_llm_adapter_subgroup_is_owned_on_cancel_deadline_and_crash(self):
+        stub = Path(self.temp.name) / "adapter"
+        stub.write_text('''#!/usr/bin/env python3
+import json,os,signal,sys,time
+from pathlib import Path
+sys.stdin.read()
+signal.signal(signal.SIGTERM,signal.SIG_IGN)
+Path(os.environ['HEADLONG_JOB_DIR']).joinpath('adapter.json').write_text(json.dumps({'pid':os.getpid(),'pgid':os.getpgrp()}))
+while True: time.sleep(.05)
+''')
+        stub.chmod(0o700)
+        self.call("admit", data=self.envelope("adapter-cancel", mode="adapter", stub=str(stub), llm=str(REPO / "bin" / "llm")))
+        self.start()
+        wait_for(lambda: (self.directory("adapter-cancel") / "adapter.json").exists())
+        adapter = json.loads((self.directory("adapter-cancel") / "adapter.json").read_text())
+        db = sqlite3.connect(self.identity / "jobs" / "ledger.sqlite3")
+        owned_group = db.execute("SELECT adapter_pgid FROM attempts WHERE job_id='adapter-cancel'").fetchone()[0]
+        db.close()
+        self.assertEqual(adapter["pgid"], owned_group)
+        self.call("cancel", "adapter-cancel")
+        self.state("adapter-cancel", "unknown")
+        wait_for(lambda: not is_running(adapter["pid"]))
+        self.call("admit", data=self.envelope("adapter-deadline", mode="adapter", stub=str(stub), llm=str(REPO / "bin" / "llm"), deadline="1"))
+        wait_for(lambda: (self.directory("adapter-deadline") / "adapter.json").exists())
+        adapter = json.loads((self.directory("adapter-deadline") / "adapter.json").read_text())
+        row = self.state("adapter-deadline", "unknown")
+        self.assertFalse(row["cancel_requested"], "attempt deadline cancelled the whole job")
+        wait_for(lambda: not is_running(adapter["pid"]))
+        self.call("admit", data=self.envelope("adapter-crash", mode="adapter", stub=str(stub), llm=str(REPO / "bin" / "llm")))
+        wait_for(lambda: (self.directory("adapter-crash") / "adapter.json").exists())
+        adapter = json.loads((self.directory("adapter-crash") / "adapter.json").read_text())
+        os.kill(self.dbrow("adapter-crash")["worker_pid"], signal.SIGKILL)
+        self.state("adapter-crash", "unknown")
+        wait_for(lambda: not is_running(adapter["pid"]))
+
+    def test_fast_deadline_preserves_settle_attempt_and_child_commission(self):
+        stub = Path(self.temp.name) / "phase-adapter"
+        stub.write_text('''#!/usr/bin/env python3
+import json,os,sys,time
+from pathlib import Path
+sys.stdin.read()
+if os.environ['HEADLONG_JOB_ATTEMPT_ID']=='fast/1': time.sleep(120)
+else:
+    time.sleep(2)
+    Path(os.environ['LLM_RESPONSE_FILE']).write_text(json.dumps({'id':'response_settle','status':'completed','output':[]}))
+    print('settle completed')
+''')
+        stub.chmod(0o700)
+        self.call("admit", data=self.envelope("parallel", mode="parallel-adapters", stub=str(stub), llm=str(REPO / "bin" / "llm")))
+        self.start()
+        wait_for(lambda: (self.directory("parallel") / "phases-running").exists())
+        child = self.envelope("commission", mode="hold")
+        child["parent_job_id"] = "parallel"
+        self.call("admit", data=child)
+        wait_for(lambda: (self.directory("commission") / "child.pid").exists())
+        row = self.state("parallel", "unknown")
+        self.assertFalse(row["cancel_requested"])
+        self.assertEqual(json.loads((self.directory("parallel") / "phase-exits.json").read_text()), [75, 0])
+        attempts = {row["attempt_id"]: row for row in self.call("attempts", "parallel")}
+        self.assertEqual(attempts["fast/1"]["state"], "unknown")
+        self.assertEqual(attempts["settle/1"]["state"], "completed")
+        commission = self.call("get", "commission")
+        self.assertEqual(commission["state"], "running")
+        self.assertFalse(commission["cancel_requested"])
+        (self.directory("commission") / "release").touch()
+        self.state("commission", "completed")
+
+    def test_four_waiting_parents_release_slots_through_two_child_levels(self):
+        for index in range(4):
+            self.call("admit", data=self.envelope("parent-" + str(index), mode="await-child", depth=2, barrier=True))
+        self.start()
+        for index in range(4):
+            wait_for(lambda index=index: (self.directory("parent-" + str(index)) / "parent-ready").exists())
+        before = {row["job_id"]: row["execution_id"] for row in self.call("list")}
+        (self.identity / "begin-waits").touch()
+        observed = []
+        def all_complete():
+            rows = self.call("list")
+            observed.append(sum(row["state"] in {"starting", "running"} for row in rows))
+            return rows if len(rows) == 12 and all(row["state"] == "completed" for row in rows) else None
+        rows = wait_for(all_complete, timeout=20)
+        self.assertLessEqual(max(observed), 4)
+        for row in rows:
+            if row["job_id"] in before:
+                self.assertEqual(row["execution_id"], before[row["job_id"]])
+                self.assertEqual(json.loads((self.directory(row["job_id"]) / "child-receipt.json").read_text())["state"], "completed")
+
+    def test_cancellation_wakes_waiting_parent_and_stops_its_child(self):
+        self.call("admit", data=self.envelope("waiting", mode="await-child", depth=1, leaf_hold=True))
+        self.call("wait-child", "waiting", "wrong-child", success=False)
+        self.start()
+        self.state("waiting", "waiting")
+        wait_for(lambda: (self.directory("waiting/child") / "child.pid").exists())
+        child_pid = int((self.directory("waiting/child") / "child.pid").read_text())
+        self.call("cancel", "waiting")
+        self.state("waiting", "unknown")
+        self.state("waiting/child", "unknown")
+        wait_for(lambda: not is_running(child_pid))
+
+    def test_waiting_parent_restart_preserves_execution_and_crash_stays_unknown(self):
+        envelope = self.envelope("waiting-restart", mode="await-child", depth=1, leaf_hold=True)
+        self.call("admit", data=envelope)
+        dispatcher = self.start()
+        row = self.state("waiting-restart", "waiting")
+        wait_for(lambda: (self.directory("waiting-restart/child") / "child.pid").exists())
+        execution = row["execution_id"]
+        os.kill(dispatcher, signal.SIGKILL)
+        wait_for(lambda: not is_running(dispatcher))
+        shutil.rmtree(self.identity / "run")
+        self.start()
+        self.assertEqual(self.state("waiting-restart", "waiting")["execution_id"], execution)
+        os.kill(self.dbrow("waiting-restart")["worker_pid"], signal.SIGKILL)
+        self.state("waiting-restart", "unknown")
+        repeated = self.call("admit", data=envelope)
+        self.assertEqual(repeated["state"], "unknown")
+        self.assertEqual(repeated["execution_id"], execution)
+        self.assertEqual(len(self.call("list")), 2)
+        self.call("cancel", "waiting-restart")
+        self.state("waiting-restart/child", "unknown")
+
+    def test_completed_handler_receipt_cannot_hide_nonzero_exit(self):
+        self.call("admit", data=self.envelope("failed", mode="failed-after-result"))
+        self.start()
+        row = self.state("failed", "unknown")
+        self.assertEqual(row["result"]["reason"], "handler_did_not_exit_successfully")
+
+    def test_preupgrade_identity_requires_explicit_quiescence(self):
+        (self.identity / "info.txt").write_text("name=historical\n")
+        denied = subprocess.run([str(CLI), "start", "--jobs-only"], env=self.env, capture_output=True, text=True)
+        self.assertNotEqual(denied.returncode, 0)
+        self.assertIn("legacy execution has not been reconciled", denied.stderr)
+        self.assertTrue(self.call("legacy-status")["legacy_execution"].startswith("untracked-"))
 
     def test_parent_cancel_fence_and_cooperative_terminal(self):
         self.call("admit", data=self.envelope("parent", mode="cooperative"))

--- a/tests/test_durable_jobs.py
+++ b/tests/test_durable_jobs.py
@@ -1,0 +1,327 @@
+"""Offline custody/recovery tests through the shipped CLI and real processes."""
+import concurrent.futures
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+REPO = Path(__file__).resolve().parents[1]
+CLI = REPO / "bin" / "thinkers"
+JOBS = REPO / "tools" / "headlong-jobs"
+
+HANDLER = '''#!/usr/bin/env python3
+import hashlib,json,os,signal,subprocess,sys,time
+from pathlib import Path
+envelope=json.load(sys.stdin)
+directory=Path(os.environ['HEADLONG_JOB_DIR'])
+directory.joinpath('received.json').write_text(json.dumps(envelope))
+mode=envelope['admitted'].get('mode','complete')
+if mode=='hold':
+    child=subprocess.Popen([sys.executable,'-c',"import time; time.sleep(120)"])
+    directory.joinpath('child.pid').write_text(str(child.pid))
+    while not directory.joinpath('release').exists(): time.sleep(.03)
+if mode=='attempts':
+    command=[os.environ['JOB_TEST_TOOL'],'attempt',envelope['job_id']]
+    stub=envelope['admitted']['stub']
+    for phase in ['fast/1','fast/1','settle/1']:
+        result=subprocess.run(command+[phase,'--',stub],input=b'hello',capture_output=True)
+        if result.returncode: raise RuntimeError(result.stderr.decode())
+    wrong=subprocess.run([os.environ['JOB_TEST_TOOL'],'attempt','wrong-job','fast/1','--',stub],input=b'hello',capture_output=True)
+    if wrong.returncode==0: raise RuntimeError('wrong job permitted')
+if mode=='uncertain':
+    command=[os.environ['JOB_TEST_TOOL'],'attempt',envelope['job_id'],'fast/1','--',envelope['admitted']['stub']]
+    first=subprocess.run(command,input=b'hello',capture_output=True)
+    second=subprocess.run(command,input=b'hello',capture_output=True)
+    if first.returncode!=75 or second.returncode!=75: raise RuntimeError('uncertain CREATE retried')
+    directory.joinpath('attempt-deduped').touch()
+    while not directory.joinpath('release').exists(): time.sleep(.03)
+if mode=='slowattempt':
+    subprocess.run([os.environ['JOB_TEST_TOOL'],'attempt',envelope['job_id'],'fast/1','--',envelope['admitted']['stub']],input=b'hello')
+if mode=='cooperative':
+    def cancel(*_):
+        Path(os.environ['HEADLONG_JOB_RESULT_FILE']).write_text(json.dumps({'outcome':'cancelled','evidence':'cooperative local stop'}))
+        sys.exit(0)
+    signal.signal(signal.SIGTERM,cancel)
+    directory.joinpath('ready').touch()
+    while True: time.sleep(.03)
+Path(os.environ['HEADLONG_JOB_RESULT_FILE']).write_text(json.dumps({'outcome':'completed','result':{'subject':envelope['trigger_step']}}))
+'''
+
+
+def wait_for(predicate, timeout=15):
+    until = time.monotonic() + timeout
+    while time.monotonic() < until:
+        value = predicate()
+        if value:
+            return value
+        time.sleep(.04)
+    raise AssertionError("timed out waiting for observed state")
+
+
+def is_running(pid):
+    result = subprocess.run(["ps", "-o", "stat=", "-p", str(pid)], capture_output=True, text=True)
+    return result.returncode == 0 and bool(result.stdout.strip()) and not result.stdout.lstrip().startswith("Z")
+
+
+class DurableJobs(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="headlong-jobs-")
+        self.identity = Path(self.temp.name) / "identity"
+        self.identity.mkdir()
+        self.env = dict(os.environ, IDENTITY_DIR=str(self.identity), JOB_TEST_TOOL=str(JOBS),
+                        PATH=str(REPO / "bin") + os.pathsep + os.environ["PATH"], HEADLONG_JOBS_MAX_CONCURRENT="4")
+        self.handler = Path(self.temp.name) / "handler"
+        self.handler.write_text(HANDLER)
+        self.handler.chmod(0o700)
+        self.hash = self.call("register", "application", data={"version": "fixture-1", "argv": [str(self.handler)]})["handler_hash"]
+        self.dispatchers = []
+
+    def tearDown(self):
+        try:
+            for row in self.call("list"):
+                self.call("cancel", row["job_id"])
+            self.call("stop")
+            wait_for(lambda: all(not is_running(pid) for pid in self.dispatchers), timeout=5)
+            # Cancels can finish after the dispatcher stops; custody workers
+            # poll the durable fence independently of the dispatcher.
+            db = sqlite3.connect(self.identity / "jobs" / "ledger.sqlite3")
+            workers = [row[0] for row in db.execute("SELECT worker_pid FROM jobs WHERE worker_pid IS NOT NULL")]
+            db.close()
+            wait_for(lambda: all(not is_running(pid) for pid in workers), timeout=5)
+        finally:
+            self.temp.cleanup()
+
+    def call(self, *args, data=None, success=True):
+        result = subprocess.run([str(CLI), "jobs", *args], input=json.dumps(data) if data is not None else "",
+                                env=self.env, text=True, capture_output=True, timeout=15)
+        if success:
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return json.loads(result.stdout)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        return result
+
+    def envelope(self, name, **context):
+        return {"version": 1, "job_id": name, "trigger_step": "subject-" + name,
+                "kind": "application", "handler": "application", "handler_hash": self.hash,
+                "admitted": context}
+
+    def directory(self, name):
+        return self.identity / "jobs" / "work" / hashlib.sha256(name.encode()).hexdigest()
+
+    def start(self):
+        result = subprocess.run([str(CLI), "start", "--jobs-only"], env=self.env, capture_output=True, text=True, timeout=15)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        pid = json.loads(result.stdout)["dispatcher_pid"]
+        self.dispatchers.append(pid)
+        return pid
+
+    def state(self, name, state):
+        return wait_for(lambda: (row if (row := self.call("get", name))["state"] == state else None))
+
+    def dbrow(self, name):
+        db = sqlite3.connect(self.identity / "jobs" / "ledger.sqlite3")
+        db.row_factory = sqlite3.Row
+        row = dict(db.execute("SELECT * FROM jobs WHERE job_id=?", (name,)).fetchone())
+        db.close()
+        return row
+
+    def test_durable_admission_dedupe_context_and_no_queue_drop(self):
+        context = {"actor": {"id": "same-label-agent", "kind": "agent"}, "delegation": ["grant-1", "grant-2"],
+            "roster": [{"id": "h1", "label": "Sam"}, {"id": "h2", "label": "Sam"}, {"id": "a1", "label": "Sam"}],
+            "runtime": {"resident": "persistent", "capabilities": ["typed-effects"]}}
+        envelope = self.envelope("one", **context)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            receipts = list(pool.map(lambda _: self.call("admit", data=envelope), range(8)))
+        self.assertTrue(all(r["envelope_hash"] == receipts[0]["envelope_hash"] for r in receipts))
+        self.call("admit", data=self.envelope("one", changed=True), success=False)
+        for i in range(24):
+            self.call("admit", data=self.envelope("queued-" + str(i)))
+        self.assertEqual(len(self.call("list")), 25)
+        self.start()
+        wait_for(lambda: all(row["state"] == "completed" for row in self.call("list")))
+        self.assertEqual(json.loads((self.directory("one") / "received.json").read_text()), envelope)
+        events = [json.loads(line) for line in (self.identity / "jobs" / "trajectory.jsonl").read_text().splitlines()]
+        self.assertEqual(sum(event["type"] == "job-running" and event["job_id"] == "one" for event in events), 1)
+        denied = subprocess.run([str(CLI), "start"], env=self.env, capture_output=True, text=True)
+        self.assertNotEqual(denied.returncode, 0)
+        self.assertIn("durable jobs", denied.stderr)
+
+    def test_dispatcher_crash_run_deletion_restart_and_exact_child_cancel(self):
+        for name in ("a", "b"):
+            self.call("admit", data=self.envelope(name, mode="hold"))
+        pid = self.start()
+        for name in ("a", "b"):
+            wait_for(lambda name=name: (self.directory(name) / "child.pid").exists())
+        a_child = int((self.directory("a") / "child.pid").read_text())
+        b_child = int((self.directory("b") / "child.pid").read_text())
+        before = self.call("get", "a")["execution_id"]
+        os.kill(pid, signal.SIGKILL)
+        wait_for(lambda: not is_running(pid))
+        shutil.rmtree(self.identity / "run")
+        self.call("admit", data=self.envelope("after-crash"))
+        self.start()
+        self.state("after-crash", "completed")
+        self.assertEqual(self.call("get", "a")["execution_id"], before)
+        self.call("cancel", "a")
+        self.state("a", "unknown")
+        wait_for(lambda: not is_running(a_child))
+        self.assertTrue(is_running(b_child), "cancellation reached another job's process group")
+        (self.directory("b") / "release").touch()
+        self.state("b", "completed")
+        wait_for(lambda: not is_running(b_child))
+
+    def test_worker_crash_reconciles_unknown_and_sweeps_descendants(self):
+        self.call("admit", data=self.envelope("crash", mode="hold"))
+        self.start()
+        wait_for(lambda: (self.directory("crash") / "child.pid").exists())
+        child = int((self.directory("crash") / "child.pid").read_text())
+        row = self.dbrow("crash")
+        os.kill(row["worker_pid"], signal.SIGKILL)
+        self.state("crash", "unknown")
+        wait_for(lambda: not is_running(child))
+        replay = self.call("admit", data=self.envelope("crash", mode="hold"))
+        self.assertEqual(replay["state"], "unknown")
+        self.assertEqual(replay["execution_id"], row["execution"])
+        self.call("recover", "crash", data={"outcome": "completed", "execution_id": "wrong",
+            "receipt_ref": "verified-worker-report", "receipt_sha256": "a" * 64}, success=False)
+        recovered = self.call("recover", "crash", data={"outcome": "completed", "execution_id": row["execution"],
+            "receipt_ref": "verified-worker-report", "receipt_sha256": "a" * 64})
+        self.assertEqual(recovered["state"], "completed")
+
+    def test_phase_attempt_dedupe_uses_typed_sidecar_and_rejects_external_call(self):
+        stub = Path(self.temp.name) / "completion"
+        stub.write_text('''#!/usr/bin/env python3
+import json,os,sys
+from pathlib import Path
+sys.stdin.read()
+with (Path(os.environ['IDENTITY_DIR'])/'calls').open('a') as out: out.write(os.environ['HEADLONG_JOB_ATTEMPT_ID']+'\\n')
+Path(os.environ['LLM_RESPONSE_FILE']).write_text(json.dumps({'id':'response_fixture','status':'completed','output':[]}))
+print('answer')
+''')
+        stub.chmod(0o700)
+        self.call("admit", data=self.envelope("phases", mode="attempts", stub=str(stub)))
+        self.call("attempt", "phases", "external", "--", str(stub), success=False)
+        self.start()
+        self.state("phases", "completed")
+        self.assertEqual((self.identity / "calls").read_text().splitlines(), ["fast/1", "settle/1"])
+
+    def test_unknown_attempt_never_recreates(self):
+        stub = Path(self.temp.name) / "uncertain"
+        stub.write_text('''#!/usr/bin/env python3
+import os,sys
+from pathlib import Path
+sys.stdin.read()
+with (Path(os.environ['IDENTITY_DIR'])/'calls').open('a') as out: out.write('create\\n')
+sys.exit(75)
+''')
+        stub.chmod(0o700)
+        self.call("admit", data=self.envelope("unknown", mode="uncertain", stub=str(stub)))
+        self.start()
+        wait_for(lambda: (self.directory("unknown") / "attempt-deduped").exists())
+        self.assertEqual((self.identity / "calls").read_text().splitlines(), ["create"])
+        self.call("cancel", "unknown")
+        self.state("unknown", "unknown")
+
+    def test_attempt_sidecar_survives_supervisor_death_without_replay(self):
+        stub = Path(self.temp.name) / "sidecar-before-crash"
+        stub.write_text('''#!/usr/bin/env python3
+import json,os,sys,time
+from pathlib import Path
+sys.stdin.read()
+with (Path(os.environ['IDENTITY_DIR'])/'calls').open('a') as out: out.write('create\\n')
+Path(os.environ['LLM_RESPONSE_FILE']).write_text(json.dumps({'id':'response_recoverable','status':'completed','output':[]}))
+Path(os.environ['HEADLONG_JOB_DIR']).joinpath('provider-completed').touch()
+time.sleep(120)
+''')
+        stub.chmod(0o700)
+        self.call("admit", data=self.envelope("sidecar", mode="slowattempt", stub=str(stub)))
+        self.start()
+        wait_for(lambda: (self.directory("sidecar") / "provider-completed").exists())
+        os.kill(self.dbrow("sidecar")["worker_pid"], signal.SIGKILL)
+        self.state("sidecar", "unknown")
+        attempts = self.call("attempts", "sidecar")
+        self.assertEqual(attempts[0]["state"], "completed")
+        self.assertFalse(attempts[0]["result"]["replayable"])
+        self.assertEqual(attempts[0]["result"]["response"]["id"], "response_recoverable")
+        self.assertEqual((self.identity / "calls").read_text().splitlines(), ["create"])
+
+    def test_starting_crash_snapshot_never_runs_and_queued_work_survives_stop(self):
+        self.env["HEADLONG_JOBS_MAX_CONCURRENT"] = "0"
+        self.call("admit", data=self.envelope("fenced"))
+        self.call("admit", data=self.envelope("queued"))
+        pid = self.start()
+        self.call("stop")
+        wait_for(lambda: not is_running(pid))
+        self.assertEqual(self.call("get", "queued")["state"], "queued")
+        # The durable snapshot after a crash between the start transaction
+        # and Popen. Nothing can establish whether an external worker began.
+        db = sqlite3.connect(self.identity / "jobs" / "ledger.sqlite3")
+        db.execute("UPDATE jobs SET state='starting',execution='crashed-before-spawn' WHERE job_id='fenced'")
+        db.commit()
+        db.close()
+        self.env["HEADLONG_JOBS_MAX_CONCURRENT"] = "4"
+        self.start()
+        self.state("fenced", "unknown")
+        self.state("queued", "completed")
+        self.assertFalse((self.directory("fenced") / "received.json").exists())
+
+    def test_legacy_start_still_dispatches_in_non_job_identity(self):
+        thinker = self.identity / "thinkers" / "fixture"
+        thinker.mkdir(parents=True)
+        (thinker / "step").write_text('#!/usr/bin/env bash\ncat > "$IDENTITY_DIR/legacy-received"\n')
+        (thinker / "step").chmod(0o700)
+        (thinker / "subscriptions.jsonl").write_text('{"types":["action"]}\n')
+        trajectory = self.identity / "trajectories" / "fixture"
+        trajectory.mkdir(parents=True)
+        (trajectory / "trajectory.jsonl").touch()
+        env = dict(self.env, IDENTITY_NAME="fixture", TRAJ_DIR=str(trajectory.parent), TRAJ_ID="fixture")
+        result = subprocess.run([str(CLI), "start"], env=env, capture_output=True, text=True, timeout=15)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        pid = int((self.identity / "run" / "dispatcher.pid").read_text())
+        self.dispatchers.append(pid)
+        try:
+            wait_for(lambda: (self.identity / "run" / "tail_pids").exists())
+            time.sleep(.1)
+            with (trajectory / "trajectory.jsonl").open("a") as out:
+                out.write('{"type":"action","content":"legacy"}\n')
+            wait_for(lambda: (self.identity / "legacy-received").exists())
+        finally:
+            stopped = subprocess.run([str(CLI), "stop", "--force"], env=env, capture_output=True, text=True, timeout=15)
+            self.assertEqual(stopped.returncode, 0, stopped.stderr)
+
+    def test_parent_cancel_fence_and_cooperative_terminal(self):
+        self.call("admit", data=self.envelope("parent", mode="cooperative"))
+        child = self.envelope("child", mode="cooperative")
+        child["parent_job_id"] = "parent"
+        self.call("admit", data=child)
+        self.start()
+        for name in ("parent", "child"):
+            wait_for(lambda name=name: (self.directory(name) / "ready").exists())
+        self.call("cancel", "parent")
+        self.state("parent", "cancelled")
+        self.state("child", "cancelled")
+        late = self.envelope("late")
+        late["parent_job_id"] = "parent"
+        self.call("admit", data=late, success=False)
+
+    def test_queued_cancel_and_changed_registered_bytes_fail_closed(self):
+        self.call("admit", data=self.envelope("queued"))
+        self.assertEqual(self.call("cancel", "queued")["state"], "cancelled")
+        self.call("admit", data=self.envelope("modified"))
+        self.handler.write_text(HANDLER + "\n# changed after admission\n")
+        self.start()
+        row = self.state("modified", "unknown")
+        self.assertEqual(row["result"]["reason"], "registered_handler_bytes_changed")
+        self.assertFalse((self.directory("queued") / "received.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_durable_jobs.sh
+++ b/tests/test_durable_jobs.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$HERE/test_durable_jobs.py"

--- a/tests/test_llm_adapter.sh
+++ b/tests/test_llm_adapter.sh
@@ -14,6 +14,10 @@
 #   - -s reaches the adapter via --system-prompt-file
 #   - --no-stream, --effort, and --thinking LEVEL are forwarded
 #   - LLM_USAGE_FILE reaches the adapter and its usage lands in the ledger
+#   - LLM_API_FORMAT=responses is allowed for the adapter provider and adds
+#     --api-format responses to the argv, with the Responses environment
+#     (LLM_RESPONSE_FILE, LLM_PREVIOUS_RESPONSE_ID, LLM_RESPONSES_BODY_FILE)
+#     visible to the adapter; chat mode passes no --api-format at all
 #   - the system-prompt tempfile is mode 0600 (private prompt in /tmp)
 #   - LLM_MAX_TIME is a hard deadline: TERM, 5s grace, then KILL — and a
 #     deadline expiry fails the call even if the adapter exits 0 on TERM
@@ -51,6 +55,14 @@ for a in "$@"; do
     fi
     prev="$a"
 done
+if [[ -n "${ADAPTER_ENV:-}" ]]; then
+    {
+        printf 'LLM_API_FORMAT=%s\n' "${LLM_API_FORMAT:-}"
+        printf 'LLM_RESPONSE_FILE=%s\n' "${LLM_RESPONSE_FILE:-}"
+        printf 'LLM_PREVIOUS_RESPONSE_ID=%s\n' "${LLM_PREVIOUS_RESPONSE_ID:-}"
+        printf 'LLM_RESPONSES_BODY_FILE=%s\n' "${LLM_RESPONSES_BODY_FILE:-}"
+    } > "$ADAPTER_ENV"
+fi
 if [[ -n "${ADAPTER_USAGE:-}" && -n "${LLM_USAGE_FILE:-}" ]]; then
     printf '%s' "$ADAPTER_USAGE" > "$LLM_USAGE_FILE"
 fi
@@ -68,16 +80,19 @@ export ADAPTER_ARGS="$WORK/adapter_args"
 export ADAPTER_STDIN="$WORK/adapter_stdin"
 export ADAPTER_SYS="$WORK/adapter_sys"
 export ADAPTER_SYS_MODE="$WORK/adapter_sys_mode"
+export ADAPTER_ENV="$WORK/adapter_env"
 export LLM_RETRIES=0
 unset ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY \
       OPENCODE_API_KEY LLM_API_KEY LLM_PROVIDER LLM_API_URL LLM_MODEL \
       LLM_MAX_TOKENS SHELLM_MODEL SHELLM_API_URL LLM_ADAPTER \
-      ADAPTER_USAGE ADAPTER_RC LLM_USAGE_FILE LLM_USAGE_LEDGER
+      ADAPTER_USAGE ADAPTER_RC LLM_USAGE_FILE LLM_USAGE_LEDGER \
+      LLM_API_FORMAT LLM_RESPONSE_FILE LLM_PREVIOUS_RESPONSE_ID \
+      LLM_RESPONSES_BODY_FILE
 cd "$WORK" || exit 1
 
 LLM="$REPO/bin/llm"
 
-reset() { : > "$ADAPTER_ARGS"; : > "$ADAPTER_STDIN"; : > "$ADAPTER_SYS"; }
+reset() { : > "$ADAPTER_ARGS"; : > "$ADAPTER_STDIN"; : > "$ADAPTER_SYS"; : > "$ADAPTER_ENV"; }
 
 has_arg_pair() {  # has_arg_pair FLAG VALUE — argv is recorded one per line
     grep -A1 -x -- "$1" "$ADAPTER_ARGS" | tail -1 | grep -qx -- "$2"
@@ -165,6 +180,51 @@ if grep -q '"in_tok":11' "$WORK/ledger.jsonl" 2>/dev/null \
     ok "adapter usage lands in the ledger"
 else
     bad "adapter usage lands in the ledger" "$(head -1 "$WORK/ledger.jsonl" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# Responses format reaches the adapter (tools/responses-ws needs this)
+# ---------------------------------------------------------------------------
+
+reset
+printf '%s' '{"store":false}' > "$WORK/body.json"
+out=$(LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter" \
+      LLM_API_FORMAT=responses \
+      LLM_RESPONSE_FILE="$WORK/resp.json" \
+      LLM_PREVIOUS_RESPONSE_ID=resp_prev \
+      LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
+      "$LLM" -m gpt-5.5 "say ok" 2>"$WORK/stderr")
+rc=$?
+if [[ "$rc" -eq 0 && "$out" == "adapter says ok" ]]; then
+    ok "the adapter provider is allowed under LLM_API_FORMAT=responses"
+else
+    bad "the adapter provider is allowed under LLM_API_FORMAT=responses" "rc=$rc: $(head -1 "$WORK/stderr")"
+fi
+if has_arg_pair "--api-format" "responses"; then
+    ok "--api-format responses is forwarded"
+else
+    bad "--api-format responses is forwarded" "$(tr '\n' ' ' < "$ADAPTER_ARGS")"
+fi
+if grep -qx "LLM_RESPONSE_FILE=$WORK/resp.json" "$ADAPTER_ENV" \
+   && grep -qx 'LLM_PREVIOUS_RESPONSE_ID=resp_prev' "$ADAPTER_ENV" \
+   && grep -qx "LLM_RESPONSES_BODY_FILE=$WORK/body.json" "$ADAPTER_ENV"; then
+    ok "the Responses environment reaches the adapter"
+else
+    bad "the Responses environment reaches the adapter" "$(tr '\n' ' ' < "$ADAPTER_ENV")"
+fi
+if jq -e '.[0].role == "user"' "$ADAPTER_STDIN" >/dev/null 2>&1; then
+    ok "typed Responses input arrives on stdin"
+else
+    bad "typed Responses input arrives on stdin" "$(head -c 120 "$ADAPTER_STDIN")"
+fi
+
+reset
+LLM_PROVIDER=adapter LLM_ADAPTER="$WORK/adapter" \
+    "$LLM" -m qwen3:8b "say ok" >/dev/null 2>"$WORK/stderr"
+if grep -qx -- "--api-format" "$ADAPTER_ARGS"; then
+    bad "chat mode passes no --api-format" "$(tr '\n' ' ' < "$ADAPTER_ARGS")"
+else
+    ok "chat mode passes no --api-format"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -512,5 +512,66 @@ else
 fi
 chmod 700 "$WORK/locked"
 
+# Compaction. LLM_RESPONSES_COMPACT_THRESHOLD owns context_management when it
+# is set; otherwise whatever the body file says stands.
+reset
+export CURL_MODE=buffered-completed
+LLM_RESPONSES_COMPACT_THRESHOLD=200000 \
+    run_openai --no-stream "compact me" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 ]] && jq -e '
+    (.context_management | length) == 1 and
+    .context_management[0].type == "compaction" and
+    .context_management[0].compact_threshold == 200000
+' "$CURL_PAYLOAD" >/dev/null; then
+    ok "LLM_RESPONSES_COMPACT_THRESHOLD adds a compaction context_management entry"
+else
+    bad "LLM_RESPONSES_COMPACT_THRESHOLD adds a compaction context_management entry" "rc=$rc payload=$(jq -c .context_management "$CURL_PAYLOAD" 2>/dev/null)"
+fi
+
+reset
+cat > "$WORK/compact-body.json" <<'JSON'
+{"context_management":[{"type":"compaction","compact_threshold":50000}]}
+JSON
+LLM_RESPONSES_BODY_FILE="$WORK/compact-body.json" \
+    run_openai --no-stream "body owns it" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 ]] \
+   && jq -e '.context_management[0].compact_threshold == 50000' "$CURL_PAYLOAD" >/dev/null; then
+    ok "a body-file context_management survives an unset compaction threshold"
+else
+    bad "a body-file context_management survives an unset compaction threshold" "rc=$rc payload=$(jq -c .context_management "$CURL_PAYLOAD" 2>/dev/null)"
+fi
+
+reset
+LLM_RESPONSES_BODY_FILE="$WORK/compact-body.json" LLM_RESPONSES_COMPACT_THRESHOLD=9000 \
+    run_openai --no-stream "env wins" >"$WORK/stdout" 2>"$WORK/stderr"
+if jq -e '(.context_management | length) == 1 and .context_management[0].compact_threshold == 9000' \
+        "$CURL_PAYLOAD" >/dev/null; then
+    ok "an explicit compaction threshold overrides the body file"
+else
+    bad "an explicit compaction threshold overrides the body file" "payload=$(jq -c .context_management "$CURL_PAYLOAD" 2>/dev/null)"
+fi
+
+reset
+LLM_RESPONSES_COMPACT_THRESHOLD=0 \
+    run_openai --no-stream "bad threshold" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && ! -e "$CURL_CALLS" ]] \
+   && grep -q 'Invalid LLM_RESPONSES_COMPACT_THRESHOLD' "$WORK/stderr"; then
+    ok "a non-positive compaction threshold fails before any request"
+else
+    bad "a non-positive compaction threshold fails before any request" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
+fi
+
+reset
+LLM_RESPONSES_COMPACT_THRESHOLD=200000 LLM_API_FORMAT=chat \
+    "$LLM" --provider openai -m gpt-5.4-mini --no-stream "chat" >"$WORK/stdout" 2>"$WORK/stderr"
+if grep -q 'LLM_RESPONSES_COMPACT_THRESHOLD ignored' "$WORK/stderr"; then
+    ok "a compaction threshold under chat format says it is ignored"
+else
+    bad "a compaction threshold under chat format says it is ignored" "stderr=$(cat "$WORK/stderr")"
+fi
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -374,7 +374,8 @@ reset
 export CURL_MODE=stream-no-terminal
 LLM_RETRIES=2 run_openai "truncated stream" >"$WORK/stdout" 2>"$WORK/stderr"
 rc=$?
-if [[ "$rc" -ne 0 && "$(cat "$CURL_CALLS")" -eq 1 && ! -e "$WORK/response.json" ]] \
+if [[ "$rc" -ne 0 && "$(cat "$CURL_CALLS")" -eq 1 ]] \
+   && jq -e '.error.code == "outcome_unknown"' "$WORK/response.json" >/dev/null \
    && grep -q 'without a terminal response' "$WORK/stderr"; then
     ok "Responses SSE with output but no terminal event fails without retry"
 else

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -415,14 +415,59 @@ else
     bad "background:true in the body file rides the create (tests/test_llm_responses_background.sh has the lifecycle)" "rc=$rc payload=$(jq -c . "$CURL_PAYLOAD" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
 fi
 
+# A Conversation is the other way to carry state: on its own it rides the
+# create, and the two ways are refused together.
+reset
+export CURL_MODE=buffered-completed
 printf '{"conversation":"conv_123"}' > "$WORK/body.json"
 LLM_API_FORMAT=responses LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
-    "$LLM" --provider openai -m gpt-5.4-mini "no" >"$WORK/stdout" 2>"$WORK/stderr"
+    "$LLM" --provider openai -m gpt-5.4-mini --no-stream "yes" \
+    >"$WORK/stdout" 2>"$WORK/stderr"
 rc=$?
-if [[ "$rc" -ne 0 ]] && grep -q 'conversation state cannot be combined' "$WORK/stderr"; then
-    ok "conversation state is rejected before continuation can conflict"
+if [[ "$rc" -eq 0 ]] \
+    && jq -e '.conversation == "conv_123" and (has("previous_response_id") | not)' \
+        "$CURL_PAYLOAD" >/dev/null; then
+    ok "a body-file conversation rides the create on its own"
 else
-    bad "conversation state is rejected before continuation can conflict" "rc=$rc stderr=$(cat "$WORK/stderr")"
+    bad "a body-file conversation rides the create on its own" "rc=$rc payload=$(jq -c . "$CURL_PAYLOAD" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
+fi
+
+reset
+LLM_API_FORMAT=responses LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
+LLM_RESPONSES_CONVERSATION="conv_env" \
+    "$LLM" --provider openai -m gpt-5.4-mini --no-stream "yes" \
+    >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 ]] && jq -e '.conversation == "conv_env"' "$CURL_PAYLOAD" >/dev/null; then
+    ok "LLM_RESPONSES_CONVERSATION owns the body file's conversation"
+else
+    bad "LLM_RESPONSES_CONVERSATION owns the body file's conversation" "rc=$rc payload=$(jq -c . "$CURL_PAYLOAD" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
+fi
+
+reset
+LLM_API_FORMAT=responses LLM_RESPONSES_CONVERSATION="conv_env" \
+LLM_PREVIOUS_RESPONSE_ID="resp_previous" \
+    "$LLM" --provider openai -m gpt-5.4-mini --no-stream "no" \
+    >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && ! -s "$CURL_CALLS" ]] \
+    && grep -q 'conversation and previous_response_id cannot both be set' "$WORK/stderr"; then
+    ok "conversation and previous_response_id are refused as a pair before curl"
+else
+    bad "conversation and previous_response_id are refused as a pair before curl" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
+fi
+
+reset
+LLM_API_FORMAT=responses LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
+LLM_PREVIOUS_RESPONSE_ID="resp_previous" \
+    "$LLM" --provider openai -m gpt-5.4-mini --no-stream "no" \
+    >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && ! -s "$CURL_CALLS" ]] \
+    && grep -q 'conversation and previous_response_id cannot both be set' "$WORK/stderr"; then
+    ok "a body-file conversation conflicts with LLM_PREVIOUS_RESPONSE_ID too"
+else
+    bad "a body-file conversation conflicts with LLM_PREVIOUS_RESPONSE_ID too" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
 fi
 
 # OpenRouter has its own Responses endpoint but remains a separate stateless

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -404,13 +404,15 @@ else
 fi
 
 printf '{"background":true}' > "$WORK/body.json"
+reset
+export CURL_MODE=stream-completed
 LLM_API_FORMAT=responses LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
-    "$LLM" --provider openai -m gpt-5.4-mini "no" >"$WORK/stdout" 2>"$WORK/stderr"
+    "$LLM" --provider openai -m gpt-5.4-mini "yes" >"$WORK/stdout" 2>"$WORK/stderr"
 rc=$?
-if [[ "$rc" -ne 0 ]] && grep -q 'background responses require lifecycle operations' "$WORK/stderr"; then
-    ok "background Responses are rejected until lifecycle support exists"
+if [[ "$rc" -eq 0 ]] && jq -e '.background == true' "$CURL_PAYLOAD" >/dev/null; then
+    ok "background:true in the body file rides the create (tests/test_llm_responses_background.sh has the lifecycle)"
 else
-    bad "background Responses are rejected until lifecycle support exists" "rc=$rc stderr=$(cat "$WORK/stderr")"
+    bad "background:true in the body file rides the create (tests/test_llm_responses_background.sh has the lifecycle)" "rc=$rc payload=$(jq -c . "$CURL_PAYLOAD" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
 fi
 
 printf '{"conversation":"conv_123"}' > "$WORK/body.json"

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -86,6 +86,9 @@ case "$CURL_MODE" in
     stream-flat-error)
         printf '%s\n\n' 'event: error' 'data: {"type":"error","message":"previous response missing","param":"previous_response_id","code":"previous_response_not_found"}'
         ;;
+    stream-no-terminal)
+        printf '%s\n\n' 'event: response.output_text.delta' 'data: {"type":"response.output_text.delta","delta":"```bash\nprintf pwned\n```"}'
+        ;;
     *)
         echo "curl stub: unknown CURL_MODE=$CURL_MODE" >&2
         exit 2
@@ -330,6 +333,17 @@ if [[ "$rc" -ne 0 ]] \
     ok "flat SSE continuation rejection is preserved without internal retries"
 else
     bad "flat SSE continuation rejection is preserved without internal retries" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) response=$(cat "$WORK/response.json" 2>/dev/null)"
+fi
+
+reset
+export CURL_MODE=stream-no-terminal
+LLM_RETRIES=2 run_openai "truncated stream" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && "$(cat "$CURL_CALLS")" -eq 1 && ! -e "$WORK/response.json" ]] \
+   && grep -q 'without a terminal response' "$WORK/stderr"; then
+    ok "Responses SSE with output but no terminal event fails without retry"
+else
+    bad "Responses SSE with output but no terminal event fails without retry" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
 fi
 
 # Provider and body validation fail before curl.

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -479,6 +479,36 @@ if [[ "$rc" -ne 0 && ! -e "$CURL_CALLS" && ! -s "$WORK/stdout" ]] \
 else
     bad "an unwritable Response sidecar fails before any request" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
 fi
+# A path that names a directory would let mv "succeed" by dropping the temp
+# file inside it, with nothing at the path the caller reads.
+reset
+mkdir -p "$WORK/as-dir"
+LLM_API_FORMAT=responses LLM_RESPONSE_FILE="$WORK/as-dir" \
+    "$LLM" --provider openai -m gpt-5.4-mini "sidecar" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && ! -e "$CURL_CALLS" && -d "$WORK/as-dir" ]] \
+   && grep -q 'Response file is a directory' "$WORK/stderr" \
+   && [[ -z "$(ls -A "$WORK/as-dir")" ]]; then
+    ok "a directory as Response sidecar fails before any request"
+else
+    bad "a directory as Response sidecar fails before any request" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
+fi
+reset
+mkdir -p "$WORK/locked" && chmod 500 "$WORK/locked"
+if [[ -w "$WORK/locked" ]]; then
+    ok "a read-only sidecar directory fails before any request (skipped: directory writable, probably root)"
+else
+    LLM_API_FORMAT=responses LLM_RESPONSE_FILE="$WORK/locked/response.json" \
+        "$LLM" --provider openai -m gpt-5.4-mini "sidecar" >"$WORK/stdout" 2>"$WORK/stderr"
+    rc=$?
+    if [[ "$rc" -ne 0 && ! -e "$CURL_CALLS" ]] \
+       && grep -q 'Response file directory is not writable' "$WORK/stderr"; then
+        ok "a read-only sidecar directory fails before any request"
+    else
+        bad "a read-only sidecar directory fails before any request" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
+    fi
+fi
+chmod 700 "$WORK/locked"
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -86,6 +86,11 @@ case "$CURL_MODE" in
     stream-flat-error)
         printf '%s\n\n' 'event: error' 'data: {"type":"error","message":"previous response missing","param":"previous_response_id","code":"previous_response_not_found"}'
         ;;
+    stream-stop-after)
+        printf '%s\n\n' 'event: response.output_text.delta' 'data: {"type":"response.output_text.delta","delta":"```bash\necho first\n```\n"}'
+        printf '%s\n\n' 'event: response.output_text.delta' 'data: {"type":"response.output_text.delta","delta":"trailing prose\n```bash\necho second\n```\n"}'
+        printf '%s\n\n' 'event: response.completed' 'data: {"type":"response.completed","response":{"id":"resp_cut","object":"response","status":"completed","output":[{"id":"msg_cut","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"```bash\necho first\n```\ntrailing prose\n```bash\necho second\n```\n"}]}],"usage":{"input_tokens":3,"output_tokens":9}}}'
+        ;;
     stream-no-terminal)
         printf '%s\n\n' 'event: response.output_text.delta' 'data: {"type":"response.output_text.delta","delta":"```bash\nprintf pwned\n```"}'
         ;;
@@ -333,6 +338,36 @@ if [[ "$rc" -ne 0 ]] \
     ok "flat SSE continuation rejection is preserved without internal retries"
 else
     bad "flat SSE continuation rejection is preserved without internal retries" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) response=$(cat "$WORK/response.json" 2>/dev/null)"
+fi
+
+# The same decision without a sidecar: the rejection is judged on the error
+# body, so a caller that sets no LLM_RESPONSE_FILE does not pay for retries
+# of a deterministic 400 either.
+reset
+export CURL_MODE=stream-http-error
+LLM_API_FORMAT=responses LLM_RETRIES=2 LLM_PREVIOUS_RESPONSE_ID=resp_missing \
+    "$LLM" --provider openai -m gpt-5.4-mini "continue" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 1 && "$(cat "$CURL_CALLS")" -eq 1 && ! -e "$WORK/response.json" ]] \
+   && grep -q 'previous response missing' "$WORK/stderr"; then
+    ok "continuation rejection is final without a Response sidecar"
+else
+    bad "continuation rejection is final without a Response sidecar" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
+fi
+
+# --stop-after-code-block keeps its contract in Responses mode: the stream is
+# cut when the first block closes, the cut is a clean finish, and the missing
+# terminal event means no sidecar and estimated usage.
+reset
+export CURL_MODE=stream-stop-after
+run_openai --stop-after-code-block "cut" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == $'```bash\necho first\n```' && ! -e "$WORK/response.json" ]] \
+   && grep -q 'stopped reading after the first code block' "$WORK/stderr" \
+   && jq -e '.estimated == true' "$WORK/usage.json" >/dev/null; then
+    ok "stop-after-code-block cuts a Responses stream cleanly"
+else
+    bad "stop-after-code-block cuts a Responses stream cleanly" "rc=$rc out=$(cat "$WORK/stdout") stderr=$(cat "$WORK/stderr") usage=$(cat "$WORK/usage.json" 2>/dev/null)"
 fi
 
 reset

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -437,5 +437,48 @@ jq -e '(.include | index("reasoning.encrypted_content")) != null' "$CURL_PAYLOAD
     && ok "OpenRouter requests encrypted reasoning for exact replay" \
     || bad "OpenRouter requests encrypted reasoning for exact replay" "$(jq -c . "$CURL_PAYLOAD" 2>/dev/null)"
 
+
+# A pinned route or a ZDR/no-training constraint says where the prompt may go,
+# so it rides the Responses payload exactly as it rides chat, merged with any
+# provider object the caller's body file already carries.
+reset
+export CURL_MODE=buffered-completed
+printf '%s' '{"provider":{"sort":"price"}}' > "$WORK/or-body.json"
+LLM_API_FORMAT=responses LLM_RESPONSES_BODY_FILE="$WORK/or-body.json" \
+LLM_OR_ONLY=openai LLM_OR_DATA_COLLECTION=deny LLM_OR_ZDR=1 \
+    "$LLM" --provider openrouter -m openai/gpt-5 --no-stream "route" \
+    >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 ]] && jq -e '
+    .provider == {sort:"price", only:["openai"], data_collection:"deny", zdr:true}
+    and .model == "openai/gpt-5" and (.input | type == "array")
+' "$CURL_PAYLOAD" >/dev/null; then
+    ok "OpenRouter routing and privacy constraints ride the Responses payload"
+else
+    bad "OpenRouter routing and privacy constraints ride the Responses payload" "rc=$rc payload=$(jq -c . "$CURL_PAYLOAD" 2>/dev/null)"
+fi
+reset
+export CURL_MODE=buffered-completed
+LLM_API_FORMAT=responses \
+    "$LLM" --provider openrouter -m openai/gpt-5 --no-stream "unpinned" \
+    >"$WORK/stdout" 2>"$WORK/stderr"
+jq -e 'has("provider") | not' "$CURL_PAYLOAD" >/dev/null \
+    && ok "unpinned OpenRouter Responses payload carries no provider object" \
+    || bad "unpinned OpenRouter Responses payload carries no provider object" "$(jq -c . "$CURL_PAYLOAD" 2>/dev/null)"
+
+# A sidecar the caller asked for must be writable before any tokens are
+# spent; a streaming reply cannot be failed cleanly for a missing directory.
+reset
+export CURL_MODE=stream-completed
+LLM_API_FORMAT=responses LLM_RESPONSE_FILE="$WORK/missing-dir/response.json" \
+    "$LLM" --provider openai -m gpt-5.4-mini "sidecar" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && ! -e "$CURL_CALLS" && ! -s "$WORK/stdout" ]] \
+   && grep -q 'Response file directory does not exist' "$WORK/stderr"; then
+    ok "an unwritable Response sidecar fails before any request"
+else
+    bad "an unwritable Response sidecar fails before any request" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
+fi
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -83,6 +83,9 @@ case "$CURL_MODE" in
     stream-http-error)
         printf '%s\n' '{"error":{"message":"previous response missing","param":"previous_response_id","code":"previous_response_not_found"}}'
         ;;
+    stream-flat-error)
+        printf '%s\n\n' 'event: error' 'data: {"type":"error","message":"previous response missing","param":"previous_response_id","code":"previous_response_not_found"}'
+        ;;
     *)
         echo "curl stub: unknown CURL_MODE=$CURL_MODE" >&2
         exit 2
@@ -136,6 +139,9 @@ mode=$(stat -c %a "$WORK/response.json" 2>/dev/null || stat -f %Lp "$WORK/respon
 jq -e '.in_tok == 21 and .out_tok == 8 and .think_tok == 3' "$WORK/usage.json" >/dev/null \
     && ok "Responses usage maps to the existing usage contract" \
     || bad "Responses usage maps to the existing usage contract" "$(cat "$WORK/usage.json")"
+jq -e '(.include | index("reasoning.encrypted_content")) != null' "$CURL_PAYLOAD" >/dev/null \
+    && ok "Responses requests include encrypted reasoning for stateless replay" \
+    || bad "Responses requests include encrypted reasoning for stateless replay" "$(jq -c . "$CURL_PAYLOAD" 2>/dev/null)"
 
 # Buffered content parts concatenate byte-for-byte like SSE deltas; jq's
 # default record newlines must not alter the model's text.
@@ -193,6 +199,7 @@ if jq -e '
     .instructions == "real instructions" and
     .previous_response_id == "resp_previous" and
     .store == false and
+    (.include | index("reasoning.encrypted_content")) != null and
     .tools[0].name == "weather" and
     .text.format.type == "json_schema" and
     .reasoning.effort == "high" and
@@ -232,13 +239,14 @@ fi
 # A 200 Response with status=failed is not successful output.
 reset
 export CURL_MODE=buffered-failed
-run_openai --no-stream "fail" >"$WORK/stdout" 2>"$WORK/stderr"
+LLM_RETRIES=2 run_openai --no-stream "fail" >"$WORK/stdout" 2>"$WORK/stderr"
 rc=$?
 if [[ "$rc" -ne 0 ]] && grep -q 'generation failed' "$WORK/stderr" \
-   && jq -e '.status == "failed"' "$WORK/response.json" >/dev/null; then
-    ok "buffered failed Response fails and preserves terminal state"
+   && jq -e '.status == "failed"' "$WORK/response.json" >/dev/null \
+   && [[ "$(cat "$CURL_CALLS")" -eq 1 ]]; then
+    ok "buffered failed Response fails once and preserves terminal state"
 else
-    bad "buffered failed Response fails and preserves terminal state" "rc=$rc stderr=$(cat "$WORK/stderr")"
+    bad "buffered failed Response fails once and preserves terminal state" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) stderr=$(cat "$WORK/stderr")"
 fi
 
 # Non-2xx error envelopes are available to machine callers for safe fallback.
@@ -311,6 +319,19 @@ else
     bad "pre-SSE continuation rejection is preserved without internal retries" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) response=$(cat "$WORK/response.json" 2>/dev/null)"
 fi
 
+reset
+export CURL_MODE=stream-flat-error
+LLM_RETRIES=2 LLM_PREVIOUS_RESPONSE_ID=resp_missing \
+    run_openai "continue" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] \
+   && jq -e '.param == "previous_response_id" and .code == "previous_response_not_found"' "$WORK/response.json" >/dev/null \
+   && [[ "$(cat "$CURL_CALLS")" -eq 1 ]]; then
+    ok "flat SSE continuation rejection is preserved without internal retries"
+else
+    bad "flat SSE continuation rejection is preserved without internal retries" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) response=$(cat "$WORK/response.json" 2>/dev/null)"
+fi
+
 # Provider and body validation fail before curl.
 reset
 export CURL_MODE=buffered-completed
@@ -343,8 +364,18 @@ else
     bad "background Responses are rejected until lifecycle support exists" "rc=$rc stderr=$(cat "$WORK/stderr")"
 fi
 
+printf '{"conversation":"conv_123"}' > "$WORK/body.json"
+LLM_API_FORMAT=responses LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
+    "$LLM" --provider openai -m gpt-5.4-mini "no" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'conversation state cannot be combined' "$WORK/stderr"; then
+    ok "conversation state is rejected before continuation can conflict"
+else
+    bad "conversation state is rejected before continuation can conflict" "rc=$rc stderr=$(cat "$WORK/stderr")"
+fi
+
 # OpenRouter has its own Responses endpoint but remains a separate stateless
-# service from Ramp Router/openai-compatible.
+# service from generic openai-compatible endpoints.
 reset
 export CURL_MODE=buffered-completed
 LLM_API_FORMAT=responses LLM_RESPONSE_FILE="$WORK/response.json" \
@@ -353,6 +384,9 @@ LLM_API_FORMAT=responses LLM_RESPONSE_FILE="$WORK/response.json" \
 grep -q 'https://openrouter.ai/api/v1/responses' "$CURL_ARGS" \
     && ok "OpenRouter selects its documented Responses endpoint" \
     || bad "OpenRouter selects its documented Responses endpoint"
+jq -e '(.include | index("reasoning.encrypted_content")) != null' "$CURL_PAYLOAD" >/dev/null \
+    && ok "OpenRouter requests encrypted reasoning for exact replay" \
+    || bad "OpenRouter requests encrypted reasoning for exact replay" "$(jq -c . "$CURL_PAYLOAD" 2>/dev/null)"
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_llm_responses.sh
+++ b/tests/test_llm_responses.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# test_llm_responses.sh — OpenAI Responses completion protocol in bin/llm
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+mkdir -p "$WORK/bin" "$WORK/home"
+cat > "$WORK/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+n=0
+[[ -f "$CURL_CALLS" ]] && read -r n < "$CURL_CALLS"
+printf '%s\n' "$((n + 1))" > "$CURL_CALLS"
+printf '%s\n' "$@" > "$CURL_ARGS"
+out_file=""
+payload_file=""
+prev=""
+for arg in "$@"; do
+    [[ "$prev" == "-o" ]] && out_file="$arg"
+    [[ "$prev" == "-d" && "$arg" == @* ]] && payload_file="${arg#@}"
+    prev="$arg"
+done
+[[ -n "$payload_file" ]] && cp "$payload_file" "$CURL_PAYLOAD"
+
+buffered_completed='{
+  "id":"resp_buffered",
+  "object":"response",
+  "status":"completed",
+  "output":[
+    {"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"brief reasoning"}]},
+    {"id":"msg_1","type":"message","role":"assistant","status":"completed","phase":"final_answer","content":[{"type":"output_text","text":"hello"}]}
+  ],
+  "usage":{"input_tokens":21,"output_tokens":8,"output_tokens_details":{"reasoning_tokens":3}}
+}'
+
+case "$CURL_MODE" in
+    buffered-completed)
+        printf '%s' "$buffered_completed" > "$out_file"
+        printf '200'
+        ;;
+    buffered-multipart)
+        printf '%s' '{"id":"resp_parts","object":"response","status":"completed","output":[{"id":"msg_parts","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"alpha"},{"type":"output_text","text":"\nbeta"},{"type":"refusal","refusal":"denied"}]}]}' > "$out_file"
+        printf '200'
+        ;;
+    buffered-function)
+        printf '%s' '{"id":"resp_fn","object":"response","status":"completed","output":[{"id":"fc_1","type":"function_call","call_id":"call_1","name":"weather","arguments":"{\"city\":\"Paris\"}","status":"completed"}],"usage":{"input_tokens":9,"output_tokens":4}}' > "$out_file"
+        printf '200'
+        ;;
+    buffered-incomplete)
+        printf '%s' '{"id":"resp_short","object":"response","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"id":"msg_2","type":"message","role":"assistant","status":"incomplete","content":[{"type":"output_text","text":"partial"}]}],"usage":{"input_tokens":7,"output_tokens":5}}' > "$out_file"
+        printf '200'
+        ;;
+    buffered-failed)
+        printf '%s' '{"id":"resp_failed","object":"response","status":"failed","error":{"code":"server_error","message":"generation failed"},"output":[]}' > "$out_file"
+        printf '200'
+        ;;
+    http-400-previous)
+        printf '%s' '{"error":{"message":"Previous response cannot be used for this organization due to Zero Data Retention.","type":"invalid_request_error","param":"previous_response_id","code":"unsupported_parameter"}}' > "$out_file"
+        printf '400'
+        ;;
+    stream-completed)
+        printf '%s\n\n' 'event: response.created' 'data: {"type":"response.created","response":{"id":"resp_stream","status":"in_progress","output":[]}}'
+        printf '%s\n\n' 'event: response.reasoning_summary_text.delta' 'data: {"type":"response.reasoning_summary_text.delta","delta":"stream reasoning"}'
+        printf '%s\n\n' 'event: response.output_text.delta' 'data: {"type":"response.output_text.delta","delta":"line one\n"}'
+        printf '%s\n\n' 'event: response.output_text.delta' 'data: {"type":"response.output_text.delta","delta":"line two"}'
+        printf '%s\n\n' 'event: response.completed' 'data: {"type":"response.completed","response":{"id":"resp_stream","object":"response","status":"completed","output":[{"id":"rs_s","type":"reasoning","summary":[{"type":"summary_text","text":"stream reasoning"}]},{"id":"msg_s","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"line one\nline two"}]}],"usage":{"input_tokens":30,"output_tokens":12,"output_tokens_details":{"reasoning_tokens":4}}}}'
+        ;;
+    stream-function)
+        printf '%s\n\n' 'event: response.output_item.done' 'data: {"type":"response.output_item.done","item":{"id":"fc_s","type":"function_call","call_id":"call_s","name":"weather","arguments":"{}","status":"completed"}}'
+        printf '%s\n\n' 'event: response.completed' 'data: {"type":"response.completed","response":{"id":"resp_stream_fn","object":"response","status":"completed","output":[{"id":"fc_s","type":"function_call","call_id":"call_s","name":"weather","arguments":"{}","status":"completed"}],"usage":{"input_tokens":5,"output_tokens":2}}}'
+        ;;
+    stream-failed)
+        printf '%s\n\n' 'event: response.failed' 'data: {"type":"response.failed","response":{"id":"resp_stream_bad","object":"response","status":"failed","error":{"code":"server_error","message":"stream generation failed"},"output":[]}}'
+        ;;
+    stream-http-error)
+        printf '%s\n' '{"error":{"message":"previous response missing","param":"previous_response_id","code":"previous_response_not_found"}}'
+        ;;
+    *)
+        echo "curl stub: unknown CURL_MODE=$CURL_MODE" >&2
+        exit 2
+        ;;
+esac
+STUB
+chmod +x "$WORK/bin/curl"
+
+export PATH="$WORK/bin:$PATH"
+export HEADLONG_HOME="$WORK/home"
+export OPENAI_API_KEY="test-openai-key"
+export OPENROUTER_API_KEY="test-openrouter-key"
+export LLM_RETRIES=0
+export CURL_ARGS="$WORK/curl.args"
+export CURL_PAYLOAD="$WORK/curl.payload"
+export CURL_CALLS="$WORK/curl.calls"
+LLM="$REPO/bin/llm"
+
+reset() {
+    : > "$CURL_ARGS"
+    : > "$CURL_PAYLOAD"
+    rm -f "$CURL_CALLS" "$WORK/response.json" "$WORK/usage.json" "$WORK/stdout" "$WORK/stderr"
+}
+
+run_openai() {
+    LLM_API_FORMAT=responses \
+    LLM_RESPONSE_FILE="$WORK/response.json" \
+    LLM_USAGE_FILE="$WORK/usage.json" \
+    "$LLM" --provider openai -m gpt-5.4-mini "$@"
+}
+
+# Buffered output, endpoint, sidecar, reasoning, and usage.
+reset
+export CURL_MODE=buffered-completed
+run_openai --no-stream --thinking medium "say hello" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+[[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "hello" ]] \
+    && ok "buffered Responses emits visible text" \
+    || bad "buffered Responses emits visible text" "rc=$rc out=$(cat "$WORK/stdout")"
+grep -q 'brief reasoning' "$WORK/stderr" \
+    && ok "buffered Responses emits reasoning summary on stderr" \
+    || bad "buffered Responses emits reasoning summary on stderr"
+grep -q 'https://api.openai.com/v1/responses' "$CURL_ARGS" \
+    && ok "native OpenAI selects /v1/responses" \
+    || bad "native OpenAI selects /v1/responses"
+jq -e '.id == "resp_buffered" and .output[1].phase == "final_answer"' "$WORK/response.json" >/dev/null \
+    && ok "terminal Response sidecar preserves the full object" \
+    || bad "terminal Response sidecar preserves the full object"
+mode=$(stat -c %a "$WORK/response.json" 2>/dev/null || stat -f %Lp "$WORK/response.json")
+[[ "$mode" == 600 ]] && ok "Response sidecar is mode 600" || bad "Response sidecar is mode 600" "mode=$mode"
+jq -e '.in_tok == 21 and .out_tok == 8 and .think_tok == 3' "$WORK/usage.json" >/dev/null \
+    && ok "Responses usage maps to the existing usage contract" \
+    || bad "Responses usage maps to the existing usage contract" "$(cat "$WORK/usage.json")"
+
+# Buffered content parts concatenate byte-for-byte like SSE deltas; jq's
+# default record newlines must not alter the model's text.
+reset
+export CURL_MODE=buffered-multipart
+run_openai --no-stream "multiple parts" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == $'alpha\nbetadenied' ]]; then
+    ok "buffered Responses concatenates content parts without invented newlines"
+else
+    bad "buffered Responses concatenates content parts without invented newlines" "rc=$rc out=$(printf %q "$(cat "$WORK/stdout")")"
+fi
+
+# Structured input is not flattened, extra fields pass through, and owned
+# fields win over conflicting values from the extra-body file.
+reset
+cat > "$WORK/body.json" <<'JSON'
+{
+  "model": "wrong-model",
+  "input": "wrong-input",
+  "stream": true,
+  "max_output_tokens": 1,
+  "instructions": "wrong instructions",
+  "previous_response_id": "wrong-id",
+  "store": false,
+  "include": ["reasoning.encrypted_content"],
+  "tools": [{"type":"function","name":"weather","description":"Weather","parameters":{"type":"object"},"strict":true}],
+  "text": {"format":{"type":"json_schema","name":"answer","schema":{"type":"object"},"strict":true}}
+}
+JSON
+cat > "$WORK/input.json" <<'JSON'
+[
+  {"role":"user","content":[{"type":"input_text","text":"describe"},{"type":"input_image","image_url":"data:image/png;base64,AAAA","detail":"low"}]},
+  {"type":"reasoning","id":"rs_old","summary":[],"encrypted_content":"encrypted"},
+  {"type":"function_call_output","call_id":"call_old","output":"sunny"}
+]
+JSON
+export CURL_MODE=buffered-completed
+LLM_API_FORMAT=responses \
+LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
+LLM_PREVIOUS_RESPONSE_ID="resp_previous" \
+LLM_RESPONSE_FILE="$WORK/response.json" \
+LLM_PROVIDER=openai-compatible \
+LLM_API_URL="https://api.router.test/v1/responses" \
+LLM_API_KEY="test-compatible-key" \
+    "$LLM" -m glm-test --no-stream --thinking high --system-prompt "real instructions" \
+    --messages-file "$WORK/input.json" >/dev/null 2>"$WORK/stderr"
+if jq -e '
+    .model == "glm-test" and
+    .input[0].content[1].type == "input_image" and
+    .input[1].encrypted_content == "encrypted" and
+    .input[2].type == "function_call_output" and
+    .stream == false and
+    .max_output_tokens == 16384 and
+    .instructions == "real instructions" and
+    .previous_response_id == "resp_previous" and
+    .store == false and
+    .tools[0].name == "weather" and
+    .text.format.type == "json_schema" and
+    .reasoning.effort == "high" and
+    .reasoning.summary == "auto"
+' "$CURL_PAYLOAD" >/dev/null; then
+    ok "Responses request preserves typed input and merges the create body"
+else
+    bad "Responses request preserves typed input and merges the create body" "$(jq -c . "$CURL_PAYLOAD" 2>/dev/null)"
+fi
+grep -q 'https://api.router.test/v1/responses' "$CURL_ARGS" \
+    && ok "openai-compatible uses the exact configured Responses URL" \
+    || bad "openai-compatible uses the exact configured Responses URL"
+
+# Function-only responses are protocol success, not an empty-response error.
+reset
+export CURL_MODE=buffered-function
+run_openai --no-stream "call the function" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && ! -s "$WORK/stdout" ]] \
+   && jq -e '.output[0].type == "function_call" and .output[0].call_id == "call_1"' "$WORK/response.json" >/dev/null; then
+    ok "buffered function-only Response succeeds through the sidecar"
+else
+    bad "buffered function-only Response succeeds through the sidecar" "rc=$rc out=$(cat "$WORK/stdout")"
+fi
+
+# Incomplete responses keep their partial output and warn.
+reset
+export CURL_MODE=buffered-incomplete
+run_openai --no-stream "be long" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "partial" ]] && grep -q 'output truncated' "$WORK/stderr"; then
+    ok "incomplete max-output Response returns partial text with warning"
+else
+    bad "incomplete max-output Response returns partial text with warning" "rc=$rc stderr=$(cat "$WORK/stderr")"
+fi
+
+# A 200 Response with status=failed is not successful output.
+reset
+export CURL_MODE=buffered-failed
+run_openai --no-stream "fail" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'generation failed' "$WORK/stderr" \
+   && jq -e '.status == "failed"' "$WORK/response.json" >/dev/null; then
+    ok "buffered failed Response fails and preserves terminal state"
+else
+    bad "buffered failed Response fails and preserves terminal state" "rc=$rc stderr=$(cat "$WORK/stderr")"
+fi
+
+# Non-2xx error envelopes are available to machine callers for safe fallback.
+reset
+export CURL_MODE=http-400-previous
+LLM_PREVIOUS_RESPONSE_ID=resp_stale run_openai --no-stream "continue" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] \
+   && jq -e '.error.param == "previous_response_id" and .error.code == "unsupported_parameter"' "$WORK/response.json" >/dev/null; then
+    ok "HTTP error envelope is written to the Response sidecar"
+else
+    bad "HTTP error envelope is written to the Response sidecar" "rc=$rc response=$(cat "$WORK/response.json" 2>/dev/null)"
+fi
+
+# SSE text/reasoning/terminal state and usage.
+reset
+export CURL_MODE=stream-completed
+run_openai --thinking medium "stream" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == $'line one\nline two' ]]; then
+    ok "Responses SSE preserves text delta newlines"
+else
+    bad "Responses SSE preserves text delta newlines" "rc=$rc out=$(printf %q "$(cat "$WORK/stdout")")"
+fi
+grep -q 'stream reasoning' "$WORK/stderr" \
+    && ok "Responses SSE emits reasoning summary deltas on stderr" \
+    || bad "Responses SSE emits reasoning summary deltas on stderr"
+if jq -e '.id == "resp_stream" and .status == "completed"' "$WORK/response.json" >/dev/null \
+   && jq -e '.in_tok == 30 and .out_tok == 12 and .think_tok == 4' "$WORK/usage.json" >/dev/null; then
+    ok "Responses SSE records terminal Response and usage"
+else
+    bad "Responses SSE records terminal Response and usage"
+fi
+
+# Function-only streams count the terminal item as protocol output.
+reset
+export CURL_MODE=stream-function
+run_openai "stream a function" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && ! -s "$WORK/stdout" ]] \
+   && jq -e '.output[0].type == "function_call"' "$WORK/response.json" >/dev/null; then
+    ok "function-only Responses SSE succeeds without visible stdout"
+else
+    bad "function-only Responses SSE succeeds without visible stdout" "rc=$rc stderr=$(cat "$WORK/stderr")"
+fi
+
+# Stream terminal failures and pre-SSE error bodies remain failures and leave
+# structured state for the caller.
+reset
+export CURL_MODE=stream-failed
+run_openai "stream failure" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'stream generation failed' "$WORK/stderr" \
+   && jq -e '.status == "failed"' "$WORK/response.json" >/dev/null; then
+    ok "terminal response.failed fails with structured state"
+else
+    bad "terminal response.failed fails with structured state" "rc=$rc stderr=$(cat "$WORK/stderr")"
+fi
+
+reset
+export CURL_MODE=stream-http-error
+LLM_RETRIES=2 LLM_PREVIOUS_RESPONSE_ID=resp_missing \
+    run_openai "continue" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] \
+   && jq -e '.error.param == "previous_response_id"' "$WORK/response.json" >/dev/null \
+   && [[ "$(cat "$CURL_CALLS")" -eq 1 ]]; then
+    ok "pre-SSE continuation rejection is preserved without internal retries"
+else
+    bad "pre-SSE continuation rejection is preserved without internal retries" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) response=$(cat "$WORK/response.json" 2>/dev/null)"
+fi
+
+# Provider and body validation fail before curl.
+reset
+export CURL_MODE=buffered-completed
+LLM_API_FORMAT=responses "$LLM" --provider anthropic -m claude-sonnet-4-5 "no" \
+    >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'Responses format is not supported for provider anthropic' "$WORK/stderr"; then
+    ok "unsupported provider fails explicitly"
+else
+    bad "unsupported provider fails explicitly" "rc=$rc stderr=$(cat "$WORK/stderr")"
+fi
+
+printf '[]' > "$WORK/body.json"
+LLM_API_FORMAT=responses LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
+    "$LLM" --provider openai -m gpt-5.4-mini "no" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'must contain a JSON object' "$WORK/stderr"; then
+    ok "Responses extra body must be an object"
+else
+    bad "Responses extra body must be an object" "rc=$rc stderr=$(cat "$WORK/stderr")"
+fi
+
+printf '{"background":true}' > "$WORK/body.json"
+LLM_API_FORMAT=responses LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
+    "$LLM" --provider openai -m gpt-5.4-mini "no" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'background responses require lifecycle operations' "$WORK/stderr"; then
+    ok "background Responses are rejected until lifecycle support exists"
+else
+    bad "background Responses are rejected until lifecycle support exists" "rc=$rc stderr=$(cat "$WORK/stderr")"
+fi
+
+# OpenRouter has its own Responses endpoint but remains a separate stateless
+# service from Ramp Router/openai-compatible.
+reset
+export CURL_MODE=buffered-completed
+LLM_API_FORMAT=responses LLM_RESPONSE_FILE="$WORK/response.json" \
+    "$LLM" --provider openrouter -m openai/gpt-5 --no-stream "hello" \
+    >"$WORK/stdout" 2>"$WORK/stderr"
+grep -q 'https://openrouter.ai/api/v1/responses' "$CURL_ARGS" \
+    && ok "OpenRouter selects its documented Responses endpoint" \
+    || bad "OpenRouter selects its documented Responses endpoint"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_llm_responses_background.sh
+++ b/tests/test_llm_responses_background.sh
@@ -51,8 +51,17 @@ if [[ "$url" == */cancel ]]; then
 fi
 
 completed='{"id":"resp_bg","object":"response","status":"completed","output":[{"id":"msg_bg","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":11,"output_tokens":2}}'
-[[ "${CURL_DELAY:-0}" == 0 ]] || sleep "$CURL_DELAY"
+if [[ "${CURL_DELAY:-0}" != 0 ]]; then
+    printf '{"call":%d,"mode":"%s","phase":"delay-entered","epoch_seconds":%s}\n' \
+        "$n" "$mode" "$(date +%s)" >> "$CURL_DIR/delay-phases.jsonl"
+    sleep "$CURL_DELAY"
+    printf '{"call":%d,"mode":"%s","phase":"delay-released","epoch_seconds":%s}\n' \
+        "$n" "$mode" "$(date +%s)" >> "$CURL_DIR/delay-phases.jsonl"
+fi
 case "$mode" in
+    stream-fixture)
+        cat "$CURL_STREAM_FIXTURE"
+        ;;
     poll-error)
         printf '%s' '{"error":{"message":"backend failed"}}' > "$out_file"
         printf '200'
@@ -96,6 +105,9 @@ case "$mode" in
         printf 'data: %s\n\n' '{"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_bg","status":"in_progress","output":[]}}'
         printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":2,"delta":"a"}'
         printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":3,"delta":"b"}'
+        ;;
+    stream-created-only)
+        printf 'data: %s\n\n' '{"type":"response.created","sequence_number":0,"response":{"id":"resp_bg","status":"queued","output":[]}}'
         ;;
     stream-resume-complete)
         printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":4,"delta":"!"}'
@@ -159,6 +171,132 @@ run_bg() {
     LLM_USAGE_FILE="$WORK/usage.json" \
     "$LLM" --provider openai -m gpt-5.4-mini "$@"
 }
+
+export CURL_STREAM_FIXTURE="$WORK/stream-fixture"
+stream_events() {
+    printf 'data: %s\n\n' "$@" > "$CURL_STREAM_FIXTURE"
+}
+
+# Initial stream errors still leave the accepted background job running.
+# A permanent generic error is not evidence that the job reached a terminal.
+for error in transient permanent after-text; do
+    for cancel_fail in 0 1; do
+        reset stream-fixture
+        stream_events '{"type":"response.created","sequence_number":0,"response":{"id":"resp_bg","status":"in_progress","output":[]}}'
+        if [[ "$error" == after-text ]]; then
+            printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":1,"delta":"partial"}' >> "$CURL_STREAM_FIXTURE"
+        fi
+        if [[ "$error" == permanent ]]; then
+            printf 'data: %s\n\n' '{"type":"error","error":{"param":"previous_response_id","message":"previous response rejected"}}' >> "$CURL_STREAM_FIXTURE"
+        else
+            printf 'data: %s\n\n' '{"type":"error","error":{"message":"synthetic stream failure"}}' >> "$CURL_STREAM_FIXTURE"
+        fi
+        CANCEL_FAIL="$cancel_fail" LLM_RETRIES=2 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+        rc=$?
+        expected_status=cancelled
+        [[ "$cancel_fail" == 0 ]] || expected_status=unknown
+        if [[ "$rc" -ne 0 && "$(calls)" -eq 2 && "$(cancels)" -eq 1 ]] \
+           && [[ "$(cancel_url)" == "https://api.openai.com/v1/responses/resp_bg/cancel" ]] \
+           && jq -e --arg status "$expected_status" '.id == "resp_bg"
+                and (if $status == "unknown" then .error.code == "outcome_unknown"
+                     and .cancellation.requested == true else .status == $status end)' "$WORK/response.json" >/dev/null; then
+            ok "initial $error stream failure cancels once and records $expected_status"
+        else
+            bad "initial $error stream failure cancels once and records $expected_status" "rc=$rc calls=$(calls) cancels=$(cancels) stderr=$(cat "$WORK/stderr")"
+        fi
+    done
+done
+
+for terminal in cancelled failed; do
+    reset stream-fixture
+    stream_events '{"type":"response.created","sequence_number":0,"response":{"id":"resp_bg","status":"in_progress","output":[]}}' \
+        "{\"type\":\"response.$terminal\",\"sequence_number\":1,\"response\":{\"id\":\"resp_bg\",\"status\":\"$terminal\",\"output\":[]}}"
+    LLM_RETRIES=2 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+    rc=$?
+    if [[ "$rc" -ne 0 && "$(calls)" -eq 1 && "$(cancels)" -eq 0 ]] \
+       && jq -e --arg status "$terminal" '.id == "resp_bg" and .status == $status' "$WORK/response.json" >/dev/null; then
+        ok "validated $terminal terminal is not cancelled again"
+    else
+        bad "validated $terminal terminal is not cancelled again" "rc=$rc calls=$(calls) cancels=$(cancels)"
+    fi
+done
+
+# Every advertised identity is checked before its text can escape. Invalid
+# terminal envelopes must not suppress cancellation of the known response.
+for invalid in \
+    '{"type":"response.output_text.delta","sequence_number":1,"response_id":"resp_other","delta":"FOREIGN"}' \
+    '{"type":"response.output_text.delta","sequence_number":1,"response_id":null,"delta":"FOREIGN"}' \
+    '{"type":"response.output_text.delta","sequence_number":1,"response_id":"resp_other","response":{"id":"resp_bg"},"delta":"FOREIGN"}' \
+    '{"type":"response.cancelled","sequence_number":1,"response":{"id":"resp_bg","status":"in_progress","output":[]}}' \
+    '{"type":"response.failed","sequence_number":1}' \
+    '{"type":"response.cancelled","sequence_number":1}' \
+    '{"type":"response.cancelled","sequence_number":1,"response":{"id":"resp_bg","status":"cancelled"}}' \
+    'not-json' '[]' '{"type":"response.output_text.delta","delta":"FOREIGN"} {}'; do
+    reset stream-fixture
+    stream_events '{"type":"response.created","sequence_number":0,"response":{"id":"resp_bg","status":"in_progress","output":[]}}' \
+        "$invalid" '{"type":"response.completed","sequence_number":2,"response":{"id":"resp_bg","status":"completed","output":[]}}'
+    CANCEL_FAIL=1 LLM_RETRIES=2 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+    rc=$?
+    if [[ "$rc" -ne 0 && ! -s "$WORK/stdout" && "$(calls)" -eq 2 && "$(cancels)" -eq 1 ]] \
+       && jq -e '.id == "resp_bg" and .error.code == "outcome_unknown" and .cancellation.requested == true' "$WORK/response.json" >/dev/null; then
+        ok "invalid stream event fails before output and cancels the known response: $invalid"
+    else
+        bad "invalid stream event fails before output and cancels the known response: $invalid" "rc=$rc calls=$(calls) cancels=$(cancels) out=$(cat "$WORK/stdout")"
+    fi
+done
+
+# The resume cursor follows the highest accepted sequence in the current
+# stream, not only the floor supplied at the start of a resumed stream.
+reset $'stream-fixture\nstream-resume-complete'
+stream_events '{"type":"response.created","sequence_number":0,"response":{"id":"resp_bg","status":"in_progress","output":[]}}' \
+    '{"type":"response.output_text.delta","sequence_number":2,"response_id":"resp_bg","delta":"a"}' \
+    '{"type":"response.output_text.delta","sequence_number":2,"response_id":"resp_bg","delta":"DUPLICATE"}' \
+    '{"type":"response.output_text.delta","sequence_number":1,"response_id":"resp_bg","delta":"BACKWARD"}' \
+    '{"type":"response.output_text.delta","sequence_number":3,"response_id":"resp_bg","delta":"b"}' \
+    '{"type":"response.output_text.delta","sequence_number":2,"response_id":"resp_bg","delta":"BACKWARD"}'
+LLM_RETRIES=1 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == 'ab!' && "$(calls)" -eq 2 && "$(cancels)" -eq 0 ]] \
+   && [[ "$(url_of 2)" == "https://api.openai.com/v1/responses/resp_bg?stream=true&starting_after=3" ]]; then
+    ok "duplicate and out-of-order sequences cannot repeat text or move the resume cursor backwards"
+else
+    bad "duplicate and out-of-order sequences cannot repeat text or move the resume cursor backwards" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout") resume=$(url_of 2)"
+fi
+reset $'stream-created-only\nstream-fixture\nstream-resume-complete'
+LLM_RETRIES=2 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == 'ab!' && "$(calls)" -eq 3 && "$(cancels)" -eq 0 ]] \
+   && [[ "$(url_of 2)" == "https://api.openai.com/v1/responses/resp_bg?stream=true&starting_after=0" ]] \
+   && [[ "$(url_of 3)" == "https://api.openai.com/v1/responses/resp_bg?stream=true&starting_after=3" ]]; then
+    ok "a resumed stream advances its own high-water sequence before a second resume"
+else
+    bad "a resumed stream advances its own high-water sequence before a second resume" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout") resume=$(url_of 3)"
+fi
+
+reset stream-fixture
+printf 'data: %s\n\n' '{"type":"response.completed","sequence_number":4,"response":{"id":"resp_bg","status":"completed","output":[]}}' >> "$CURL_STREAM_FIXTURE"
+LLM_RESPONSES_BACKGROUND=0 run_bg "foreground" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == 'ab' && "$(calls)" -eq 1 && "$(cancels)" -eq 0 ]]; then
+    ok "foreground streams also discard duplicate and out-of-order deltas"
+else
+    bad "foreground streams also discard duplicate and out-of-order deltas" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout")"
+fi
+
+for sequence in '"08"' '0.5' '9007199254740992' '-1' 'null' 'true'; do
+    reset stream-fixture
+    stream_events '{"type":"response.created","sequence_number":0,"response":{"id":"resp_bg","status":"in_progress","output":[]}}' \
+        "{\"type\":\"response.output_text.delta\",\"sequence_number\":$sequence,\"delta\":\"INVALID\"}" \
+        '{"type":"response.completed","sequence_number":4,"response":{"id":"resp_bg","status":"completed","output":[]}}'
+    LLM_RESPONSES_BACKGROUND=0 run_bg "foreground" >"$WORK/stdout" 2>"$WORK/stderr"
+    rc=$?
+    if [[ "$rc" -ne 0 && ! -s "$WORK/stdout" && "$(calls)" -eq 1 && "$(cancels)" -eq 0 ]] \
+       && jq -e '.id == "resp_bg" and .error.code == "outcome_unknown"' "$WORK/response.json" >/dev/null; then
+        ok "foreground stream refuses a sequence that is not a nonnegative safe integer number: $sequence"
+    else
+        bad "foreground stream refuses a sequence that is not a nonnegative safe integer number: $sequence" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout")"
+    fi
+done
 
 # --- polling ------------------------------------------------------------------
 # A buffered background create returns queued; llm polls the response by id
@@ -380,12 +518,25 @@ for mode in create-queued stream-created-drop; do
     reset "$mode"
     args=(--no-stream)
     [[ "$mode" != stream-* ]] || args=()
-    CURL_DELAY=2 LLM_MAX_TIME=1 LLM_RETRIES=3 LLM_RESPONSES_BACKGROUND=1 \
+    # Allow local setup to finish before the fake transfer consumes the
+    # original budget. The phase receipt keeps a pre-CREATE refusal visible.
+    CURL_DELAY=4 LLM_MAX_TIME=3 LLM_RETRIES=3 LLM_RESPONSES_BACKGROUND=1 \
         run_bg "${args[@]+"${args[@]}"}" bg >"$WORK/stdout" 2>"$WORK/stderr"
     rc=$?
-    if [[ "$rc" -ne 0 && "$(calls)" -eq 2 && "$(cancels)" -eq 1 ]] && grep -q 'LLM_MAX_TIME' "$WORK/stderr"; then
+    printf 'slow %s phase receipt: %s\n' "$mode" "$(cat "$CURL_DIR/delay-phases.jsonl" 2>/dev/null)"
+    if [[ "$rc" -ne 0 && "$(calls)" -eq 2 && "$(cancels)" -eq 1 ]] \
+       && grep -q 'LLM_MAX_TIME' "$WORK/stderr" \
+       && jq -e -s --arg mode "$mode" 'length == 2
+            and all(.[]; .call == 1 and .mode == $mode)
+            and .[0].phase == "delay-entered" and .[1].phase == "delay-released"
+            and (.[1].epoch_seconds - .[0].epoch_seconds >= 4)' "$CURL_DIR/delay-phases.jsonl" >/dev/null 2>&1 \
+       && jq -es 'length == 1 and (.[0] | type == "object" and .id == "resp_bg"
+            and .status == "cancelled" and (.output | type == "array"))' "$WORK/response.json" >/dev/null 2>&1; then
         ok "slow $mode spends the original deadline, not a new poll/resume budget"
-    else bad "slow $mode spends the original deadline, not a new poll/resume budget" "rc=$rc calls=$(calls)"; fi
+    else
+        bad "slow $mode spends the original deadline, not a new poll/resume budget" \
+            "rc=$rc calls=$(calls) cancels=$(cancels) stderr=$(cat "$WORK/stderr")"
+    fi
 done
 
 reset stream-created-drop

--- a/tests/test_llm_responses_background.sh
+++ b/tests/test_llm_responses_background.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# test_llm_responses_background.sh — background Responses in bin/llm: polling,
+# stream resume from the last sequence number, and cancel on signal, deadline,
+# and exhausted resumes (design/responses-lifecycle.md).
+#
+# curl is stubbed. $CURL_MODE_FILE holds one mode per line; line N applies to
+# call N and the last line repeats. Every call's argv is recorded, so tests pin
+# the exact URLs, verbs, and payloads of the create, the polls, the resume, and
+# the cancel.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+mkdir -p "$WORK/bin" "$WORK/home" "$WORK/calls"
+cat > "$WORK/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+n=$(( $(cat "$CURL_DIR/count" 2>/dev/null || echo 0) + 1 ))
+printf '%s' "$n" > "$CURL_DIR/count"
+printf '%s\n' "$@" > "$CURL_DIR/args-$n"
+mode=$(sed -n "${n}p" "$CURL_MODE_FILE")
+[[ -z "$mode" ]] && mode=$(tail -1 "$CURL_MODE_FILE")
+out_file=""
+prev=""
+for a in "$@"; do
+    [[ "$prev" == "-o" ]] && out_file="$a"
+    [[ "$prev" == "-d" && "$a" == @* ]] && cp "${a#@}" "$CURL_DIR/payload-$n"
+    prev="$a"
+done
+# The URL is always the last argument; a cancel is answered 200 whatever the
+# mode says, since the mode describes the response being polled.
+url="${*: -1}"
+if [[ "$url" == */cancel ]]; then
+    printf 'cancelled\n' >> "$CURL_DIR/cancels"
+    printf '200'
+    exit 0
+fi
+
+completed='{"id":"resp_bg","object":"response","status":"completed","output":[{"id":"msg_bg","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":11,"output_tokens":2}}'
+case "$mode" in
+    create-queued)
+        printf '%s' '{"id":"resp_bg","object":"response","status":"queued","output":[]}' > "$out_file"
+        printf '200'
+        ;;
+    poll-in-progress)
+        printf '%s' '{"id":"resp_bg","object":"response","status":"in_progress","output":[]}' > "$out_file"
+        printf '200'
+        ;;
+    poll-completed)
+        printf '%s' "$completed" > "$out_file"
+        printf '200'
+        ;;
+    poll-cancelled)
+        printf '%s' '{"id":"resp_bg","object":"response","status":"cancelled","output":[]}' > "$out_file"
+        printf '200'
+        ;;
+    poll-500)
+        printf '%s' '{"error":{"message":"boom"}}' > "$out_file"
+        printf '500'
+        ;;
+    chat-ok)
+        printf '%s' '{"choices":[{"message":{"content":"ok"}}]}' > "$out_file"
+        printf '200'
+        ;;
+    stream-created-drop)
+        printf 'data: %s\n\n' '{"type":"response.created","sequence_number":0,"response":{"id":"resp_bg","status":"queued","output":[]}}'
+        printf 'data: %s\n\n' '{"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_bg","status":"in_progress","output":[]}}'
+        printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":2,"delta":"a"}'
+        printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":3,"delta":"b"}'
+        ;;
+    stream-resume-complete)
+        printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":4,"delta":"!"}'
+        printf 'data: %s\n\n' '{"type":"response.completed","sequence_number":5,"response":{"id":"resp_bg","object":"response","status":"completed","output":[{"id":"msg_bg","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ab!"}]}],"usage":{"input_tokens":11,"output_tokens":3}}}'
+        ;;
+    stream-resume-terminal-only)
+        printf 'data: %s\n\n' '{"type":"response.completed","sequence_number":4,"response":{"id":"resp_bg","object":"response","status":"completed","output":[{"id":"msg_bg","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ab"}]}],"usage":{"input_tokens":11,"output_tokens":2}}}'
+        ;;
+    stream-empty)
+        :
+        ;;
+    stream-complete)
+        printf 'data: %s\n\n' '{"type":"response.created","sequence_number":0,"response":{"id":"resp_fg","status":"in_progress","output":[]}}'
+        printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":1,"delta":"ok"}'
+        printf 'data: %s\n\n' '{"type":"response.completed","sequence_number":2,"response":{"id":"resp_fg","object":"response","status":"completed","output":[{"id":"msg_fg","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":5,"output_tokens":1}}}'
+        ;;
+    stream-bg-block)
+        printf 'data: %s\n\n' '{"type":"response.created","sequence_number":0,"response":{"id":"resp_bg","status":"in_progress","output":[]}}'
+        printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":1,"delta":"```bash\necho hi\n```\n"}'
+        printf 'data: %s\n\n' '{"type":"response.output_text.delta","sequence_number":2,"delta":"trailing prose that costs tokens"}'
+        printf 'data: %s\n\n' '{"type":"response.completed","sequence_number":3,"response":{"id":"resp_bg","object":"response","status":"completed","output":[],"usage":{"input_tokens":5,"output_tokens":9}}}'
+        ;;
+    *)
+        echo "curl stub: unknown mode '$mode' for call $n" >&2
+        exit 2
+        ;;
+esac
+STUB
+chmod +x "$WORK/bin/curl"
+
+export PATH="$WORK/bin:$PATH"
+export HEADLONG_HOME="$WORK/home"
+export OPENAI_API_KEY="test-openai-key"
+export LLM_RETRY_BACKOFF=0
+export LLM_RESPONSES_POLL_INTERVAL=0
+export CURL_DIR="$WORK/calls"
+export CURL_MODE_FILE="$WORK/modes"
+LLM="$REPO/bin/llm"
+
+reset() {
+    rm -rf "$CURL_DIR"; mkdir -p "$CURL_DIR"
+    printf '%s\n' "$1" > "$CURL_MODE_FILE"
+    rm -f "$WORK/response.json" "$WORK/usage.json" "$WORK/stdout" "$WORK/stderr"
+}
+calls()   { cat "$CURL_DIR/count" 2>/dev/null || echo 0; }
+url_of()  { tail -1 "$CURL_DIR/args-$1" 2>/dev/null; }
+has_arg() { grep -qxF -- "$2" "$CURL_DIR/args-$1" 2>/dev/null; }
+cancels() { cat "$CURL_DIR/cancels" 2>/dev/null | wc -l | tr -d ' '; }
+cancel_url() {
+    local f u
+    for f in "$CURL_DIR"/args-*; do
+        u=$(tail -1 "$f")
+        [[ "$u" == */cancel ]] && { printf '%s' "$u"; return 0; }
+    done
+    return 1
+}
+
+run_bg() {
+    LLM_API_FORMAT=responses \
+    LLM_RESPONSE_FILE="$WORK/response.json" \
+    LLM_USAGE_FILE="$WORK/usage.json" \
+    "$LLM" --provider openai -m gpt-5.4-mini "$@"
+}
+
+# --- polling ------------------------------------------------------------------
+# A buffered background create returns queued; llm polls the response by id
+# until it is terminal, then treats the final object like any buffered reply.
+reset $'create-queued\npoll-in-progress\npoll-completed'
+LLM_RESPONSES_BACKGROUND=1 run_bg --no-stream "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "done" && "$(calls)" -eq 3 ]] \
+   && [[ "$(url_of 2)" == "https://api.openai.com/v1/responses/resp_bg" ]] \
+   && [[ "$(url_of 3)" == "https://api.openai.com/v1/responses/resp_bg" ]] \
+   && ! has_arg 2 "-d" && ! has_arg 3 "-d" \
+   && jq -e '.background == true and .stream == false' "$CURL_DIR/payload-1" >/dev/null \
+   && jq -e '.status == "completed" and .id == "resp_bg"' "$WORK/response.json" >/dev/null \
+   && jq -e '.in_tok == 11' "$WORK/usage.json" >/dev/null; then
+    ok "background --no-stream polls the response by id until it completes"
+else
+    bad "background --no-stream polls the response by id until it completes" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout") u2=$(url_of 2) u3=$(url_of 3) stderr=$(cat "$WORK/stderr")"
+fi
+
+# A transient poll failure is retried within LLM_RETRIES; the poll succeeds.
+reset $'create-queued\npoll-500\npoll-completed'
+LLM_RETRIES=1 LLM_RESPONSES_BACKGROUND=1 run_bg --no-stream "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "done" && "$(calls)" -eq 3 ]]; then
+    ok "a transient poll error is retried without recreating the response"
+else
+    bad "a transient poll error is retried without recreating the response" "rc=$rc calls=$(calls) stderr=$(cat "$WORK/stderr")"
+fi
+
+# cancelled is terminal: sidecar, no text, warning, non-zero.
+reset $'create-queued\npoll-cancelled'
+LLM_RESPONSES_BACKGROUND=1 run_bg --no-stream "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && ! -s "$WORK/stdout" ]] \
+   && jq -e '.status == "cancelled"' "$WORK/response.json" >/dev/null \
+   && grep -q 'response cancelled' "$WORK/stderr"; then
+    ok "a cancelled background response fails with its terminal state"
+else
+    bad "a cancelled background response fails with its terminal state" "rc=$rc out=$(cat "$WORK/stdout") stderr=$(cat "$WORK/stderr")"
+fi
+
+# --- streaming: resume from the last sequence number -------------------------
+reset $'stream-created-drop\nstream-resume-complete'
+LLM_RETRIES=2 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "ab!" && "$(calls)" -eq 2 ]] \
+   && [[ "$(url_of 2)" == "https://api.openai.com/v1/responses/resp_bg?stream=true&starting_after=3" ]] \
+   && ! has_arg 2 "-d" \
+   && jq -e '.background == true and .stream == true' "$CURL_DIR/payload-1" >/dev/null \
+   && jq -e '.status == "completed"' "$WORK/response.json" >/dev/null \
+   && grep -q 'resuming' "$WORK/stderr"; then
+    ok "a dropped background stream resumes after its last sequence number"
+else
+    bad "a dropped background stream resumes after its last sequence number" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout") u2=$(url_of 2) stderr=$(cat "$WORK/stderr")"
+fi
+
+# Text streamed before the drop is not printed again when the resume only
+# delivers the terminal event.
+reset $'stream-created-drop\nstream-resume-terminal-only'
+LLM_RETRIES=2 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "ab" && "$(calls)" -eq 2 ]]; then
+    ok "a resume that brings only the terminal event repeats no text"
+else
+    bad "a resume that brings only the terminal event repeats no text" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout") stderr=$(cat "$WORK/stderr")"
+fi
+
+# A drop before any id is known has nothing to resume: the create is retried.
+reset $'stream-empty\nstream-complete'
+LLM_RETRIES=2 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "ok" && "$(calls)" -eq 2 ]] \
+   && has_arg 2 "-d" && [[ "$(url_of 2)" == "https://api.openai.com/v1/responses" ]]; then
+    ok "a drop before the response id is known retries the create"
+else
+    bad "a drop before the response id is known retries the create" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout") u2=$(url_of 2) stderr=$(cat "$WORK/stderr")"
+fi
+
+# Resumes are bounded by LLM_RETRIES; when they run out the job is cancelled.
+reset $'stream-created-drop\nstream-created-drop'
+LLM_RETRIES=1 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && "$(calls)" -eq 3 && "$(cancels)" -eq 1 ]] \
+   && [[ "$(cancel_url)" == "https://api.openai.com/v1/responses/resp_bg/cancel" ]] \
+   && grep -q 'resumes are used up' "$WORK/stderr"; then
+    ok "exhausted resumes cancel the background response"
+else
+    bad "exhausted resumes cancel the background response" "rc=$rc calls=$(calls) cancels=$(cancels) stderr=$(cat "$WORK/stderr")"
+fi
+
+# A cut after the first code block leaves the model generating: cancel it.
+reset $'stream-bg-block'
+LLM_RESPONSES_BACKGROUND=1 run_bg --stop-after-code-block "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == $'```bash\necho hi\n```' && "$(cancels)" -eq 1 ]]; then
+    ok "stop-after-code-block cancels the background response it abandons"
+else
+    bad "stop-after-code-block cancels the background response it abandons" "rc=$rc cancels=$(cancels) out=$(cat "$WORK/stdout") stderr=$(cat "$WORK/stderr")"
+fi
+
+# --- cancel on signal and on deadline -----------------------------------------
+reset $'create-queued\npoll-in-progress'
+LLM_API_FORMAT=responses LLM_RESPONSE_FILE="$WORK/response.json" \
+LLM_RESPONSES_POLL_INTERVAL=1 LLM_RESPONSES_BACKGROUND=1 \
+    "$LLM" --provider openai -m gpt-5.4-mini --no-stream "bg" >"$WORK/stdout" 2>"$WORK/stderr" &
+pid=$!
+i=0
+while [[ "$(calls)" -lt 2 && "$i" -lt 100 ]]; do sleep 0.1; i=$((i+1)); done
+kill -TERM "$pid" 2>/dev/null
+wait "$pid"
+rc=$?
+if [[ "$rc" -ne 0 && "$(cancels)" -eq 1 ]] \
+   && [[ "$(cancel_url)" == "https://api.openai.com/v1/responses/resp_bg/cancel" ]] \
+   && grep -q 'cancelled background response resp_bg' "$WORK/stderr"; then
+    ok "SIGTERM while polling cancels the background response"
+else
+    bad "SIGTERM while polling cancels the background response" "rc=$rc calls=$(calls) cancels=$(cancels) stderr=$(cat "$WORK/stderr")"
+fi
+
+reset $'create-queued\npoll-in-progress'
+LLM_MAX_TIME=1 LLM_RESPONSES_POLL_INTERVAL=1 LLM_RESPONSES_BACKGROUND=1 \
+    run_bg --no-stream "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && "$(cancels)" -eq 1 ]] && grep -q 'LLM_MAX_TIME' "$WORK/stderr"; then
+    ok "LLM_MAX_TIME bounds the whole wait and cancels the response"
+else
+    bad "LLM_MAX_TIME bounds the whole wait and cancels the response" "rc=$rc calls=$(calls) cancels=$(cancels) stderr=$(cat "$WORK/stderr")"
+fi
+
+# --- opting in --------------------------------------------------------------------
+printf '%s' '{"background":true}' > "$WORK/body.json"
+reset $'create-queued\npoll-completed'
+LLM_RESPONSES_BODY_FILE="$WORK/body.json" run_bg --no-stream "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "done" && "$(calls)" -eq 2 ]] \
+   && jq -e '.background == true' "$CURL_DIR/payload-1" >/dev/null; then
+    ok "background:true in the body file is accepted and polled"
+else
+    bad "background:true in the body file is accepted and polled" "rc=$rc calls=$(calls) stderr=$(cat "$WORK/stderr")"
+fi
+
+reset $'poll-completed'
+LLM_RESPONSES_BACKGROUND=0 LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
+    run_bg --no-stream "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(calls)" -eq 1 ]] \
+   && jq -e 'has("background") | not' "$CURL_DIR/payload-1" >/dev/null; then
+    ok "LLM_RESPONSES_BACKGROUND=0 owns the field over the body file"
+else
+    bad "LLM_RESPONSES_BACKGROUND=0 owns the field over the body file" "rc=$rc calls=$(calls) payload=$(cat "$CURL_DIR/payload-1" 2>/dev/null)"
+fi
+
+reset $'create-queued'
+LLM_RESPONSES_BACKGROUND=maybe run_bg --no-stream "bg" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && "$(calls)" -eq 0 ]] && grep -q 'Invalid LLM_RESPONSES_BACKGROUND' "$WORK/stderr"; then
+    ok "an invalid LLM_RESPONSES_BACKGROUND fails before any request"
+else
+    bad "an invalid LLM_RESPONSES_BACKGROUND fails before any request" "rc=$rc calls=$(calls) stderr=$(cat "$WORK/stderr")"
+fi
+
+reset $'chat-ok'
+LLM_RESPONSES_BACKGROUND=1 LLM_API_FORMAT=chat \
+    "$LLM" --provider openai -m gpt-5.4-mini --no-stream "x" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "ok" ]] \
+   && grep -q 'LLM_RESPONSES_BACKGROUND ignored' "$WORK/stderr" \
+   && jq -e 'has("background") | not' "$CURL_DIR/payload-1" >/dev/null; then
+    ok "chat mode ignores the background flag with a note"
+else
+    bad "chat mode ignores the background flag with a note" "rc=$rc out=$(cat "$WORK/stdout") stderr=$(cat "$WORK/stderr")"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_llm_responses_background.sh
+++ b/tests/test_llm_responses_background.sh
@@ -40,12 +40,33 @@ done
 url="${*: -1}"
 if [[ "$url" == */cancel ]]; then
     printf 'cancelled\n' >> "$CURL_DIR/cancels"
+    if [[ "${CANCEL_FAIL:-0}" == 1 ]]; then
+        printf '%s' '{"error":{"message":"cancel unavailable"}}' > "$out_file"
+        printf '500'
+        exit 0
+    fi
+    printf '%s' '{"id":"resp_bg","status":"cancelled","output":[]}' > "$out_file"
     printf '200'
     exit 0
 fi
 
 completed='{"id":"resp_bg","object":"response","status":"completed","output":[{"id":"msg_bg","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":11,"output_tokens":2}}'
+[[ "${CURL_DELAY:-0}" == 0 ]] || sleep "$CURL_DELAY"
 case "$mode" in
+    poll-error)
+        printf '%s' '{"error":{"message":"backend failed"}}' > "$out_file"
+        printf '200'
+        ;;
+    poll-invalid)
+        printf '%s' '{"id":"resp_bg","status":"unexpected","output":[]}' > "$out_file"
+        printf '200'
+        ;;
+    create-lost)
+        exit 28
+        ;;
+    stream-cancelled)
+        printf 'data: %s\n\n' '{"type":"response.cancelled","sequence_number":4,"response":{"id":"resp_bg","status":"cancelled","output":[]}}'
+        ;;
     create-queued)
         printf '%s' '{"id":"resp_bg","object":"response","status":"queued","output":[]}' > "$out_file"
         printf '200'
@@ -205,15 +226,15 @@ else
     bad "a resume that brings only the terminal event repeats no text" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout") stderr=$(cat "$WORK/stderr")"
 fi
 
-# A drop before any id is known has nothing to resume: the create is retried.
+# A lost acknowledgement is not evidence that the create was never accepted.
 reset $'stream-empty\nstream-complete'
 LLM_RETRIES=2 LLM_RESPONSES_BACKGROUND=1 run_bg "bg" >"$WORK/stdout" 2>"$WORK/stderr"
 rc=$?
-if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "ok" && "$(calls)" -eq 2 ]] \
-   && has_arg 2 "-d" && [[ "$(url_of 2)" == "https://api.openai.com/v1/responses" ]]; then
-    ok "a drop before the response id is known retries the create"
+if [[ "$rc" -ne 0 && "$(calls)" -eq 1 ]] \
+   && jq -e '.error.code == "outcome_unknown"' "$WORK/response.json" >/dev/null; then
+    ok "a drop before the response id is known never recreates"
 else
-    bad "a drop before the response id is known retries the create" "rc=$rc calls=$(calls) out=$(cat "$WORK/stdout") u2=$(url_of 2) stderr=$(cat "$WORK/stderr")"
+    bad "a drop before the response id is known never recreates" "rc=$rc calls=$(calls) stderr=$(cat "$WORK/stderr")"
 fi
 
 # Resumes are bounded by LLM_RETRIES; when they run out the job is cancelled.
@@ -251,7 +272,7 @@ wait "$pid"
 rc=$?
 if [[ "$rc" -ne 0 && "$(cancels)" -eq 1 ]] \
    && [[ "$(cancel_url)" == "https://api.openai.com/v1/responses/resp_bg/cancel" ]] \
-   && grep -q 'cancelled background response resp_bg' "$WORK/stderr"; then
+   && grep -q 'background response resp_bg confirmed cancelled' "$WORK/stderr"; then
     ok "SIGTERM while polling cancels the background response"
 else
     bad "SIGTERM while polling cancels the background response" "rc=$rc calls=$(calls) cancels=$(cancels) stderr=$(cat "$WORK/stderr")"
@@ -310,6 +331,70 @@ if [[ "$rc" -eq 0 && "$(cat "$WORK/stdout")" == "ok" ]] \
 else
     bad "chat mode ignores the background flag with a note" "rc=$rc out=$(cat "$WORK/stdout") stderr=$(cat "$WORK/stderr")"
 fi
+
+# Fault boundaries must never turn terminal failure or an ambiguous create
+# into another POST, even when retry budget remains.
+for mode in create-lost poll-cancelled stream-cancelled; do
+    reset "$mode"
+    args=(--no-stream)
+    [[ "$mode" != stream-* ]] || args=()
+    LLM_RETRIES=3 LLM_RESPONSES_BACKGROUND=1 run_bg "${args[@]+"${args[@]}"}" bg >"$WORK/stdout" 2>"$WORK/stderr"
+    rc=$?
+    if [[ "$rc" -ne 0 && "$(calls)" -eq 1 ]]; then ok "$mode fails without recreating"
+    else bad "$mode fails without recreating" "rc=$rc calls=$(calls)"; fi
+done
+
+for mode in poll-error poll-invalid; do
+    reset "$(printf 'create-queued\n%s' "$mode")"
+    LLM_RESPONSES_BACKGROUND=1 run_bg --no-stream bg >"$WORK/stdout" 2>"$WORK/stderr"
+    rc=$?
+    if [[ "$rc" -ne 0 && ! -s "$WORK/stdout" ]]; then ok "$mode cannot become a successful completion"
+    else bad "$mode cannot become a successful completion" "rc=$rc"; fi
+done
+
+reset $'stream-created-drop\nstream-cancelled'
+LLM_RETRIES=3 LLM_RESPONSES_BACKGROUND=1 run_bg bg >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && "$(calls)" -eq 2 && "$(cancels)" -eq 0 ]] \
+    && jq -e '.status == "cancelled"' "$WORK/response.json" >/dev/null; then
+    ok "external cancellation during resume is terminal, not another cancel or create"
+else bad "external cancellation during resume is terminal, not another cancel or create" "rc=$rc calls=$(calls)"; fi
+
+reset stream-created-drop
+CANCEL_FAIL=1 LLM_RETRIES=0 LLM_RESPONSES_BACKGROUND=1 run_bg bg >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'cancellation not confirmed' "$WORK/stderr" \
+    && jq -e '.id == "resp_bg" and .error.code == "outcome_unknown" and .cancellation.http_code == "500"' "$WORK/response.json" >/dev/null; then
+    ok "failed cancellation preserves recovery handle without claiming success"
+else bad "failed cancellation preserves recovery handle without claiming success"; fi
+
+reset $'create-queued\npoll-completed'
+start=$SECONDS
+LLM_MAX_TIME=1 LLM_RESPONSES_POLL_INTERVAL=30 LLM_RESPONSES_BACKGROUND=1 run_bg --no-stream bg >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && "$((SECONDS-start))" -lt 5 && "$(calls)" -eq 2 && "$(cancels)" -eq 1 ]]; then
+    ok "long poll sleep is clamped; no GET starts after the deadline"
+else bad "long poll sleep is clamped; no GET starts after the deadline" "rc=$rc calls=$(calls)"; fi
+
+for mode in create-queued stream-created-drop; do
+    reset "$mode"
+    args=(--no-stream)
+    [[ "$mode" != stream-* ]] || args=()
+    CURL_DELAY=2 LLM_MAX_TIME=1 LLM_RETRIES=3 LLM_RESPONSES_BACKGROUND=1 \
+        run_bg "${args[@]+"${args[@]}"}" bg >"$WORK/stdout" 2>"$WORK/stderr"
+    rc=$?
+    if [[ "$rc" -ne 0 && "$(calls)" -eq 2 && "$(cancels)" -eq 1 ]] && grep -q 'LLM_MAX_TIME' "$WORK/stderr"; then
+        ok "slow $mode spends the original deadline, not a new poll/resume budget"
+    else bad "slow $mode spends the original deadline, not a new poll/resume budget" "rc=$rc calls=$(calls)"; fi
+done
+
+reset stream-created-drop
+start=$SECONDS
+LLM_MAX_TIME=1 LLM_RETRY_BACKOFF=30 LLM_RETRIES=3 LLM_RESPONSES_BACKGROUND=1 run_bg bg >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+if [[ "$rc" -ne 0 && "$((SECONDS-start))" -lt 5 && "$(calls)" -eq 2 && "$(cancels)" -eq 1 ]]; then
+    ok "resume backoff is clamped to the original deadline"
+else bad "resume backoff is clamped to the original deadline" "rc=$rc calls=$(calls)"; fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_llm_responses_faults.sh
+++ b/tests/test_llm_responses_faults.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Synchronous completion faults shared with the limited upstream integration.
+set -uo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/bin" "$WORK/home"
+cat > "$WORK/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+printf 'create\n' >> "$CALLS"
+out=""; prev=""
+for arg in "$@"; do
+    [[ "$prev" != -o ]] || out="$arg"
+    prev="$arg"
+done
+case "$MODE" in
+    lost) exit 28 ;;
+    http500) printf '{"error":{"message":"internal"}}' > "$out"; printf 500 ;;
+    lost-id) printf '{"id":"resp_a","status":"in_progress"}' > "$out"; exit 28 ;;
+    malformed) printf '{' > "$out"; printf 200 ;;
+    empty) printf ' \n' > "$out"; printf 200 ;;
+    unknown) printf '{"id":"resp_a","status":"new_status","output":[]}' > "$out"; printf 200 ;;
+    cancelled|failed)
+        printf '{"id":"resp_a","status":"%s","output":[]}' "$MODE" > "$out"; printf 200 ;;
+    embedded) printf '{"id":"resp_a","status":"completed","error":{"message":"broken"},"output":[]}' > "$out"; printf 200 ;;
+    stream-empty) : ;;
+    stream-lost)
+        printf 'data: {"type":"response.created","response":{"id":"resp_a","status":"in_progress"}}\n\n'
+        ;;
+    stream-cancelled|stream-failed)
+        status="${MODE#stream-}"
+        printf 'data: {"type":"response.%s","response":{"id":"resp_a","status":"%s","output":[]}}\n\n' "$status" "$status"
+        ;;
+    stream-malformed)
+        printf 'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+        ;;
+    stream-mismatch)
+        printf 'data: {"type":"response.completed","response":{"id":"resp_a","status":"incomplete","output":[]}}\n\n'
+        ;;
+    stream-identity)
+        printf 'data: {"type":"response.created","response":{"id":"resp_a","status":"in_progress"}}\n\n'
+        printf 'data: {"type":"response.completed","response":{"id":"resp_b","status":"completed","output":[]}}\n\n'
+        ;;
+esac
+STUB
+chmod +x "$WORK/bin/curl"
+export PATH="$WORK/bin:$PATH" HEADLONG_HOME="$WORK/home" OPENAI_API_KEY=test-key
+export LLM_API_FORMAT=responses LLM_RETRIES=3 LLM_RETRY_BACKOFF=0
+export LLM_RESPONSE_FILE="$WORK/response" CALLS="$WORK/calls"
+pass=0; fail=0
+for MODE in lost lost-id http500 malformed empty unknown cancelled failed embedded stream-empty stream-lost stream-cancelled stream-failed stream-malformed stream-mismatch stream-identity; do
+    export MODE
+    rm -f "$CALLS" "$LLM_RESPONSE_FILE"
+    args=(--no-stream)
+    [[ "$MODE" != stream-* ]] || args=()
+    "$REPO/bin/llm" --provider openai -m gpt-5.4-mini "${args[@]+"${args[@]}"}" test >"$WORK/out" 2>"$WORK/err"
+    rc=$?
+    if [[ "$rc" -ne 0 && "$(wc -l < "$CALLS" | tr -d ' ')" == 1 && ! -s "$WORK/out" ]]; then
+        printf 'ok   %s fails with exactly one create\n' "$MODE"; pass=$((pass+1))
+    else
+        printf 'FAIL %s rc=%s: %s\n' "$MODE" "$rc" "$(cat "$WORK/err")"; fail=$((fail+1))
+    fi
+    case "$MODE" in
+        cancelled|failed|embedded|stream-cancelled|stream-failed) continue ;;
+    esac
+    if jq -e '.error.code == "outcome_unknown"' "$LLM_RESPONSE_FILE" >/dev/null 2>&1; then
+        printf 'ok   %s preserves typed unknown outcome\n' "$MODE"; pass=$((pass+1))
+    else
+        printf 'FAIL %s missing unknown outcome sidecar\n' "$MODE"; fail=$((fail+1))
+    fi
+    case "$MODE" in
+        stream-lost|lost-id|unknown)
+            if jq -e '.id == "resp_a"' "$LLM_RESPONSE_FILE" >/dev/null; then
+                printf 'ok   %s preserves known response handle\n' "$MODE"; pass=$((pass+1))
+            else
+                printf 'FAIL %s discarded known response handle\n' "$MODE"; fail=$((fail+1))
+            fi ;;
+    esac
+done
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_llm_retry.sh
+++ b/tests/test_llm_retry.sh
@@ -118,6 +118,18 @@ case "$mode" in
         printf '{"choices":[{"message":{"content":"truncated tex"},"finish_reason":"length"}]}' > "$out_file"
         printf '200'
         ;;
+    sse-anthropic-error)   # Anthropic: an error event before any output (overloaded_error)
+        printf 'data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n'
+        printf 'data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n'
+        ;;
+    sse-anthropic-ok)      # Anthropic: one text block, then a clean stop
+        printf 'data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n'
+        printf 'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n'
+        printf 'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n'
+        printf 'data: {"type":"content_block_stop","index":0}\n\n'
+        printf 'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n'
+        printf 'data: {"type":"message_stop"}\n\n'
+        ;;
     sse-finish-length)  # streamed output whose final chunk reports the cap
         printf 'data: {"choices":[{"delta":{"content":"truncated te"},"finish_reason":null}]}\n\n'
         printf 'data: {"choices":[{"delta":{"content":"x"},"finish_reason":null}]}\n\n'
@@ -163,6 +175,17 @@ check "persistent failure fails"     test "$rc" -ne 0
 check "no output on failure"         test -z "$out"
 check "three attempts then give up"  test "$(calls)" = "3"
 check "original error preserved"     grep -q "llm: error: API error: Provider returned error" "$WORK/stderr"
+
+# ---------------------------------------------------------------------------
+# Streaming (Anthropic): an in-stream error event before any output exits the
+# handler with 1, not 75 (overloaded_error arrives this way) -> still retried
+# ---------------------------------------------------------------------------
+
+reset $'sse-anthropic-error\nsse-anthropic-ok'
+out=$(ANTHROPIC_API_KEY=test-key LLM_RETRIES=2 "$LLM" -m claude-sonnet-4-5-20250929 "say ok" 2>"$WORK/stderr")
+check "anthropic pre-output error event retried" test "$?" -eq 0
+check "anthropic retry output correct"           test "$out" = "ok"
+check "anthropic two curl calls"                 test "$(calls)" = "2"
 
 # ---------------------------------------------------------------------------
 # LLM_RETRIES=0 restores single-shot behavior

--- a/tests/test_prompt_section_failure.sh
+++ b/tests/test_prompt_section_failure.sh
@@ -46,7 +46,7 @@ check "stderr carries the command message"   grep -q 'boom: no frontmatter' "$WO
 n=$(jq -r 'select(.type=="error" and .reason=="prompt-section-failed") | .section' "$TRAJ" | grep -c '^skills$')
 check "one error step recorded for the skills section" test "$n" -eq 1
 check "error step says the section is missing"       bash -c 'jq -r "select(.type==\"error\") | .content" "$1" | grep -q "missing from every wakeup"' _ "$TRAJ"
-check "error step carries the exit code"             bash -c 'jq -e "select(.type==\"error\") | .rc == 1" "$1"' _ "$TRAJ"
+check "error step carries the exit code"             bash -c 'jq -s -e "any(.[]; .type==\"error\" and .reason==\"prompt-section-failed\" and .section==\"skills\" and .rc == 1)" "$1"' _ "$TRAJ"
 
 build >/dev/null 2>"$WORK/err2"
 n=$(jq -r 'select(.type=="error" and .reason=="prompt-section-failed") | .section' "$TRAJ" | grep -c '^skills$')

--- a/tests/test_recap_context_upgrade.sh
+++ b/tests/test_recap_context_upgrade.sh
@@ -64,8 +64,8 @@ mk_block() { # mk_block <run-name> <tier> <s> <e> <summary>
     local f
     f=$(blockfile "$1" "$2" "$3" "$4")
     mkdir -p "$(dirname "$f")"
-    jq -n -c --argjson tier "$2" --argjson start "$3" --argjson end "$4" --arg sum "$5" \
-        '{tier:$tier, start:$start, end:$end, n:($end-$start), summary:$sum, step_ids:["x1","x2"]}' > "$f"
+    jq -n -c --argjson tier "$2" --argjson start "$3" --argjson stop "$4" --arg sum "$5" \
+        '{tier:$tier, start:$start, end:$stop, n:($stop-$start), summary:$sum, step_ids:["x1","x2"]}' > "$f"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recent_stream_filter.sh
+++ b/tests/test_recent_stream_filter.sh
@@ -68,17 +68,18 @@ step t2  thought   "$(head -c 2000 /dev/zero | tr '\0' x)" 5
 out=$(stream 30)
 types=$(printf '%s\n' "$out" | jq -r .type | tr '\n' ' ')
 
-if ! printf '%s\n' "$out" | jq -e 'select(.type == "reasoning")' >/dev/null 2>&1; then
+# Slurp once so jq 1.6 checks every record instead of the last input's exit status.
+if printf '%s\n' "$out" | jq -s -e 'all(.[]; .type != "reasoning")' >/dev/null 2>&1; then
     ok "reasoning steps are dropped"
 else
     bad "reasoning steps are dropped" "$types"
 fi
-if ! printf '%s\n' "$out" | jq -e 'select(.type == "shell-output")' >/dev/null 2>&1; then
+if printf '%s\n' "$out" | jq -s -e 'all(.[]; .type != "shell-output")' >/dev/null 2>&1; then
     ok "machinery steps stay out"
 else
     bad "machinery steps stay out"
 fi
-printf '%s\n' "$out" | jq -e 'select(.step_id == "f1")' >/dev/null 2>&1 && ok "final steps are kept" || bad "final steps are kept" "$types"
+printf '%s\n' "$out" | jq -s -e 'any(.[]; .step_id == "f1")' >/dev/null 2>&1 && ok "final steps are kept" || bad "final steps are kept" "$types"
 # A final is all the next wake sees of its run, so it carries a command that
 # prints the run's raw steps; a final without a run id (old rows) carries none.
 details=$(printf '%s\n' "$out" | jq -r 'select(.step_id == "f1") | .details // "none"')
@@ -143,7 +144,7 @@ fi
 
 # A final without a run id (old rows) carries no details command.
 step f2 final "old final, no run id" 4
-printf '%s\n' "$(stream 30)" | jq -e 'select(.step_id == "f2") | has("details") | not' >/dev/null 2>&1 && ok "a final without a run id carries no details" || bad "a final without a run id carries no details"
+printf '%s\n' "$(stream 30)" | jq -s -e 'any(.[]; .step_id == "f2" and (has("details") | not))' >/dev/null 2>&1 && ok "a final without a run id carries no details" || bad "a final without a run id carries no details"
 
 # Observation/final pairs: a final drops the nearest earlier observation of
 # its run; earlier milestones, orphan observations, and orphan finals stay.

--- a/tests/test_responder_metrics.sh
+++ b/tests/test_responder_metrics.sh
@@ -105,7 +105,7 @@ if [[ -n "$obs" && "$(field "$obs" decision)" == replied ]]; then
 else
     bad "replied observation written" "$(tail -3 "$WORK/step.log")"
 fi
-if jq -e --arg t trig-1 'select(.type=="message" and .from=="testid" and .reply_to==$t)' "$TRAJ" >/dev/null; then
+if jq -s -e --arg t trig-1 'any(.[]; .type=="message" and .from=="testid" and .reply_to==$t)' "$TRAJ" >/dev/null; then
     ok "reply stamped to the trigger"
 else
     bad "reply stamped to the trigger"

--- a/tests/test_responder_person_notes.sh
+++ b/tests/test_responder_person_notes.sh
@@ -143,7 +143,7 @@ msg trig-4 stranger "$ME" "hello"
 printf 'hi\n' > "$STUB_REPLY_FILE"
 printf 'Stranger said hello.\n' > "$STUB_NOTES_FILE"
 run_step "$(grep -F '"step_id":"trig-4"' "$TRAJ")"
-jq -e 'select(.type=="message" and .reply_to=="trig-4")' "$TRAJ" >/dev/null && ok "first contact replies and writes notes without error" || bad "first contact replies"
+jq -s -e 'any(.[]; .type=="message" and .reply_to=="trig-4")' "$TRAJ" >/dev/null && ok "first contact replies and writes notes without error" || bad "first contact replies"
 
 echo
 echo "$pass passed, $fail failed"

--- a/tests/test_responses_cli.sh
+++ b/tests/test_responses_cli.sh
@@ -9,6 +9,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(dirname "$HERE")"
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
+REAL_CURL=$(command -v curl)
 
 pass=0
 fail=0
@@ -37,9 +38,56 @@ done
 printf '%s %s\n' "$method" "$url" >> "$CURL_LOG"
 [[ -n "$payload_file" ]] && cp "$payload_file" "$CURL_PAYLOAD"
 [[ -n "$auth_file" ]] && cp "$auth_file" "$CURL_AUTH"
+if [[ "${CURL_CHECK_PERMS:-0}" == 1 ]]; then
+    find "$TMPDIR" -type f ! -perm 600 -print >> "$CURL_BAD_MODES"
+    find "$TMPDIR" -mindepth 1 -type d ! -perm 700 -print >> "$CURL_BAD_MODES"
+fi
 emit() { if [[ -n "$out_file" ]]; then printf '%s' "$1" > "$out_file"; else printf '%s' "$1"; fi; }
 
 case "$CURL_MODE" in
+    hang)
+        printf '%s\n' "$$" > "$CURL_PID"
+        exec sleep 60
+        ;;
+    network-error) exit 28 ;;
+    oversize)
+        # Sparse file: exercise the aggregate byte guard without a large
+        # allocation, even if a transport fails to enforce max-filesize.
+        python3 - "$out_file" <<'PY'
+import sys
+with open(sys.argv[1], 'wb') as f:
+    f.truncate(67108865)
+PY
+        printf '200'
+        ;;
+    late-malformed)
+        if [[ "$n" -eq 1 ]]; then
+            emit '{"data":[{"id":"itm_1"}],"has_more":true}'
+        else
+            emit 'not JSON'
+        fi
+        printf '200'
+        ;;
+    fixture)
+        emit "$CURL_FIXTURE"
+        printf '200'
+        ;;
+    cycle)
+        emit "{\"data\":[{\"id\":\"itm_$(( (n - 1) % 2 ))\"}],\"has_more\":true}"
+        printf '200'
+        ;;
+    boundary|cap)
+        more=true
+        [[ "$CURL_MODE" == boundary && "$n" -eq 500 ]] && more=false
+        emit "{\"data\":[{\"id\":\"itm_$n\"}],\"has_more\":$more}"
+        printf '200'
+        ;;
+    duplicate)
+        more=true
+        [[ "$n" -eq 2 ]] && more=false
+        emit "{\"data\":[{\"id\":\"shared\"},{\"id\":\"itm_$n\"}],\"has_more\":$more}"
+        printf '200'
+        ;;
     response)
         emit '{"id":"resp_1","object":"response","status":"completed","output":[]}'
         printf '200'
@@ -53,7 +101,7 @@ case "$CURL_MODE" in
         printf '200'
         ;;
     compacted)
-        emit '{"id":"resp_c","object":"response.compaction","output":[{"id":"cmp_1","type":"compaction","encrypted_content":"opaque"}]}'
+        emit '{"id":"resp_c","object":"response.compaction","output":[{"id":"cmp_1","type":"compaction","encrypted_content":"opaque"}],"usage":{"input_tokens":100,"output_tokens":12}}'
         printf '200'
         ;;
     pages)
@@ -338,6 +386,14 @@ else
     bad "compact merges --body-file first and lets CLI-owned fields win" "$(cat "$CURL_PAYLOAD")"
 fi
 
+if jq -e 'select(.operation == "responses.compact") | .model == "gpt-5.4-mini"
+    and .provider == "openai" and .in_tok == 100 and .out_tok == 12' \
+    "$HEADLONG_HOME/usage/llm.jsonl" >/dev/null; then
+    ok "standalone compaction usage enters the shared inference ledger"
+else
+    bad "standalone compaction usage enters the shared inference ledger"
+fi
+
 reset
 run compact --model gpt-5.4-mini --previous-response-id resp_1
 jq -e '.previous_response_id == "resp_1" and (has("input") | not)' "$CURL_PAYLOAD" >/dev/null \
@@ -430,6 +486,198 @@ usage_case "an items file that is not a JSON array" conversations add conv_1 \
     --items-file "$WORK/notarray.json"
 usage_case "an items file that does not exist" conversations add conv_1 \
     --items-file "$WORK/missing.json"
+
+# Path ids must never change the target of a destructive operation.
+for id in '' '.' '..' '../resp_other' 'resp_1?other=1' 'resp_1#fragment' 'resp_%2fother' 'resp_[1-2]' 'resp_1/'; do
+    usage_case "unsafe response id: $id" delete "$id"
+done
+usage_case "unsafe conversation id" conversations delete '../conv_other'
+usage_case "unsafe item id" conversations remove conv_1 'itm_1?other=1'
+usage_case "invalid cursor" input-items resp_1 --after '../item'
+usage_case "invalid page limit" input-items resp_1 --limit -1
+usage_case "invalid order" input-items resp_1 --order sideways
+usage_case "invalid stream sequence" get resp_1 --stream --starting-after nope
+
+# --all must not turn malformed data or a safety bound into exhaustion.
+export TMPDIR="$WORK/tmp with spaces"
+mkdir -p "$TMPDIR"
+for fixture in \
+    'not JSON' '{}' '[]' \
+    '{"data":[],"has_more":null}' \
+    '{"data":[],"has_more":"false"}' \
+    '{"data":[],"has_more":0}' \
+    '{"data":[],"has_more":true}' \
+    '{"data":[{}],"has_more":false}' \
+    '{"data":[{"id":""}],"has_more":true}' \
+    '{"data":[{"id":123}],"has_more":false}' \
+    '{"data":[{"id":"../item"}],"has_more":true}' \
+    '{"data":[{"id":"a"}],"last_id":"b","has_more":false}' \
+    '{"data":{},"has_more":false}' \
+    '{"data":[],"has_more":false} {"data":[],"has_more":false}'; do
+    reset
+    CURL_MODE=fixture CURL_FIXTURE="$fixture" run input-items resp_1 --all
+    rc=$?
+    if [[ "$rc" -eq 1 && ! -s "$WORK/stdout" && -s "$WORK/stderr" && "$(cat "$CURL_CALLS")" == 1 ]]; then
+        ok "--all rejects malformed page: $fixture"
+    else
+        bad "--all rejects malformed page: $fixture" "rc=$rc"
+    fi
+done
+for mode in fixture cycle duplicate cap late-malformed oversize; do
+    reset
+    CURL_MODE="$mode" CURL_FIXTURE='{"data":[{"id":"same"}],"has_more":true}' \
+        run conversations items conv_1 --all
+    rc=$?
+    calls=$(cat "$CURL_CALLS")
+    expected=2
+    [[ "$mode" == cycle ]] && expected=3
+    [[ "$mode" == cap ]] && expected=500
+    [[ "$mode" == oversize ]] && expected=1
+    if [[ "$rc" -eq 1 && ! -s "$WORK/stdout" && "$calls" -eq "$expected" && -s "$WORK/stderr" ]]; then
+        ok "--all fails closed on $mode ($expected requests)"
+    else
+        bad "--all fails closed on $mode" "rc=$rc calls=$calls"
+    fi
+done
+reset
+CURL_MODE=boundary run input-items resp_1 --all
+if [[ $? -eq 0 && "$(cat "$CURL_CALLS")" == 500 ]] \
+    && jq -e '.has_more == false and (.data | length) == 500' "$WORK/stdout" >/dev/null; then
+    ok "actual exhaustion at page 500 succeeds"
+else
+    bad "actual exhaustion at page 500 succeeds"
+fi
+reset
+CURL_MODE=fixture CURL_FIXTURE='{"data":[],"has_more":false}' run input-items resp_1 --all
+if [[ $? -eq 0 ]] && jq -e '.data == [] and .has_more == false and .last_id == null' "$WORK/stdout" >/dev/null; then
+    ok "an explicitly exhausted empty list succeeds"
+else
+    bad "an explicitly exhausted empty list succeeds"
+fi
+
+# Every file, not just auth, is private and removed on success and failure.
+export CURL_BAD_MODES="$WORK/bad-modes" CURL_CHECK_PERMS=1
+for mode in response not-found network-error stream-terminal stream-truncated pages; do
+    reset
+    : > "$CURL_BAD_MODES"
+    case "$mode" in
+        stream-*) CURL_MODE="$mode" run get resp_1 --stream ;;
+        pages) CURL_MODE="$mode" run input-items resp_1 --all ;;
+        *) CURL_MODE="$mode" run conversations update conv_1 --metadata '{"private":"body"}' ;;
+    esac
+    if [[ -z "$(ls -A "$TMPDIR")" && ! -s "$CURL_BAD_MODES" ]]; then
+        ok "$mode cleans private temporary files with spaces in TMPDIR"
+    else
+        bad "$mode cleans private temporary files with spaces in TMPDIR"
+    fi
+done
+unset CURL_CHECK_PERMS
+
+# Reset SIGINT before exec (the test runner may itself inherit it ignored).
+# The stub execs sleep, so its recorded PID is the actual network child.
+export CURL_PID="$WORK/curl.pid"
+if python3 - "$R" "$WORK" <<'PY'
+import os, pathlib, signal, subprocess, sys, time
+r, work = sys.argv[1:]
+env = dict(os.environ, CURL_MODE="hang")
+pidfile = pathlib.Path(env["CURL_PID"])
+def reset_signals():
+    for sig in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, signal.SIG_DFL)
+for sig in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    for args in (["get", "resp_1"], ["get", "resp_1", "--stream"],
+                 ["conversations", "update", "conv_1", "--metadata", '{"private":"body"}']):
+        pidfile.unlink(missing_ok=True)
+        with open(work + "/signal.out", "wb") as out:
+            p = subprocess.Popen([r, *args], env=env, stdout=out, stderr=out,
+                                 preexec_fn=reset_signals)
+            child = None
+            try:
+                deadline = time.monotonic() + 5
+                while not pidfile.exists() and time.monotonic() < deadline:
+                    time.sleep(.01)
+                child = int(pidfile.read_text())
+                p.send_signal(sig)
+                assert p.wait(timeout=3) == 128 + sig
+                try:
+                    os.kill(child, 0)
+                except ProcessLookupError:
+                    pass
+                else:
+                    raise AssertionError("network child survived")
+                assert not list(pathlib.Path(env["TMPDIR"]).iterdir()), "temporary files survived"
+            finally:
+                if p.poll() is None:
+                    p.kill()
+                    p.wait()
+                if child:
+                    try:
+                        os.kill(child, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+PY
+then ok "HUP/INT/TERM reap network children and clean files (9 cases)"
+else bad "HUP/INT/TERM reap network children and clean files"
+fi
+
+# Real curl against an in-process loopback fixture, never a provider. Empty
+# include[] is accepted by curl even without globoff; globoff also ensures
+# configured base paths containing curl metacharacters are sent literally.
+if python3 - "$R" "$REAL_CURL" "$WORK" <<'PY'
+import http.server, json, os, pathlib, subprocess, sys, threading
+r, curl, work = sys.argv[1:]
+paths = []
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        paths.append(self.path)
+        if self.path.startswith('/oversize/'):
+            self.send_response(200)
+            self.send_header('Content-Length', '67108865')
+            self.end_headers()
+            return
+        data = (b'data: {"type":"response.completed"}\n\n' if 'stream=true' in self.path
+                else b'{"id":"resp_1"}')
+        self.send_response(200)
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+    def log_message(self, *args):
+        pass
+server = http.server.HTTPServer(('127.0.0.1', 0), Handler)
+thread = threading.Thread(target=server.serve_forever, daemon=True)
+thread.start()
+realbin = pathlib.Path(work) / 'realbin'
+realbin.mkdir()
+(realbin / 'curl').symlink_to(curl)
+base = 'http://127.0.0.1:' + str(server.server_port)
+env = dict(os.environ, PATH=str(realbin) + ':' + os.environ['PATH'],
+           LLM_PROVIDER='openai-compatible', LLM_API_URL=base + '/v{1,2}',
+           LLM_API_KEY='fixture-key', NO_PROXY='127.0.0.1', no_proxy='127.0.0.1')
+try:
+    subprocess.run([curl, '-fsS', base + '/plain?include[]=reasoning.encrypted_content'],
+                   check=True, capture_output=True, env=env, timeout=5)
+    assert paths.pop() == '/plain?include[]=reasoning.encrypted_content'
+    for stream in (False, True):
+        args = [r, 'get', 'resp_1', '--include', 'reasoning.encrypted_content',
+                '--include', 'message.output_text.logprobs'] + (['--stream'] if stream else [])
+        result = subprocess.run(args, check=True, capture_output=True, env=env, timeout=5)
+        json.loads(result.stdout)
+        query = ('stream=true&' if stream else '') + 'include[]=reasoning.encrypted_content&include[]=message.output_text.logprobs'
+        assert paths == ['/v{1,2}/responses/resp_1?' + query], paths
+        paths.clear()
+    env['LLM_API_URL'] = base + '/oversize'
+    result = subprocess.run([r, 'input-items', 'resp_1', '--all'],
+                            capture_output=True, env=env, timeout=5)
+    assert result.returncode == 1 and not result.stdout and result.stderr
+    assert not list(pathlib.Path(env['TMPDIR']).iterdir())
+finally:
+    server.shutdown()
+    server.server_close()
+    thread.join()
+PY
+then ok "real curl preserves includes and literal URL targets (buffered and streamed)"
+else bad "real curl preserves includes and literal URL targets"
+fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/test_responses_cli.sh
+++ b/tests/test_responses_cli.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# test_responses_cli.sh: bin/responses, the Responses lifecycle CLI.
+# Hermetic: a curl stub on PATH records method, URL, body, and the auth
+# config file, and replays canned JSON per CURL_MODE. Runs under bash 3.2.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+mkdir -p "$WORK/bin" "$WORK/home"
+cat > "$WORK/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+n=0
+[[ -f "$CURL_CALLS" ]] && read -r n < "$CURL_CALLS"
+n=$((n + 1))
+printf '%s\n' "$n" > "$CURL_CALLS"
+printf '%s\n' "$@" > "$CURL_ARGS"
+method="GET"; out_file=""; payload_file=""; auth_file=""; url=""; prev=""
+for arg in "$@"; do
+    case "$prev" in
+        -X) method="$arg" ;;
+        -o) out_file="$arg" ;;
+        -K) auth_file="$arg" ;;
+        -d) [[ "$arg" == @* ]] && payload_file="${arg#@}" ;;
+    esac
+    case "$arg" in http://*|https://*) url="$arg" ;; esac
+    prev="$arg"
+done
+printf '%s %s\n' "$method" "$url" >> "$CURL_LOG"
+[[ -n "$payload_file" ]] && cp "$payload_file" "$CURL_PAYLOAD"
+[[ -n "$auth_file" ]] && cp "$auth_file" "$CURL_AUTH"
+emit() { if [[ -n "$out_file" ]]; then printf '%s' "$1" > "$out_file"; else printf '%s' "$1"; fi; }
+
+case "$CURL_MODE" in
+    response)
+        emit '{"id":"resp_1","object":"response","status":"completed","output":[]}'
+        printf '200'
+        ;;
+    deleted)
+        emit '{"id":"resp_1","object":"response","deleted":true}'
+        printf '200'
+        ;;
+    conversation)
+        emit '{"id":"conv_1","object":"conversation","created_at":1,"metadata":{}}'
+        printf '200'
+        ;;
+    compacted)
+        emit '{"id":"resp_c","object":"response.compaction","output":[{"id":"cmp_1","type":"compaction","encrypted_content":"opaque"}]}'
+        printf '200'
+        ;;
+    pages)
+        if [[ "$n" -eq 1 ]]; then
+            emit '{"object":"list","data":[{"id":"itm_1"},{"id":"itm_2"}],"first_id":"itm_1","last_id":"itm_2","has_more":true}'
+        else
+            emit '{"object":"list","data":[{"id":"itm_3"}],"first_id":"itm_3","last_id":"itm_3","has_more":false}'
+        fi
+        printf '200'
+        ;;
+    not-found)
+        emit '{"error":{"message":"No such response: resp_missing","type":"invalid_request_error"}}'
+        printf '404'
+        ;;
+    stream-terminal)
+        printf '%s\n\n' 'event: response.output_text.delta' 'data: {"type":"response.output_text.delta","sequence_number":43,"delta":"hi"}'
+        printf '%s\n\n' 'event: response.completed' 'data: {"type":"response.completed","sequence_number":44,"response":{"id":"resp_1","status":"completed"}}'
+        ;;
+    stream-truncated)
+        printf '%s\n\n' 'event: response.output_text.delta' 'data: {"type":"response.output_text.delta","sequence_number":43,"delta":"hi"}'
+        ;;
+    *)
+        echo "curl stub: unknown CURL_MODE=$CURL_MODE" >&2
+        exit 2
+        ;;
+esac
+STUB
+chmod +x "$WORK/bin/curl"
+
+export PATH="$WORK/bin:$PATH"
+export HEADLONG_HOME="$WORK/home"
+export OPENAI_API_KEY="test-openai-key"
+export OPENROUTER_API_KEY="test-openrouter-key"
+export CURL_ARGS="$WORK/curl.args"
+export CURL_PAYLOAD="$WORK/curl.payload"
+export CURL_CALLS="$WORK/curl.calls"
+export CURL_LOG="$WORK/curl.log"
+export CURL_AUTH="$WORK/curl.auth"
+unset LLM_PROVIDER LLM_API_URL LLM_API_KEY SHELLM_API_URL
+R="$REPO/bin/responses"
+
+reset() {
+    : > "$CURL_ARGS"; : > "$CURL_PAYLOAD"; : > "$CURL_LOG"; : > "$CURL_AUTH"
+    rm -f "$CURL_CALLS" "$WORK/stdout" "$WORK/stderr"
+}
+run() { "$R" "$@" >"$WORK/stdout" 2>"$WORK/stderr"; }
+logged() { cat "$CURL_LOG"; }
+
+# --- get: path, verb, stdout contract ---------------------------------------
+reset
+export CURL_MODE=response
+run get resp_1
+rc=$?
+if [[ "$rc" -eq 0 && "$(logged)" == "GET https://api.openai.com/v1/responses/resp_1" ]]; then
+    ok "get retrieves GET /responses/{id} on the native OpenAI base"
+else
+    bad "get retrieves GET /responses/{id} on the native OpenAI base" "rc=$rc log=$(logged)"
+fi
+if [[ "$(wc -l < "$WORK/stdout" | tr -d ' ')" == "1" ]] \
+   && jq -e '.id == "resp_1"' "$WORK/stdout" >/dev/null; then
+    ok "stdout is the API object as one compact JSON line"
+else
+    bad "stdout is the API object as one compact JSON line" "$(cat "$WORK/stdout")"
+fi
+
+# The key reaches curl exactly the way bin/llm sends it: a 0600 config file
+# holding one header line, never argv.
+if ! grep -q 'test-openai-key' "$CURL_ARGS" \
+   && [[ "$(cat "$CURL_AUTH")" == 'header = "Authorization: Bearer test-openai-key"' ]]; then
+    ok "the key travels in a curl config header, never on argv"
+else
+    bad "the key travels in a curl config header, never on argv" "auth=$(cat "$CURL_AUTH")"
+fi
+
+# --- get: repeated include, net guards, pretty ------------------------------
+reset
+run get resp_1 --include reasoning.encrypted_content --include message.output_text.logprobs
+url=$(sed -n '1s/^GET //p' "$CURL_LOG")
+if [[ "$url" == "https://api.openai.com/v1/responses/resp_1?include[]=reasoning.encrypted_content&include[]=message.output_text.logprobs" ]]; then
+    ok "repeated --include becomes repeated include[] query params in order"
+else
+    bad "repeated --include becomes repeated include[] query params in order" "url=$url"
+fi
+
+reset
+LLM_CONNECT_TIMEOUT=3 LLM_MAX_TIME=44 run get resp_1
+if grep -qx -- '--connect-timeout' "$CURL_ARGS" && grep -qx '3' "$CURL_ARGS" \
+   && grep -qx -- '--max-time' "$CURL_ARGS" && grep -qx '44' "$CURL_ARGS"; then
+    ok "LLM_CONNECT_TIMEOUT and LLM_MAX_TIME reach curl"
+else
+    bad "LLM_CONNECT_TIMEOUT and LLM_MAX_TIME reach curl"
+fi
+
+reset
+run get resp_1 --pretty
+[[ "$(wc -l < "$WORK/stdout" | tr -d ' ')" -gt 1 ]] \
+    && ok "--pretty prints the object across lines" \
+    || bad "--pretty prints the object across lines"
+
+# --- cancel and delete ------------------------------------------------------
+reset
+run cancel resp_1
+[[ "$(logged)" == "POST https://api.openai.com/v1/responses/resp_1/cancel" ]] \
+    && ok "cancel posts to /responses/{id}/cancel" \
+    || bad "cancel posts to /responses/{id}/cancel" "$(logged)"
+
+reset
+export CURL_MODE=deleted
+run delete resp_1
+if [[ "$(logged)" == "DELETE https://api.openai.com/v1/responses/resp_1" ]] \
+   && jq -e '.deleted == true' "$WORK/stdout" >/dev/null; then
+    ok "delete sends DELETE /responses/{id} and prints the deletion object"
+else
+    bad "delete sends DELETE /responses/{id} and prints the deletion object" "$(logged)"
+fi
+
+# --- input-items: query params and --all pagination -------------------------
+reset
+export CURL_MODE=pages
+run input-items resp_1 --after itm_0 --limit 2 --order asc
+url=$(sed -n '1s/^GET //p' "$CURL_LOG")
+if [[ "$url" == "https://api.openai.com/v1/responses/resp_1/input_items?after=itm_0&limit=2&order=asc" ]]; then
+    ok "input-items sends after, limit, and order"
+else
+    bad "input-items sends after, limit, and order" "url=$url"
+fi
+jq -e '.has_more == true' "$WORK/stdout" >/dev/null \
+    && ok "a single page is printed as the API returned it" \
+    || bad "a single page is printed as the API returned it" "$(cat "$WORK/stdout")"
+
+reset
+run input-items resp_1 --all
+if [[ "$(cat "$CURL_CALLS")" == "2" ]] \
+   && [[ "$(sed -n '2s/^GET //p' "$CURL_LOG")" == "https://api.openai.com/v1/responses/resp_1/input_items?after=itm_2" ]]; then
+    ok "--all follows has_more with after=<last id of the page>"
+else
+    bad "--all follows has_more with after=<last id of the page>" "calls=$(cat "$CURL_CALLS") log=$(logged)"
+fi
+if jq -e '[.data[].id] == ["itm_1","itm_2","itm_3"] and .has_more == false
+          and .first_id == "itm_1" and .last_id == "itm_3" and .object == "list"' \
+        "$WORK/stdout" >/dev/null; then
+    ok "--all prints one merged list object"
+else
+    bad "--all prints one merged list object" "$(cat "$WORK/stdout")"
+fi
+
+# --- error contract ---------------------------------------------------------
+reset
+export CURL_MODE=not-found
+run get resp_missing
+rc=$?
+if [[ "$rc" -eq 1 && ! -s "$WORK/stdout" ]] \
+   && grep -q '^responses: error: No such response: resp_missing$' "$WORK/stderr"; then
+    ok "a non-2xx prints the API message on stderr, nothing on stdout, exit 1"
+else
+    bad "a non-2xx prints the API message on stderr, nothing on stdout, exit 1" \
+        "rc=$rc out=$(cat "$WORK/stdout") err=$(cat "$WORK/stderr")"
+fi
+
+# --- usage errors: exit 2, before any request -------------------------------
+export CURL_MODE=response
+usage_case() {  # usage_case <label> <args...>
+    local label="$1"; shift
+    reset
+    run "$@"
+    local rc=$?
+    if [[ "$rc" -eq 2 && ! -e "$CURL_CALLS" && ! -s "$WORK/stdout" ]]; then
+        ok "usage error: $label"
+    else
+        bad "usage error: $label" "rc=$rc calls=$(cat "$CURL_CALLS" 2>/dev/null) err=$(cat "$WORK/stderr")"
+    fi
+}
+usage_case "no subcommand"
+usage_case "unknown subcommand" frobnicate
+usage_case "get without an id" get
+usage_case "get with a second positional" get resp_1 resp_2
+usage_case "unknown option" get resp_1 --nope
+usage_case "an option the subcommand does not take" cancel resp_1 --limit 5
+usage_case "conversations update without --metadata" conversations update conv_1
+usage_case "an unsupported provider" --provider anthropic get resp_1
+
+reset
+run --help
+[[ $? -eq 0 && ! -e "$CURL_CALLS" ]] && grep -q 'responses get ID' "$WORK/stdout" \
+    && ok "--help prints usage and exits 0" \
+    || bad "--help prints usage and exits 0" "$(head -3 "$WORK/stdout")"
+
+# conversations add refuses more than the API's 20 items before sending.
+reset
+jq -nc '[range(21) | {type:"message", role:"user", content:"x"}]' > "$WORK/items21.json"
+run conversations add conv_1 --items-file "$WORK/items21.json"
+rc=$?
+if [[ "$rc" -eq 2 && ! -e "$CURL_CALLS" ]] && grep -q '20' "$WORK/stderr"; then
+    ok "conversations add refuses more than 20 items before sending"
+else
+    bad "conversations add refuses more than 20 items before sending" "rc=$rc err=$(cat "$WORK/stderr")"
+fi
+
+# --- streaming get ----------------------------------------------------------
+reset
+export CURL_MODE=stream-terminal
+run get resp_1 --stream --starting-after 42
+rc=$?
+url=$(sed -n '1s/^GET //p' "$CURL_LOG")
+if [[ "$rc" -eq 0 && "$url" == "https://api.openai.com/v1/responses/resp_1?stream=true&starting_after=42" ]]; then
+    ok "get --stream asks for stream=true with starting_after"
+else
+    bad "get --stream asks for stream=true with starting_after" "rc=$rc url=$url"
+fi
+if [[ "$(wc -l < "$WORK/stdout" | tr -d ' ')" == "2" ]] \
+   && [[ "$(sed -n '2p' "$WORK/stdout" | jq -r '.type')" == "response.completed" ]]; then
+    ok "each SSE data payload is printed as one JSON line"
+else
+    bad "each SSE data payload is printed as one JSON line" "$(cat "$WORK/stdout")"
+fi
+
+reset
+export CURL_MODE=stream-truncated
+run get resp_1 --stream
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q '^responses: error: ' "$WORK/stderr"; then
+    ok "a stream that ends without a terminal event fails"
+else
+    bad "a stream that ends without a terminal event fails" "rc=$rc err=$(cat "$WORK/stderr")"
+fi
+
+# --- base URL derivation ----------------------------------------------------
+reset
+export CURL_MODE=response
+LLM_PROVIDER=openai-compatible LLM_API_URL="https://router.test/v1/responses" \
+    LLM_API_KEY=compat-key run get resp_1
+if [[ "$(logged)" == "GET https://router.test/v1/responses/resp_1" ]] \
+   && [[ "$(cat "$CURL_AUTH")" == 'header = "Authorization: Bearer compat-key"' ]]; then
+    ok "LLM_API_URL loses its /responses suffix and becomes the base"
+else
+    bad "LLM_API_URL loses its /responses suffix and becomes the base" "$(logged) auth=$(cat "$CURL_AUTH")"
+fi
+
+reset
+LLM_PROVIDER=openai-compatible LLM_API_URL="https://router.test/v1/chat/completions" \
+    run get resp_1
+[[ "$(logged)" == "GET https://router.test/v1/responses/resp_1" ]] \
+    && ok "a /chat/completions URL yields the same base" \
+    || bad "a /chat/completions URL yields the same base" "$(logged)"
+
+reset
+LLM_PROVIDER=openai-compatible run get resp_1
+rc=$?
+if [[ "$rc" -eq 1 && ! -e "$CURL_CALLS" ]] && grep -q 'LLM_API_URL' "$WORK/stderr"; then
+    ok "openai-compatible without a URL fails before any request"
+else
+    bad "openai-compatible without a URL fails before any request" "rc=$rc err=$(cat "$WORK/stderr")"
+fi
+
+reset
+run --provider openrouter get resp_1
+[[ "$(logged)" == "GET https://openrouter.ai/api/v1/responses/resp_1" ]] \
+    && ok "--provider openrouter uses the OpenRouter base" \
+    || bad "--provider openrouter uses the OpenRouter base" "$(logged)"
+[[ "$(cat "$CURL_AUTH")" == 'header = "Authorization: Bearer test-openrouter-key"' ]] \
+    && ok "OpenRouter sends its own key" \
+    || bad "OpenRouter sends its own key" "$(cat "$CURL_AUTH")"
+
+# --- compact ----------------------------------------------------------------
+reset
+export CURL_MODE=compacted
+printf '%s' '[{"role":"user","content":"hello"}]' > "$WORK/input.json"
+printf '%s' '{"model":"wrong","instructions":"wrong","prompt_cache_key":"pck"}' > "$WORK/cbody.json"
+run compact --model gpt-5.4-mini --input-file "$WORK/input.json" \
+    --instructions "keep the plan" --body-file "$WORK/cbody.json"
+if [[ "$(logged)" == "POST https://api.openai.com/v1/responses/compact" ]]; then
+    ok "compact posts to /responses/compact"
+else
+    bad "compact posts to /responses/compact" "$(logged)"
+fi
+if jq -e '.model == "gpt-5.4-mini" and .instructions == "keep the plan"
+          and .input == [{"role":"user","content":"hello"}]
+          and .prompt_cache_key == "pck" and (has("previous_response_id") | not)' \
+        "$CURL_PAYLOAD" >/dev/null; then
+    ok "compact merges --body-file first and lets CLI-owned fields win"
+else
+    bad "compact merges --body-file first and lets CLI-owned fields win" "$(cat "$CURL_PAYLOAD")"
+fi
+
+reset
+run compact --model gpt-5.4-mini --previous-response-id resp_1
+jq -e '.previous_response_id == "resp_1" and (has("input") | not)' "$CURL_PAYLOAD" >/dev/null \
+    && ok "compact sends previous_response_id when there is no input file" \
+    || bad "compact sends previous_response_id when there is no input file" "$(cat "$CURL_PAYLOAD")"
+
+usage_case "compact without an input source" compact --model gpt-5.4-mini
+usage_case "compact with both input sources" compact --model m \
+    --input-file "$WORK/input.json" --previous-response-id resp_1
+usage_case "compact without a model" compact --input-file "$WORK/input.json"
+
+# --- conversations ----------------------------------------------------------
+reset
+export CURL_MODE=conversation
+printf '%s' '[{"type":"message","role":"user","content":"hi"}]' > "$WORK/items.json"
+run conversations create --items-file "$WORK/items.json" --metadata '{"run":"r1"}'
+if [[ "$(logged)" == "POST https://api.openai.com/v1/conversations" ]] \
+   && jq -e '.items == [{"type":"message","role":"user","content":"hi"}] and .metadata.run == "r1"' \
+        "$CURL_PAYLOAD" >/dev/null; then
+    ok "conversations create posts items and metadata to /conversations"
+else
+    bad "conversations create posts items and metadata to /conversations" "$(logged) $(cat "$CURL_PAYLOAD")"
+fi
+
+reset
+run conversations get conv_1
+[[ "$(logged)" == "GET https://api.openai.com/v1/conversations/conv_1" ]] \
+    && ok "conversations get reads /conversations/{cid}" \
+    || bad "conversations get reads /conversations/{cid}" "$(logged)"
+
+reset
+run conversations update conv_1 --metadata '{"run":"r2"}'
+if [[ "$(logged)" == "POST https://api.openai.com/v1/conversations/conv_1" ]] \
+   && jq -e '. == {"metadata":{"run":"r2"}}' "$CURL_PAYLOAD" >/dev/null; then
+    ok "conversations update posts metadata alone"
+else
+    bad "conversations update posts metadata alone" "$(logged) $(cat "$CURL_PAYLOAD")"
+fi
+
+reset
+run conversations delete conv_1
+[[ "$(logged)" == "DELETE https://api.openai.com/v1/conversations/conv_1" ]] \
+    && ok "conversations delete removes the conversation" \
+    || bad "conversations delete removes the conversation" "$(logged)"
+
+reset
+export CURL_MODE=pages
+run conversations items conv_1 --limit 2 --order asc
+url=$(sed -n '1s/^GET //p' "$CURL_LOG")
+[[ "$url" == "https://api.openai.com/v1/conversations/conv_1/items?limit=2&order=asc" ]] \
+    && ok "conversations items lists /conversations/{cid}/items" \
+    || bad "conversations items lists /conversations/{cid}/items" "url=$url"
+
+reset
+run conversations items conv_1 --all
+[[ "$(cat "$CURL_CALLS")" == "2" ]] \
+    && jq -e '[.data[].id] == ["itm_1","itm_2","itm_3"]' "$WORK/stdout" >/dev/null \
+    && ok "conversations items --all merges pages too" \
+    || bad "conversations items --all merges pages too" "calls=$(cat "$CURL_CALLS")"
+
+reset
+export CURL_MODE=conversation
+run conversations add conv_1 --items-file "$WORK/items.json" --include reasoning.encrypted_content
+url=$(sed -n '1s/^POST //p' "$CURL_LOG")
+if [[ "$url" == "https://api.openai.com/v1/conversations/conv_1/items?include[]=reasoning.encrypted_content" ]] \
+   && jq -e '. == {"items":[{"type":"message","role":"user","content":"hi"}]}' "$CURL_PAYLOAD" >/dev/null; then
+    ok "conversations add posts {items} with include on the query"
+else
+    bad "conversations add posts {items} with include on the query" "url=$url body=$(cat "$CURL_PAYLOAD")"
+fi
+
+reset
+run conversations item conv_1 itm_1
+[[ "$(logged)" == "GET https://api.openai.com/v1/conversations/conv_1/items/itm_1" ]] \
+    && ok "conversations item reads one item" \
+    || bad "conversations item reads one item" "$(logged)"
+
+reset
+run conversations remove conv_1 itm_1
+[[ "$(logged)" == "DELETE https://api.openai.com/v1/conversations/conv_1/items/itm_1" ]] \
+    && ok "conversations remove deletes one item" \
+    || bad "conversations remove deletes one item" "$(logged)"
+
+usage_case "conversations without a subcommand" conversations
+usage_case "conversations add without --items-file" conversations add conv_1
+usage_case "conversations item without an item id" conversations item conv_1
+usage_case "metadata that is not a JSON object" conversations update conv_1 --metadata '[1]'
+printf '%s' '{"not":"an array"}' > "$WORK/notarray.json"
+usage_case "an items file that is not a JSON array" conversations add conv_1 \
+    --items-file "$WORK/notarray.json"
+usage_case "an items file that does not exist" conversations add conv_1 \
+    --items-file "$WORK/missing.json"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_responses_cli.sh
+++ b/tests/test_responses_cli.sh
@@ -123,6 +123,9 @@ PY
     stream-truncated)
         printf '%s\n\n' 'event: response.output_text.delta' 'data: {"type":"response.output_text.delta","sequence_number":43,"delta":"hi"}'
         ;;
+    stream-fixture)
+        printf '%s\n' "$CURL_FIXTURE"
+        ;;
     *)
         echo "curl stub: unknown CURL_MODE=$CURL_MODE" >&2
         exit 2
@@ -328,6 +331,58 @@ else
     bad "a stream that ends without a terminal event fails" "rc=$rc err=$(cat "$WORK/stderr")"
 fi
 
+# Retrieval succeeds for any valid terminal state of the requested response,
+# but an unrelated terminal tag or malformed payload cannot complete the read.
+stream_case() {
+    local label="$1" expected="$2" fixture="$3" rc
+    reset
+    CURL_MODE=stream-fixture CURL_FIXTURE="$fixture" run get resp_1 --stream
+    rc=$?
+    if [[ "$expected" == success && "$rc" -eq 0 ]] \
+       && jq -se 'length > 0 and all(.[]; type == "object")' "$WORK/stdout" >/dev/null 2>&1; then
+        ok "$label"
+    elif [[ "$expected" == failure && "$rc" -ne 0 ]] \
+         && grep -q '^responses: error: ' "$WORK/stderr" \
+         && jq -se 'all(.[]; type == "object"
+             and (.type | type == "string" and length > 0)
+             and (if has("response") then .response.id == "resp_1" else true end)
+             and (if has("response_id") then .response_id == "resp_1" else true end))' \
+             "$WORK/stdout" >/dev/null 2>&1; then
+        ok "$label"
+    else
+        bad "$label" "rc=$rc expected=$expected"
+    fi
+}
+for status in completed incomplete failed cancelled; do
+    stream_case "stream retrieval accepts a same-response $status terminal" success \
+        "data: {\"type\":\"response.$status\",\"response\":{\"id\":\"resp_1\",\"status\":\"$status\",\"output\":[]}}"
+done
+terminal='data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[]}}'
+stream_case "a foreign response terminal cannot complete retrieval" failure \
+    'data: {"type":"response.completed","response":{"id":"resp_other","status":"completed","output":[]}}'
+stream_case "terminal type and response status must agree" failure \
+    'data: {"type":"response.completed","response":{"id":"resp_1","status":"in_progress","output":[]}}'
+stream_case "a terminal requires its response object" failure \
+    'data: {"type":"response.completed"}'
+stream_case "a terminal requires the requested response ID" failure \
+    'data: {"type":"response.completed","response":{"status":"completed","output":[]}}'
+stream_case "a response field cannot be a scalar" failure \
+    'data: {"type":"response.completed","response":"resp_1"}'
+stream_case "a foreign created event cannot precede a matching terminal" failure \
+    $'data: {"type":"response.created","response":{"id":"resp_other","status":"in_progress"}}\n'"$terminal"
+stream_case "a foreign top-level response ID cannot enter the stream" failure \
+    $'data: {"type":"response.output_text.delta","response_id":"resp_other","delta":"foreign"}\n'"$terminal"
+stream_case "malformed data before a valid terminal fails" failure \
+    $'data: not-json\n'"$terminal"
+stream_case "malformed data after a valid terminal fails" failure \
+    "$terminal"$'\ndata: not-json'
+stream_case "two JSON values are not one SSE data payload" failure \
+    $'data: {"type":"response.created"} {"type":"response.created"}\n'"$terminal"
+stream_case "an array is not a typed SSE event" failure \
+    $'data: []\n'"$terminal"
+stream_case "an event requires a nonempty type" failure \
+    $'data: {"delta":"untyped"}\n'"$terminal"
+
 # --- base URL derivation ----------------------------------------------------
 reset
 export CURL_MODE=response
@@ -487,6 +542,27 @@ usage_case "an items file that is not a JSON array" conversations add conv_1 \
 usage_case "an items file that does not exist" conversations add conv_1 \
     --items-file "$WORK/missing.json"
 
+# Body validators require one JSON value before any provider request. An
+# explicit empty metadata argument is invalid even when create could omit it.
+for document in '' $' \t\n' '[] []'; do
+    printf '%s' "$document" > "$WORK/invalid-array.json"
+    usage_case "compact array file has zero or multiple JSON values: $document" \
+        compact --model m --input-file "$WORK/invalid-array.json"
+    usage_case "Conversation create array file has zero or multiple JSON values: $document" \
+        conversations create --items-file "$WORK/invalid-array.json"
+    usage_case "Conversation add array file has zero or multiple JSON values: $document" \
+        conversations add conv_1 --items-file "$WORK/invalid-array.json"
+done
+for document in '' $' \t\n' '{} {}'; do
+    printf '%s' "$document" > "$WORK/invalid-object.json"
+    usage_case "compact body file has zero or multiple JSON values: $document" \
+        compact --model m --previous-response-id resp_1 --body-file "$WORK/invalid-object.json"
+    usage_case "Conversation create metadata has zero or multiple JSON values: $document" \
+        conversations create --metadata "$document"
+    usage_case "Conversation update metadata has zero or multiple JSON values: $document" \
+        conversations update conv_1 --metadata "$document"
+done
+
 # Path ids must never change the target of a destructive operation.
 for id in '' '.' '..' '../resp_other' 'resp_1?other=1' 'resp_1#fragment' 'resp_%2fother' 'resp_[1-2]' 'resp_1/'; do
     usage_case "unsafe response id: $id" delete "$id"
@@ -635,7 +711,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.send_header('Content-Length', '67108865')
             self.end_headers()
             return
-        data = (b'data: {"type":"response.completed"}\n\n' if 'stream=true' in self.path
+        data = (b'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[]}}\n\n' if 'stream=true' in self.path
                 else b'{"id":"resp_1"}')
         self.send_response(200)
         self.send_header('Content-Length', str(len(data)))

--- a/tests/test_responses_examples.sh
+++ b/tests/test_responses_examples.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Hermetic contract tests for docs/examples/responses-request.sh.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+EXAMPLE="$REPO/docs/examples/responses-request.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/bin"
+
+pass=0; fail=0
+ok() { pass=$((pass + 1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail + 1)); printf 'FAIL %s\n' "$1"; }
+check() { local label="$1"; shift; if "$@" >/dev/null 2>&1; then ok "$label"; else bad "$label"; fi; }
+mode() { stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null; }
+
+# This is the only llm visible to the worker. It performs no I/O outside the
+# fixture and lets each test select an exact lifecycle result.
+cat > "$WORK/bin/llm" <<'STUB'
+#!/usr/bin/env bash
+set -u
+printf 'call\n' >> "$STUB_CALLS"
+printf '%s\n' "$@" > "$STUB_ARGS"
+{
+    printf 'format=%s\n' "${LLM_API_FORMAT-}"
+    printf 'response=%s\n' "${LLM_RESPONSE_FILE-}"
+    printf 'usage=%s\n' "${LLM_USAGE_FILE-}"
+    printf 'body=%s\n' "${LLM_RESPONSES_BODY_FILE-}"
+    printf 'marker=%s\n' "${FORWARD_MARKER-}"
+} > "$STUB_ENV"
+printf 'fixture stdout\n'
+printf 'fixture stderr\n' >&2
+case "${STUB_CASE:-completed}" in
+    completed) printf '%s\n' '{"id":"resp_fixture","status":"completed","error":null,"output":[]}' > "$LLM_RESPONSE_FILE" ;;
+    incomplete) printf '%s\n' '{"id":"resp_fixture","status":"incomplete","error":null,"output":[]}' > "$LLM_RESPONSE_FILE" ;;
+    error) printf '%s\n' '{"id":"resp_fixture","status":"completed","error":{"message":"fixture"},"output":[]}' > "$LLM_RESPONSE_FILE" ;;
+    unknown) printf '%s\n' '{"id":"resp_fixture","status":"mystery","error":null,"output":[]}' > "$LLM_RESPONSE_FILE" ;;
+    malformed) printf '%s\n' '{not json' > "$LLM_RESPONSE_FILE" ;;
+    missing) : ;;
+    child_failure) printf '%s\n' '{"id":"resp_fixture","status":"completed","error":null,"output":[]}' > "$LLM_RESPONSE_FILE"; exit 7 ;;
+    wait_term)
+        trap 'printf received > "$STUB_TERM_SEEN"; exit 143' TERM
+        printf ready > "$STUB_READY"
+        while :; do sleep 1; done
+        ;;
+esac
+STUB
+chmod +x "$WORK/bin/llm"
+
+export PATH="$WORK/bin:$PATH"
+export STUB_CALLS="$WORK/calls" STUB_ARGS="$WORK/args" STUB_ENV="$WORK/env"
+INPUT="$WORK/input.json"; BODY="$WORK/body.json"
+printf '%s\n' '[{"role":"user","content":"fixture"}]' > "$INPUT"
+printf '%s\n' '{"reasoning":{"effort":"low"}}' > "$BODY"
+
+rm -f "$STUB_CALLS"
+check "no arguments prints help and exits zero" bash -c 'bash "$1" >"$2" 2>"$3"' _ "$EXAMPLE" "$WORK/help.out" "$WORK/help.err"
+check "no arguments does not dispatch" test ! -e "$STUB_CALLS"
+rm -f "$STUB_CALLS"
+check "--help exits zero" bash -c 'bash "$1" --help >"$2" 2>"$3"' _ "$EXAMPLE" "$WORK/help2.out" "$WORK/help2.err"
+check "--help does not dispatch" test ! -e "$STUB_CALLS"
+
+printf '%s\n' '{}' > "$WORK/not-array.json"
+rm -f "$STUB_CALLS"; INVALID_OUT="$WORK/invalid-input-out"
+check "non-array input is rejected" bash -c '! bash "$1" "$2" "$3" >/dev/null 2>&1' _ "$EXAMPLE" "$INVALID_OUT" "$WORK/not-array.json"
+check "input validates before output directory creation" test ! -e "$INVALID_OUT"
+check "invalid input does not dispatch" test ! -e "$STUB_CALLS"
+printf '%s\n' '[]' > "$WORK/not-object.json"
+rm -f "$STUB_CALLS"; INVALID_BODY_OUT="$WORK/invalid-body-out"
+check "non-object body is rejected" bash -c '! bash "$1" "$2" "$3" "$4" >/dev/null 2>&1' _ "$EXAMPLE" "$INVALID_BODY_OUT" "$INPUT" "$WORK/not-object.json"
+check "body validates before output directory creation" test ! -e "$INVALID_BODY_OUT"
+check "invalid body does not dispatch" test ! -e "$STUB_CALLS"
+
+OUT="$WORK/completed"; rm -f "$STUB_CALLS"
+export STUB_CASE=completed FORWARD_MARKER=forwarded
+if bash "$EXAMPLE" "$OUT" "$INPUT" "$BODY" > "$WORK/worker.out" 2> "$WORK/worker.err"; then
+    ok "completed valid response exits zero"
+else
+    bad "completed valid response exits zero"
+fi
+check "exactly one create request is made" test "$(wc -l < "$STUB_CALLS")" -eq 1
+check "input file and fixed request flags are forwarded" grep -Fxq -- "--messages-file" "$STUB_ARGS"
+check "input path is forwarded" grep -Fxq -- "$INPUT" "$STUB_ARGS"
+check "body file and caller environment are forwarded" bash -c 'grep -Fxq "body=$1" "$2" && grep -Fxq marker=forwarded "$2"' _ "$BODY" "$STUB_ENV"
+check "Responses API and evidence paths are forwarded" bash -c 'grep -Fxq format=responses "$1" && grep -Fxq "response=$2/response.json" "$1" && grep -Fxq "usage=$2/usage.json" "$1"' _ "$STUB_ENV" "$OUT"
+check "output directory is private (0700)" test "$(mode "$OUT")" = 700
+check "response evidence is private (0600)" test "$(mode "$OUT/response.json")" = 600
+check "stdout evidence is preserved" grep -Fxq 'fixture stdout' "$OUT/stdout.txt"
+check "stderr evidence is preserved" grep -Fxq 'fixture stderr' "$OUT/stderr.txt"
+check "completed outcome is preserved and printed" bash -c 'jq -e '\''.outcome == "completed" and .exit_code == 0'\'' "$1/outcome.json" >/dev/null && cmp -s "$1/outcome.json" "$2"' _ "$OUT" "$WORK/worker.out"
+
+mkdir "$WORK/existing"; printf sentinel > "$WORK/existing/sentinel"; before=$(wc -l < "$STUB_CALLS")
+check "an existing output directory is rejected" bash -c '! bash "$1" "$2" "$3" >/dev/null 2>&1' _ "$EXAMPLE" "$WORK/existing" "$INPUT"
+check "existing evidence is not overwritten or dispatched" bash -c 'test -f "$1/sentinel" && test "$(wc -l < "$2")" -eq "$3"' _ "$WORK/existing" "$STUB_CALLS" "$before"
+
+for case_name in incomplete error unknown malformed missing child_failure; do
+    export STUB_CASE="$case_name"
+    CASE_OUT="$WORK/$case_name"
+    before=$(wc -l < "$STUB_CALLS")
+    if bash "$EXAMPLE" "$CASE_OUT" "$INPUT" > "$WORK/$case_name.out" 2> "$WORK/$case_name.err"; then
+        bad "$case_name result exits nonzero"
+    else
+        ok "$case_name result exits nonzero"
+    fi
+    check "$case_name result is needs_review" jq -e '.outcome == "needs_review" and .exit_code != 0' "$CASE_OUT/outcome.json"
+    check "$case_name result is not retried" test "$(wc -l < "$STUB_CALLS")" -eq $((before + 1))
+done
+check "failed child exit code is preserved" jq -e '.exit_code == 7' "$WORK/child_failure/outcome.json"
+check "failed child streams and response are preserved" bash -c 'grep -Fxq "fixture stdout" "$1/stdout.txt" && grep -Fxq "fixture stderr" "$1/stderr.txt" && test -s "$1/response.json"' _ "$WORK/child_failure"
+
+export STUB_CASE=wait_term STUB_READY="$WORK/ready" STUB_TERM_SEEN="$WORK/term-seen"
+SIGNAL_OUT="$WORK/signalled"
+bash "$EXAMPLE" "$SIGNAL_OUT" "$INPUT" > "$WORK/signalled.out" 2> "$WORK/signalled.err" & worker=$!
+for _ in $(seq 1 100); do [[ -e "$STUB_READY" ]] && break; sleep 0.02; done
+if [[ -e "$STUB_READY" ]]; then kill -TERM "$worker"; fi
+signal_rc=0; wait "$worker" || signal_rc=$?
+check "TERM is forwarded to the owned child" test -e "$STUB_TERM_SEEN"
+check "worker waits and exits nonzero after TERM" test "$signal_rc" -ne 0
+check "interrupted request records needs_review" jq -e '.outcome == "needs_review" and .exit_code != 0' "$SIGNAL_OUT/outcome.json"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_responses_install.sh
+++ b/tests/test_responses_install.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Copied-prefix lifecycle/optional adapter packaging, without uv or a provider.
+set -uo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+pass=0; fail=0
+ok() { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s\n' "$1"; }
+
+mkdir -p "$WORK/source" "$WORK/home" "$WORK/prefix" "$WORK/support" "$WORK/wd"
+cp -R "$REPO/bin" "$REPO/tools" "$WORK/source/"
+cp "$REPO/install.sh" "$WORK/source/"
+cp "$REPO/uninstall.sh" "$WORK/uninstall.sh"
+# An explicit dependency PATH excludes uv, cargo, and any other checkout's
+# tools, even when these happen to be installed on the developer machine.
+for tool in bash basename dirname pwd cp chmod mkdir rm rmdir ln readlink realpath \
+    jq curl python3 sed grep uname cat mktemp date sleep wc tr head tail sort \
+    cut fold find touch mv env awk; do
+    path=$(command -v "$tool")
+    [[ "$path" == /* ]] || path="/bin/$tool"
+    ln -s "$path" "$WORK/support/$tool"
+done
+clean() {
+    env -i HOME="$WORK/home" HEADLONG_HOME="$WORK/home/.headlong" \
+        PREFIX="$WORK/prefix" PATH="$WORK/prefix:$WORK/support" SHELL=/bin/bash \
+        "$@"
+}
+if clean bash -c '! command -v uv' && clean bash "$WORK/source/install.sh" --no-init > "$WORK/install.out" 2>&1; then
+    ok "normal copy installation succeeds without uv"
+else
+    bad "normal copy installation succeeds without uv"
+    cat "$WORK/install.out"
+fi
+if [[ -x "$WORK/prefix/responses-ws" && ! -L "$WORK/prefix/responses-ws" ]] \
+    && cmp -s "$WORK/source/tools/responses-ws" "$WORK/prefix/responses-ws"; then
+    ok "copy inventory installs the optional adapter executable unchanged"
+else
+    bad "copy inventory installs the optional adapter executable unchanged"
+fi
+
+rm -rf "$WORK/source"
+# Extract the installed resolver, not a test reimplementation. No source tree
+# or PATH fallback exists now, so this must find the installed sibling.
+sed -n '/^tool_sibling_path() {/,/^}/p; /^resolve_shellm_tool_path() {/,/^}/p' \
+    "$WORK/prefix/shellm" > "$WORK/resolver"
+resolved=$(clean bash -c 'source "$1"; resolve_shellm_tool_path "$2" responses-ws' \
+    _ "$WORK/resolver" "$WORK/prefix/shellm")
+if [[ "$resolved" == "$(realpath "$WORK/prefix/responses-ws")" ]]; then
+    ok "copied shellm resolves its adapter with the source checkout unavailable"
+else
+    bad "copied shellm resolves its adapter with the source checkout unavailable"
+fi
+if clean "$WORK/prefix/responses" --help > /dev/null; then
+    ok "copied lifecycle CLI runs without the source checkout or uv"
+else
+    bad "copied lifecycle CLI runs without the source checkout or uv"
+fi
+
+# An ordinary chat completion still does not need uv. Stub only the HTTP edge.
+rm "$WORK/support/curl"
+cat > "$WORK/support/curl" <<'STUB'
+#!/usr/bin/env bash
+body='{"choices":[{"message":{"content":"chat fixture"}}]}'
+out=""; prev=""
+for arg in "$@"; do
+    [[ "$prev" == -o ]] && out="$arg"
+    prev="$arg"
+done
+if [[ -n "$out" ]]; then printf '%s' "$body" > "$out"; printf 200
+else printf '%s' "$body"; fi
+STUB
+chmod +x "$WORK/support/curl"
+if ( cd "$WORK/wd" && clean env LLM_PROVIDER=openai OPENAI_API_KEY=fixture-key \
+    LLM_RETRIES=0 "$WORK/prefix/llm" --no-stream -m fixture-model hello ) \
+    > "$WORK/chat.out" 2> "$WORK/chat.err" && grep -q 'chat fixture' "$WORK/chat.out"; then
+    ok "ordinary copied chat completion does not require uv"
+else
+    bad "ordinary copied chat completion does not require uv"
+    cat "$WORK/chat.err"
+fi
+
+if ( cd "$WORK/wd" && clean env OPENAI_API_KEY=fixture-key SHELLM_ENV=local \
+    SHELLM_API_FORMAT=responses SHELLM_API_TRANSPORT=websocket SHELLM_MODEL=gpt-test \
+    "$WORK/prefix/shellm" --workdir "$WORK/wd" --max-iterations 1 test ) \
+    > "$WORK/ws.out" 2> "$WORK/ws.err"; then
+    bad "selecting the copied WebSocket adapter without uv fails before inference"
+elif grep -q 'WebSocket transport requires uv' "$WORK/ws.err"; then
+    ok "selecting the copied WebSocket adapter without uv gives actionable guidance"
+else
+    bad "selecting the copied WebSocket adapter without uv gives actionable guidance"
+    cat "$WORK/ws.err"
+fi
+
+if clean bash "$WORK/uninstall.sh" --yes --no-stop > "$WORK/uninstall.out" 2>&1 \
+    && [[ ! -e "$WORK/prefix/responses-ws" && ! -e "$WORK/prefix/responses" ]]; then
+    ok "standalone uninstall removes copied lifecycle and adapter executables"
+else
+    bad "standalone uninstall removes copied lifecycle and adapter executables"
+    cat "$WORK/uninstall.out"
+fi
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_responses_ws.sh
+++ b/tests/test_responses_ws.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# test_responses_ws.sh — tools/responses-ws, the Responses WebSocket adapter
+#
+# Usage: tests/test_responses_ws.sh
+#
+# A fake WebSocket server written against the same library the adapter uses
+# stands in for api.openai.com, so this is hermetic: nothing leaves the loopback
+# interface. RESPONSES_WS_URL points the adapter at it. The cases:
+#
+#   - the response.create payload: model, input passthrough, instructions,
+#     previous_response_id, reasoning effort, extra-body store passthrough,
+#     the encrypted-reasoning include, and no transport-only fields
+#   - streamed text order on stdout, reasoning summary on stderr, through the
+#     whole bin/llm adapter path
+#   - the terminal sidecar (mode 0600, terminal object) and LLM_USAGE_FILE
+#   - an error event naming previous_response_id: non-zero exit with the
+#     envelope in the sidecar, matching the pattern shellm falls back on
+#   - the broker: two concurrent callers through one unix socket get their own
+#     stream_id lanes and both complete, and stop shuts it down
+#
+# The adapter needs uv (it is a PEP 723 script). Without uv, or without a way
+# to prepare its one dependency, the test prints one skip line and exits 0,
+# like the Docker-gated tests.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+cleanup_all() {
+    [[ -n "${BROKER_PID:-}" ]] && kill "$BROKER_PID" 2>/dev/null
+    [[ -n "${SERVER_PID:-}" ]] && kill "$SERVER_PID" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup_all EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "ok   skipped: uv is not installed (tools/responses-ws is a uv PEP 723 script)"
+    exit 0
+fi
+
+# --- the fake OpenAI WebSocket endpoint --------------------------------------
+# Records every response.create it receives and answers with the SSE event
+# shapes the Responses API uses. FAKE_MODE picks the answer; FAKE_PAIR makes it
+# hold each response until two have arrived, so a broker that serialised its
+# callers instead of giving them lanes would stall rather than pass.
+cat > "$WORK/fake_server.py" <<'PYEOF'
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["websockets>=13"]
+# ///
+import asyncio
+import json
+import os
+import pathlib
+import uuid
+
+import websockets
+from websockets.asyncio.server import serve
+
+REQ_DIR = pathlib.Path(os.environ["FAKE_REQ_DIR"])
+MODE = os.environ.get("FAKE_MODE", "ok")
+PAIR = int(os.environ.get("FAKE_PAIR", "0"))
+
+arrived = 0
+both = asyncio.Event()
+
+
+async def answer(ws, request):
+    global arrived
+    sid = request.get("stream_id")
+    marker = ""
+    items = request.get("input") or []
+    if items and isinstance(items[-1], dict):
+        marker = str(items[-1].get("content") or "")
+    rid = "resp_" + uuid.uuid4().hex[:8]
+    REQ_DIR.joinpath(rid + ".json").write_text(json.dumps(request))
+
+    if PAIR:
+        arrived += 1
+        if arrived >= 2:
+            both.set()
+        try:
+            await asyncio.wait_for(both.wait(), timeout=10)
+        except asyncio.TimeoutError:
+            pass
+
+    def tag(event):
+        if sid is not None:
+            event["stream_id"] = sid
+        return json.dumps(event)
+
+    if MODE == "prev-missing":
+        await ws.send(tag({
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "previous_response_not_found",
+                "param": "previous_response_id",
+                "message": "Previous response with id 'resp_gone' not found.",
+            },
+        }))
+        return
+
+    await ws.send(tag({"type": "response.reasoning_summary_text.delta", "delta": "weighing "}))
+    await ws.send(tag({"type": "response.reasoning_summary_text.delta", "delta": "options"}))
+    await ws.send(tag({"type": "response.output_text.delta", "delta": "hello "}))
+    await ws.send(tag({"type": "response.output_text.delta", "delta": marker}))
+    await ws.send(tag({
+        "type": "response.completed",
+        "response": {
+            "id": rid,
+            "object": "response",
+            "status": "completed",
+            "output": [
+                {"id": "rs_1", "type": "reasoning", "summary": [{"type": "summary_text", "text": "weighing options"}], "encrypted_content": "enc"},
+                {"id": "msg_1", "type": "message", "role": "assistant", "status": "completed",
+                 "content": [{"type": "output_text", "text": "hello " + marker}]},
+            ],
+            "usage": {
+                "input_tokens": 7,
+                "output_tokens": 11,
+                "output_tokens_details": {"reasoning_tokens": 3},
+                "input_tokens_details": {"cached_tokens": 2},
+            },
+        },
+    }))
+
+
+async def handler(ws):
+    tasks = []
+    try:
+        async for raw in ws:
+            request = json.loads(raw)
+            if request.get("type") != "response.create":
+                continue
+            tasks.append(asyncio.create_task(answer(ws, request)))
+    except websockets.exceptions.ConnectionClosed:
+        pass
+    for task in tasks:
+        task.cancel()
+
+
+async def main():
+    async with serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        pathlib.Path(os.environ["FAKE_PORT_FILE"]).write_text(str(port))
+        await asyncio.Future()
+
+
+asyncio.run(main())
+PYEOF
+
+# Preparing the dependency is the same work the adapter itself does, so if it
+# cannot be done (no network and no cache) the adapter cannot run either and
+# there is nothing here to test.
+cat > "$WORK/probe.py" <<'PYEOF'
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["websockets>=13"]
+# ///
+import websockets  # noqa: F401
+PYEOF
+if ! uv run --quiet --script "$WORK/probe.py" >/dev/null 2>&1; then
+    echo "ok   skipped: uv cannot prepare the websockets dependency (no network, no cache)"
+    exit 0
+fi
+
+ADAPTER="$REPO/tools/responses-ws"
+PORT_FILE="$WORK/port"
+REQ_DIR="$WORK/requests"
+
+start_server() {   # start_server MODE PAIR
+    rm -rf "$REQ_DIR" "$PORT_FILE"
+    mkdir -p "$REQ_DIR"
+    FAKE_REQ_DIR="$REQ_DIR" FAKE_MODE="$1" FAKE_PAIR="${2:-0}" \
+        FAKE_PORT_FILE="$PORT_FILE" \
+        uv run --quiet --script "$WORK/fake_server.py" >"$WORK/server.log" 2>&1 &
+    SERVER_PID=$!
+    local waited=0
+    while [[ ! -s "$PORT_FILE" && "$waited" -lt 60 ]]; do
+        sleep 0.5
+        waited=$((waited + 1))
+    done
+    [[ -s "$PORT_FILE" ]] || return 1
+    WS_URL="ws://127.0.0.1:$(cat "$PORT_FILE")/v1/responses"
+    return 0
+}
+
+stop_server() {
+    [[ -n "${SERVER_PID:-}" ]] && kill "$SERVER_PID" 2>/dev/null
+    wait "$SERVER_PID" 2>/dev/null
+    SERVER_PID=""
+}
+
+# Bounded run: nothing in this test may hang a CI job waiting on a socket.
+# The child's stdin is named explicitly because a backgrounded command in a
+# non-interactive shell is handed /dev/null otherwise, which would silently
+# starve an adapter waiting for its input items.
+run_limited() {   # run_limited SECONDS COMMAND...   (stdin from $RUN_STDIN)
+    local limit="$1"; shift
+    "$@" < "${RUN_STDIN:-/dev/null}" &
+    local pid=$!
+    local waited=0
+    while kill -0 "$pid" 2>/dev/null && [[ "$waited" -lt "$limit" ]]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null
+        wait "$pid" 2>/dev/null
+        return 124
+    fi
+    wait "$pid"
+}
+
+export HEADLONG_HOME="$WORK/home"
+mkdir -p "$HEADLONG_HOME"
+unset ANTHROPIC_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY OPENCODE_API_KEY \
+      LLM_API_KEY LLM_API_URL LLM_MODEL LLM_MAX_TOKENS SHELLM_MODEL \
+      SHELLM_API_URL RESPONSES_WS_SOCKET
+export OPENAI_API_KEY="test-key"
+export LLM_RETRIES=0
+export LLM_USAGE_LEDGER=/dev/null
+
+# ---------------------------------------------------------------------------
+# The whole bin/llm adapter path against the fake endpoint
+# ---------------------------------------------------------------------------
+
+if ! start_server ok 0; then
+    bad "fake WebSocket server starts" "$(head -5 "$WORK/server.log" 2>/dev/null)"
+    printf '\n%d passed, %d failed\n' "$pass" "$fail"
+    exit 1
+fi
+ok "fake WebSocket server starts"
+
+printf '%s' '{"store":false,"metadata":{"run":"t1"}}' > "$WORK/body.json"
+run_limited 90 env \
+    LLM_PROVIDER=adapter LLM_ADAPTER="$ADAPTER" \
+    LLM_API_FORMAT=responses \
+    LLM_RESPONSE_FILE="$WORK/response.json" \
+    LLM_USAGE_FILE="$WORK/usage.json" \
+    LLM_RESPONSES_BODY_FILE="$WORK/body.json" \
+    LLM_PREVIOUS_RESPONSE_ID=resp_prev \
+    RESPONSES_WS_URL="$WS_URL" \
+    "$REPO/bin/llm" -m gpt-5.5 -t 321 -s "be brief" --thinking high "world" \
+    >"$WORK/out" 2>"$WORK/err"
+rc=$?
+
+REQ=$(ls "$REQ_DIR"/*.json 2>/dev/null | head -1)
+if [[ "$rc" -eq 0 && -n "$REQ" ]]; then
+    ok "llm drives the adapter to a completed response"
+else
+    bad "llm drives the adapter to a completed response" "rc=$rc: $(head -3 "$WORK/err")"
+fi
+
+if [[ -n "$REQ" ]] && jq -e '
+        .type == "response.create"
+        and .model == "gpt-5.5"
+        and .max_output_tokens == 321
+        and .instructions == "be brief"
+        and .previous_response_id == "resp_prev"
+        and .reasoning.effort == "high"
+        and .reasoning.summary == "auto"
+        and .store == false
+        and .metadata.run == "t1"
+        and (.include | index("reasoning.encrypted_content")) != null
+        and (has("stream") | not)
+        and (has("background") | not)' "$REQ" >/dev/null 2>&1; then
+    ok "the response.create payload carries the create body without transport fields"
+else
+    bad "the response.create payload carries the create body without transport fields" "$(jq -c . "$REQ" 2>/dev/null | head -c 300)"
+fi
+
+if [[ -n "$REQ" ]] && jq -e '.input | type == "array" and length == 1
+        and .[0].role == "user" and (.[0].content | contains("world"))' "$REQ" >/dev/null 2>&1; then
+    ok "typed input items pass through unreshaped"
+else
+    bad "typed input items pass through unreshaped" "$(jq -c '.input' "$REQ" 2>/dev/null)"
+fi
+
+if [[ "$(cat "$WORK/out")" == "hello world" ]]; then
+    ok "streamed text arrives on stdout in order"
+else
+    bad "streamed text arrives on stdout in order" "$(cat "$WORK/out")"
+fi
+
+if grep -q 'weighing options' "$WORK/err"; then
+    ok "reasoning summary deltas arrive on stderr"
+else
+    bad "reasoning summary deltas arrive on stderr" "$(head -3 "$WORK/err")"
+fi
+
+if jq -e '.status == "completed" and (.id | startswith("resp_")) and (.output | length) == 2' \
+        "$WORK/response.json" >/dev/null 2>&1; then
+    ok "the terminal Response object lands in the sidecar"
+else
+    bad "the terminal Response object lands in the sidecar" "$(head -c 200 "$WORK/response.json" 2>/dev/null)"
+fi
+
+mode=$(stat -c %a "$WORK/response.json" 2>/dev/null || stat -f %Lp "$WORK/response.json" 2>/dev/null)
+if [[ "$mode" == "600" ]]; then
+    ok "the sidecar is mode 0600"
+else
+    bad "the sidecar is mode 0600" "mode=$mode"
+fi
+
+if jq -e '.in_tok == 7 and .out_tok == 11 and .think_tok == 3 and .cache_tok == 2' \
+        "$WORK/usage.json" >/dev/null 2>&1; then
+    ok "usage is recorded in LLM_USAGE_FILE"
+else
+    bad "usage is recorded in LLM_USAGE_FILE" "$(cat "$WORK/usage.json" 2>/dev/null)"
+fi
+
+stop_server
+
+# ---------------------------------------------------------------------------
+# A rejected previous_response_id fails the call with the envelope in the
+# sidecar, in the shape shellm's replay fallback looks for
+# ---------------------------------------------------------------------------
+
+if start_server prev-missing 0; then
+    rm -f "$WORK/response.json"
+    printf '%s' '[{"role":"user","content":"world"}]' > "$WORK/input.json"
+    RUN_STDIN="$WORK/input.json"
+    run_limited 90 env \
+        LLM_RESPONSE_FILE="$WORK/response.json" \
+        LLM_PREVIOUS_RESPONSE_ID=resp_gone \
+        RESPONSES_WS_URL="$WS_URL" \
+        "$ADAPTER" --model gpt-5.5 --max-tokens 64 --api-format responses \
+        >"$WORK/out" 2>"$WORK/err"
+    rc=$?
+    RUN_STDIN=""
+    if [[ "$rc" -ne 0 && ! -s "$WORK/out" ]]; then
+        ok "an error event fails the call with no text on stdout"
+    else
+        bad "an error event fails the call with no text on stdout" "rc=$rc out=$(cat "$WORK/out")"
+    fi
+    # The same jq test bin/shellm uses to decide on the replay fallback.
+    if jq -e '[.error.param?,.error.code?,.error.message?,.param?,.code?,.message?,.detail?]
+              | map(select(. != null) | tostring | ascii_downcase) | join(" ")
+              | test("previous[ _]response[ _]id|previous response")' \
+            "$WORK/response.json" >/dev/null 2>&1; then
+        ok "the error envelope in the sidecar triggers shellm's replay fallback"
+    else
+        bad "the error envelope in the sidecar triggers shellm's replay fallback" "$(cat "$WORK/response.json" 2>/dev/null)"
+    fi
+    stop_server
+else
+    bad "fake WebSocket server starts (prev-missing)" "$(head -5 "$WORK/server.log" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# The broker: one connection, two concurrent callers, two lanes
+# ---------------------------------------------------------------------------
+
+if start_server ok 1; then
+    SOCK="$WORK/ws.sock"
+    RESPONSES_WS_URL="$WS_URL" "$ADAPTER" serve --socket "$SOCK" --idle 1 \
+        >"$WORK/broker.log" 2>&1 &
+    BROKER_PID=$!
+    waited=0
+    while [[ ! -S "$SOCK" && "$waited" -lt 60 ]]; do
+        sleep 0.5
+        waited=$((waited + 1))
+    done
+
+    if [[ -S "$SOCK" ]]; then
+        ok "the broker listens on its unix socket"
+    else
+        bad "the broker listens on its unix socket" "$(head -5 "$WORK/broker.log")"
+    fi
+
+    call_through_broker() {   # call_through_broker MARKER OUTFILE
+        RESPONSES_WS_SOCKET="$SOCK" LLM_RESPONSE_FILE="$WORK/resp-$1.json" \
+            "$ADAPTER" --model gpt-5.5 --max-tokens 64 --api-format responses \
+            >"$2" 2>>"$WORK/broker-callers.err" <<EOF
+[{"role":"user","content":"$1"}]
+EOF
+    }
+
+    call_through_broker alpha "$WORK/out-alpha" &
+    p1=$!
+    call_through_broker beta "$WORK/out-beta" &
+    p2=$!
+    waited=0
+    while { kill -0 "$p1" 2>/dev/null || kill -0 "$p2" 2>/dev/null; } && [[ "$waited" -lt 90 ]]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    kill -9 "$p1" "$p2" 2>/dev/null
+    wait "$p1" 2>/dev/null; rc1=$?
+    wait "$p2" 2>/dev/null; rc2=$?
+
+    if [[ "$rc1" -eq 0 && "$rc2" -eq 0 ]]; then
+        ok "two concurrent callers through one broker both complete"
+    else
+        bad "two concurrent callers through one broker both complete" "rc=$rc1/$rc2: $(tail -3 "$WORK/broker-callers.err" 2>/dev/null)"
+    fi
+    if [[ "$(cat "$WORK/out-alpha" 2>/dev/null)" == "hello alpha" \
+       && "$(cat "$WORK/out-beta" 2>/dev/null)" == "hello beta" ]]; then
+        ok "each caller gets its own answer"
+    else
+        bad "each caller gets its own answer" "alpha=$(cat "$WORK/out-alpha" 2>/dev/null) beta=$(cat "$WORK/out-beta" 2>/dev/null)"
+    fi
+    lanes=$(cat "$REQ_DIR"/*.json 2>/dev/null | jq -r '.stream_id' | sort -u | grep -c .)
+    if [[ "$lanes" -eq 2 ]]; then
+        ok "the two calls ride distinct stream_id lanes"
+    else
+        bad "the two calls ride distinct stream_id lanes" "distinct lanes=$lanes"
+    fi
+
+    run_limited 30 "$ADAPTER" stop --socket "$SOCK" >/dev/null 2>&1
+    waited=0
+    while kill -0 "$BROKER_PID" 2>/dev/null && [[ "$waited" -lt 30 ]]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    if kill -0 "$BROKER_PID" 2>/dev/null; then
+        bad "stop shuts the broker down" "still running after ${waited}s"
+        kill -9 "$BROKER_PID" 2>/dev/null
+    else
+        ok "stop shuts the broker down"
+    fi
+    BROKER_PID=""
+    stop_server
+else
+    bad "fake WebSocket server starts (broker)" "$(head -5 "$WORK/server.log" 2>/dev/null)"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_responses_ws.sh
+++ b/tests/test_responses_ws.sh
@@ -318,6 +318,27 @@ else
     bad "usage is recorded in LLM_USAGE_FILE" "$(cat "$WORK/usage.json" 2>/dev/null)"
 fi
 
+# Conversation mode travels over the connection the same way the id chain
+# does: the create names the container and nothing else changes.
+rm -f "$REQ_DIR"/*.json
+run_limited 90 env \
+    LLM_PROVIDER=adapter LLM_ADAPTER="$ADAPTER" \
+    LLM_API_FORMAT=responses \
+    LLM_RESPONSE_FILE="$WORK/response.json" \
+    LLM_RESPONSES_CONVERSATION=conv_ws \
+    RESPONSES_WS_URL="$WS_URL" \
+    "$REPO/bin/llm" -m gpt-5.5 -t 321 "world" \
+    >"$WORK/out" 2>"$WORK/err"
+rc=$?
+REQ=$(ls "$REQ_DIR"/*.json 2>/dev/null | head -1)
+if [[ "$rc" -eq 0 && -n "$REQ" ]] \
+    && jq -e '.conversation == "conv_ws" and (has("previous_response_id") | not)' \
+        "$REQ" >/dev/null 2>&1; then
+    ok "LLM_RESPONSES_CONVERSATION rides the response.create payload"
+else
+    bad "LLM_RESPONSES_CONVERSATION rides the response.create payload" "rc=$rc payload=$(jq -c . "$REQ" 2>/dev/null | head -c 200) err=$(head -3 "$WORK/err")"
+fi
+
 stop_server
 
 # ---------------------------------------------------------------------------

--- a/tests/test_responses_ws.sh
+++ b/tests/test_responses_ws.sh
@@ -18,9 +18,8 @@
 #   - the broker: two concurrent callers through one unix socket get their own
 #     stream_id lanes and both complete, and stop shuts it down
 #
-# The adapter needs uv (it is a PEP 723 script). Without uv, or without a way
-# to prepare its one dependency, the test prints one skip line and exits 0,
-# like the Docker-gated tests.
+# The adapter needs uv (it is a PEP 723 script). A missing runtime or dependency
+# is a test failure, never an unnoticed skip.
 
 set -uo pipefail
 
@@ -41,8 +40,8 @@ ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
 bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
 
 if ! command -v uv >/dev/null 2>&1; then
-    echo "ok   skipped: uv is not installed (tools/responses-ws is a uv PEP 723 script)"
-    exit 0
+    echo "FAIL uv is required to exercise tools/responses-ws"
+    exit 1
 fi
 
 # --- the fake OpenAI WebSocket endpoint --------------------------------------
@@ -53,7 +52,7 @@ fi
 cat > "$WORK/fake_server.py" <<'PYEOF'
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["websockets>=13"]
+# dependencies = ["websockets==17.1"]
 # ///
 import asyncio
 import json
@@ -157,19 +156,18 @@ async def main():
 asyncio.run(main())
 PYEOF
 
-# Preparing the dependency is the same work the adapter itself does, so if it
-# cannot be done (no network and no cache) the adapter cannot run either and
-# there is nothing here to test.
+# Preparing the exact dependency is part of the executable contract.
 cat > "$WORK/probe.py" <<'PYEOF'
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["websockets>=13"]
+# dependencies = ["websockets==17.1"]
 # ///
-import websockets  # noqa: F401
+import websockets
+assert websockets.__version__ == "17.1"
 PYEOF
 if ! uv run --quiet --script "$WORK/probe.py" >/dev/null 2>&1; then
-    echo "ok   skipped: uv cannot prepare the websockets dependency (no network, no cache)"
-    exit 0
+    echo "FAIL uv cannot prepare the pinned websockets==17.1 dependency"
+    exit 1
 fi
 
 ADAPTER="$REPO/tools/responses-ws"
@@ -224,7 +222,10 @@ export HEADLONG_HOME="$WORK/home"
 mkdir -p "$HEADLONG_HOME"
 unset ANTHROPIC_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY OPENCODE_API_KEY \
       LLM_API_KEY LLM_API_URL LLM_MODEL LLM_MAX_TOKENS SHELLM_MODEL \
-      SHELLM_API_URL RESPONSES_WS_SOCKET
+      SHELLM_API_URL RESPONSES_WS_SOCKET LLM_PROVIDER RESPONSES_WS_PROVIDER \
+      LLM_OR_ONLY LLM_OR_DATA_COLLECTION LLM_OR_ZDR LLM_STOP_AFTER_CODE_BLOCK \
+      LLM_RESPONSES_BACKGROUND LLM_RESPONSES_BODY_FILE LLM_PREVIOUS_RESPONSE_ID \
+      LLM_RESPONSES_CONVERSATION LLM_RESPONSES_COMPACT_THRESHOLD
 export OPENAI_API_KEY="test-key"
 export LLM_RETRIES=0
 export LLM_USAGE_LEDGER=/dev/null
@@ -453,6 +454,12 @@ EOF
     stop_server
 else
     bad "fake WebSocket server starts (broker)" "$(head -5 "$WORK/server.log" 2>/dev/null)"
+fi
+
+if uv run --quiet --script "$HERE/test_responses_ws_faults.py"; then
+    ok "WebSocket conformance and broker fault regressions (Python unittest)"
+else
+    bad "WebSocket conformance and broker fault regressions (Python unittest)"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/test_responses_ws_faults.py
+++ b/tests/test_responses_ws_faults.py
@@ -340,6 +340,141 @@ class BrokerFaults(unittest.IsolatedAsyncioTestCase):
         await until(lambda: self.broker.slots._value == 16)
         self.assertEqual(len(self.received), 16)
 
+    async def test_completed_lane_cannot_deliver_a_stale_terminal_to_a_later_call(self):
+        old_ws = None
+        for index in range(M["MAX_LANES"]):
+            task, capture = self.call()
+            ws, body = await self.request()
+            old_ws = old_ws or ws
+            self.assertIs(ws, old_ws)
+            await self.send(ws, {"type": "response.created", "stream_id": body["stream_id"],
+                                 "response": {"id": f"resp_{index}"}})
+            await self.send(ws, completed(body["stream_id"], f"resp_{index}"))
+            self.assertEqual(await asyncio.wait_for(task, 5), 0)
+            await until(lambda: not self.broker.connection.lanes)
+
+        old_generation = self.broker.connection
+        close_gate = asyncio.Event()
+        real_close = self.broker._close
+
+        async def delayed_close(ws):
+            await close_gate.wait()
+            await real_close(ws)
+
+        self.broker._close = delayed_close
+        try:
+            task, capture = self.call()
+            ws, body = await self.request()
+            await self.send(old_ws, completed("lane-0", "resp_0", "stale response"))
+            await until(lambda: task.done() or old_generation.retired)
+            self.assertFalse(task.done(), "a retired response settled a later call")
+            self.assertIsNot(ws, old_ws)
+            await self.send(ws, {"type": "response.created", "stream_id": body["stream_id"],
+                                 "response": {"id": "resp_current"}})
+            await self.send(ws, completed(body["stream_id"], "resp_current", "current response"))
+            self.assertEqual(await asyncio.wait_for(task, 5), 0)
+            self.assertEqual(capture.events[-1]["response"]["id"], "resp_current")
+            self.assertEqual(len(self.received), M["MAX_LANES"] + 1)
+        finally:
+            close_gate.set()
+
+    async def test_lane_exhaustion_preserves_the_last_active_call_before_rotation(self):
+        old_ws = None
+        for index in range(M["MAX_LANES"] - 1):
+            task, _ = self.call()
+            ws, body = await self.request()
+            old_ws = old_ws or ws
+            self.assertIs(ws, old_ws)
+            await self.send(ws, completed(body["stream_id"], f"resp_{index}"))
+            self.assertEqual(await asyncio.wait_for(task, 5), 0)
+            await until(lambda: not self.broker.connection.lanes)
+
+        last, last_capture = self.call()
+        last_ws, last_body = await self.request()
+        self.assertIs(last_ws, old_ws)
+        next_call, next_capture = self.call()
+        await until(lambda: self.broker.slots._value == M["MAX_IN_FLIGHT"] - 2)
+        await self.send(last_ws, completed(last_body["stream_id"], "resp_last"))
+        self.assertEqual(await asyncio.wait_for(last, 5), 0)
+        self.assertEqual(last_capture.events[-1]["response"]["id"], "resp_last")
+        next_ws, next_body = await self.request()
+        self.assertIsNot(next_ws, old_ws)
+        await self.send(next_ws, completed(next_body["stream_id"], "resp_new"))
+        self.assertEqual(await asyncio.wait_for(next_call, 5), 0)
+        self.assertEqual(next_capture.events[-1]["response"]["id"], "resp_new")
+
+    async def last_available_lane(self):
+        for index in range(M["MAX_LANES"] - 1):
+            task, _ = self.call()
+            ws, body = await self.request()
+            await self.send(ws, completed(body["stream_id"], f"resp_{index}"))
+            self.assertEqual(await asyncio.wait_for(task, 5), 0)
+            await until(lambda: not self.broker.connection.lanes)
+        task, capture = self.call()
+        ws, body = await self.request()
+        return task, capture, ws, body
+
+    async def test_disconnected_exhaustion_waiter_never_creates(self):
+        last, _, ws, body = await self.last_available_lane()
+        _, writer = await self.client()
+        await until(lambda: self.broker.slots._value == M["MAX_IN_FLIGHT"] - 2)
+        writer.close()
+        await until(lambda: self.broker.slots._value == M["MAX_IN_FLIGHT"] - 1)
+        self.assertEqual(len(self.received), M["MAX_LANES"])
+        await self.send(ws, completed(body["stream_id"], "resp_last"))
+        self.assertEqual(await asyncio.wait_for(last, 5), 0)
+        next_call, capture = self.call()
+        next_ws, next_body = await self.request()
+        self.assertIsNot(next_ws, ws)
+        await self.send(next_ws, completed(next_body["stream_id"], "resp_next"))
+        self.assertEqual(await asyncio.wait_for(next_call, 5), 0)
+        self.assertEqual(capture.events[-1]["response"]["id"], "resp_next")
+        self.assertEqual(len(self.received), M["MAX_LANES"] + 1)
+
+    async def test_exhaustion_wait_is_bounded_without_abandoning_live_call(self):
+        last, _, ws, body = await self.last_available_lane()
+        with patch.dict(G, IO_TIMEOUT=.05):
+            waiting, capture = self.call()
+            self.assertEqual(await asyncio.wait_for(waiting, 1), 1)
+        self.assertIn("lane exhaustion wait timed out", capture.events[-1]["error"]["message"])
+        self.assertEqual(len(self.received), M["MAX_LANES"])
+        self.assertFalse(self.broker.connection.retired)
+        await self.send(ws, completed(body["stream_id"], "resp_last"))
+        self.assertEqual(await asyncio.wait_for(last, 5), 0)
+
+    async def test_shutdown_wakes_exhaustion_waiters_without_reconnecting(self):
+        last, _, _, _ = await self.last_available_lane()
+        waiting, capture = self.call()
+        await until(lambda: self.broker.slots._value == M["MAX_IN_FLIGHT"] - 2)
+        self.broker.stopping.set()
+        await asyncio.wait_for(self.broker.close_connection(), 5)
+        self.assertEqual(await asyncio.wait_for(last, 5), 1)
+        self.assertEqual(await asyncio.wait_for(waiting, 5), 1)
+        self.assertIn("broker stopped before admission", capture.events[-1]["error"]["message"])
+        self.assertIsNone(self.broker.connection)
+        self.assertEqual(len(self.received), M["MAX_LANES"])
+
+    async def test_shutdown_during_connect_never_admits_a_create(self):
+        connected, release = asyncio.Event(), asyncio.Event()
+        connect = G["ws_connect"]
+
+        async def held_connect(*args, **kwargs):
+            ws = await connect(*args, **kwargs)
+            connected.set()
+            await release.wait()
+            return ws
+
+        with patch.dict(G, ws_connect=held_connect):
+            task, capture = self.call()
+            await asyncio.wait_for(connected.wait(), 5)
+            self.broker.stopping.set()
+            await asyncio.wait_for(self.broker.close_connection(), 5)
+            release.set()
+            self.assertEqual(await asyncio.wait_for(task, 5), 1)
+        self.assertIn("broker stopped before admission", capture.events[-1]["error"]["message"])
+        self.assertIsNone(self.broker.connection)
+        self.assertEqual(self.received, [])
+
     async def test_untagged_error_fans_out_original_diagnostic(self):
         a, ca = self.call()
         b, cb = self.call()

--- a/tests/test_responses_ws_faults.py
+++ b/tests/test_responses_ws_faults.py
@@ -1,0 +1,513 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["websockets==17.1"]
+# ///
+"""Local-only protocol conformance and adversarial broker ownership tests."""
+import argparse
+import asyncio
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import runpy
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import websockets
+from websockets.asyncio.server import serve as ws_serve
+
+ROOT = Path(__file__).resolve().parents[1]
+TEST_PATH = os.environ.get("PATH", os.defpath)
+M = runpy.run_path(str(ROOT / "tools/responses-ws"))
+# Patch function globals, not runpy's copied result dictionary.
+G = M["Broker"].handle.__globals__
+LIMIT = M["MAX_FRAME"]
+
+
+def completed(lane, rid="resp_ok", text="ok"):
+    return {"type": "response.completed", "stream_id": lane, "response": {
+        "id": rid, "status": "completed", "output": [
+            {"type": "message", "content": [{"type": "output_text", "text": text}]}]}}
+
+
+async def until(predicate):
+    async def wait():
+        while not predicate():
+            await asyncio.sleep(.005)
+    await asyncio.wait_for(wait(), 5)
+
+
+class Capture:
+    def __init__(self):
+        self.events = []
+        self.terminal = False
+        self.exit_code = 1
+
+    def feed(self, event):
+        self.events.append(event)
+        self.terminal = event.get("type") in M["TERMINAL_EVENTS"] or event.get("type") == "error"
+        self.exit_code = int(event.get("type") not in ("response.completed", "response.incomplete"))
+        return self.terminal
+
+
+class Conformance(unittest.TestCase):
+    def setUp(self):
+        self.env = patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.args = argparse.Namespace(model="test-model", max_tokens=321, thinking="",
+                                       effort="", system_prompt_file="")
+
+    def body(self, value):
+        path = Path(self.tmp.name) / "body.json"
+        path.write_text(json.dumps(value))
+        os.environ["LLM_RESPONSES_BODY_FILE"] = str(path)
+
+    def test_exact_dependency(self):
+        self.assertEqual(websockets.__version__, "17.1")
+        self.assertIn('dependencies = ["websockets==17.1"]', (ROOT / "tools/responses-ws").read_text())
+
+    def test_invalid_terminal_never_succeeds(self):
+        path = Path(self.tmp.name) / "response.json"
+        os.environ["LLM_RESPONSE_FILE"] = str(path)
+        for response in ({}, {"id": "resp_a", "status": "completed"},
+                         {"id": "resp_a", "status": "incomplete", "output": []},
+                         {"id": "resp_a", "status": "completed", "output": [], "error": {"message": "broken"}}):
+            emitter = M["Emitter"](stream=False)
+            with self.subTest(response=response), contextlib.redirect_stderr(io.StringIO()):
+                self.assertTrue(emitter.feed({"type": "response.completed", "response": response}))
+                self.assertEqual(emitter.exit_code, 1)
+                self.assertEqual(json.loads(path.read_text())["error"]["code"], "outcome_unknown")
+
+    def test_http_payload_conformance(self):
+        # Exercise the actual HTTP builder without its CLI, curl, or inference.
+        source = (ROOT / "bin/llm").read_text()
+        builder = source.split("_build_payload_responses() {", 1)[1].split("\nbuild_payload_gemini()", 1)[0]
+        for settings, body, system, effort in [
+            ({}, {"instructions": "stale", "previous_response_id": "stale", "conversation": "conv_body"}, "", ""),
+            ({"LLM_PREVIOUS_RESPONSE_ID": "resp_new"}, {"store": False, "metadata": {"test": "a"}}, "brief", "high"),
+            ({"LLM_RESPONSES_CONVERSATION": "conv_new", "LLM_RESPONSES_COMPACT_THRESHOLD": "123"},
+             {"conversation": "conv_old", "context_management": [{"type": "compaction", "compact_threshold": 99}]}, "", ""),
+            ({"LLM_RESPONSES_BACKGROUND": "0"}, {"background": False, "include": ["reasoning.encrypted_content"]}, "", ""),
+            ({"LLM_RESPONSES_BACKGROUND": "0"}, {"background": True}, "", ""),
+            ({}, {"instructions": "stale", "reasoning": {"effort": "low"}}, "", ""),
+        ]:
+            with self.subTest(settings=settings, body=body), patch.dict(os.environ, settings, clear=True):
+                self.body(body)
+                system_file = Path(self.tmp.name) / "system"
+                system_file.write_text(system)
+                self.args.system_prompt_file = str(system_file) if system else ""
+                self.args.effort = effort
+                items = [{"role": "user", "content": "unicode λ and \"escapes\""},
+                         {"type": "reasoning", "encrypted_content": "opaque", "summary": []}]
+                ws = M["build_create"](self.args, items)
+                env = dict(os.environ, PATH=TEST_PATH, LLM_MODEL=self.args.model, LLM_MAX_TOKENS="321",
+                           LLM_MESSAGES=json.dumps(items), LLM_SYSTEM=system, LLM_EFFORT=effort,
+                           LLM_PROVIDER="openai-compatible", LLM_STREAM="1")
+                result = subprocess.run(["bash", "-c", "_build_payload_responses() {" + builder +
+                                         "\n_build_payload_responses"], env=env, capture_output=True, text=True, check=True)
+                http = json.loads(result.stdout)
+                http.pop("stream", None)
+                http.pop("background", None)
+                http["type"] = "response.create"
+                self.assertEqual(ws, http)
+
+    def test_background_and_unsupported_body_rejected(self):
+        for body in ({"background": True}, {"stream_options": {}}, {"provider": {"zdr": True}}):
+            with self.subTest(body=body):
+                self.body(body)
+                with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+                    M["build_create"](self.args, [])
+        self.body({})
+        for value in ("1", "true"):
+            os.environ["LLM_RESPONSES_BACKGROUND"] = value
+            with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+                M["build_create"](self.args, [])
+
+    def test_conversation_exclusion(self):
+        self.body({"conversation": "conv_body", "previous_response_id": "stale"})
+        self.assertNotIn("previous_response_id", M["build_create"](self.args, []))
+        os.environ["LLM_PREVIOUS_RESPONSE_ID"] = "resp_new"
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            M["build_create"](self.args, [])
+
+    def test_compaction_threshold_validation(self):
+        for value in ("0", "-1", "1.5", "abc", "１２"):
+            with self.subTest(value=value), patch.dict(os.environ, LLM_RESPONSES_COMPACT_THRESHOLD=value):
+                with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+                    M["build_create"](self.args, [])
+
+    def test_endpoint_and_auth_matrix(self):
+        cases = [
+            ({}, M["DEFAULT_URL"], "native-test-key"),
+            ({"LLM_PROVIDER": "openai", "LLM_API_URL": "https://example.invalid/custom?x=1"}, "wss://example.invalid/custom?x=1", "native-test-key"),
+            ({"LLM_PROVIDER": "openai-compatible", "SHELLM_API_URL": "http://example.invalid/v1/responses"}, "ws://example.invalid/v1/responses", "compatible-test-key"),
+            ({"LLM_PROVIDER": "adapter", "RESPONSES_WS_PROVIDER": "openai-compatible", "LLM_API_URL": "https://example.invalid/responses"}, "wss://example.invalid/responses", "compatible-test-key"),
+            ({"LLM_PROVIDER": "adapter", "LLM_API_URL": "http://example.invalid/responses"}, "ws://example.invalid/responses", "compatible-test-key"),
+            ({"RESPONSES_WS_PROVIDER": "openai-compatible", "LLM_API_URL": "http://example.invalid/old", "RESPONSES_WS_URL": "ws://example.invalid/new"}, "ws://example.invalid/new", "compatible-test-key"),
+        ]
+        for env, url, key in cases:
+            with self.subTest(env=env), patch.dict(os.environ, dict(env, OPENAI_API_KEY="native-test-key", LLM_API_KEY="compatible-test-key"), clear=True):
+                self.assertEqual(M["endpoint_config"](), (url, key))
+                self.assertEqual(M["connect_kwargs"]()["additional_headers"], {"Authorization": "Bearer " + key})
+        with patch.dict(os.environ, {"LLM_PROVIDER": "openai-compatible", "LLM_API_URL": "http://example.invalid/responses", "OPENAI_API_KEY": "native-test-key"}, clear=True):
+            self.assertEqual(M["connect_kwargs"]()["additional_headers"], {})
+
+    def test_provider_policy_and_invalid_endpoint_rejected(self):
+        for env in (
+            {"RESPONSES_WS_PROVIDER": "openrouter"}, {"LLM_PROVIDER": "anthropic"},
+            {"LLM_PROVIDER": "openai-compatible"}, {"LLM_OR_ZDR": "1"},
+            {"LLM_OR_DATA_COLLECTION": "deny"}, {"LLM_OR_ONLY": "some-provider"},
+            {"LLM_STOP_AFTER_CODE_BLOCK": "1"}, {"RESPONSES_WS_URL": "ftp://example.invalid"},
+            {"RESPONSES_WS_URL": "https://user:secret@example.invalid/responses"},
+        ):
+            with self.subTest(env=env), patch.dict(os.environ, env, clear=True):
+                with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+                    M["endpoint_config"]()
+
+    def test_frame_byte_boundary(self):
+        self.assertEqual(len(M["encode_frame"]("a" * (LIMIT - 2))), LIMIT)
+        with self.assertRaisesRegex(ValueError, "frame_too_large"):
+            M["encode_frame"]("a" * (LIMIT - 1))
+        with self.assertRaisesRegex(ValueError, "frame_too_large"):
+            M["encode_frame"]("λ" * (LIMIT // 2))
+
+    def test_queue_count_bound(self):
+        lane = M["Lane"]()
+        for _ in range(M["MAX_QUEUE_EVENTS"]):
+            lane.put({"type": "response.output_text.delta", "delta": "a"})
+        with self.assertRaisesRegex(ValueError, "bounded event queue"):
+            lane.put({"type": "response.output_text.delta"})
+        lane.fail(M["transport_error"]("failure"))
+        self.assertEqual(lane.queue.qsize(), 1)
+
+    def test_queue_byte_bound(self):
+        lane = M["Lane"]()
+        with patch.dict(G, MAX_QUEUE_BYTES=200):
+            lane.put({"delta": "a" * 100})
+            with self.assertRaisesRegex(ValueError, "bounded event queue"):
+                lane.put({"delta": "a" * 100})
+
+
+class BrokerFaults(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.env = patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        # Keep the Unix socket path below macOS's sockaddr_un limit as well.
+        self.tmp = tempfile.TemporaryDirectory(dir="/tmp")
+        self.addCleanup(self.tmp.cleanup)
+        self.requests = asyncio.Queue()
+        self.received = []
+        self.handlers = set()
+        self.writers = []
+        self.calls = []
+
+        async def provider(ws):
+            try:
+                async for raw in ws:
+                    body = json.loads(raw)
+                    self.received.append(body)
+                    await self.requests.put((ws, body))
+            except websockets.exceptions.ConnectionClosed:
+                pass
+
+        self.provider = await ws_serve(provider, "127.0.0.1", 0, max_size=LIMIT + 1024)
+        port = self.provider.sockets[0].getsockname()[1]
+        self.url = f"ws://127.0.0.1:{port}/v1/responses"
+        self.broker = M["Broker"](self.url, 60)
+        self.path = self.tmp.name + "/broker.sock"
+
+        async def handle(reader, writer):
+            task = asyncio.current_task()
+            self.handlers.add(task)
+            try:
+                await self.broker.handle(reader, writer)
+            finally:
+                self.handlers.discard(task)
+
+        self.server = await asyncio.start_unix_server(handle, path=self.path, limit=LIMIT + 1)
+
+    async def asyncTearDown(self):
+        for writer in self.writers:
+            writer.close()
+        for task in self.calls:
+            task.cancel()
+        await asyncio.gather(*self.calls, return_exceptions=True)
+        for task in list(self.handlers):
+            task.cancel()
+        await asyncio.gather(*list(self.handlers), return_exceptions=True)
+        await self.broker.close_connection()
+        self.server.close()
+        await self.server.wait_closed()
+        self.provider.close()
+        await self.provider.wait_closed()
+
+    async def request(self):
+        return await asyncio.wait_for(self.requests.get(), 5)
+
+    async def client(self):
+        reader, writer = await asyncio.open_unix_connection(self.path, limit=LIMIT + 1)
+        self.writers.append(writer)
+        await M["drain_line"](writer, {"op": "create", "body": {"type": "response.create"}})
+        return reader, writer
+
+    def call(self, body=None, emitter=None):
+        emitter = emitter or Capture()
+        task = asyncio.create_task(M["run_via_broker"](self.path, body or {"type": "response.create"}, emitter))
+        self.calls.append(task)
+        return task, emitter
+
+    async def send(self, ws, event):
+        await ws.send(json.dumps(event))
+
+    async def test_sixteen_silent_abandoned_clients_release_capacity(self):
+        clients = [await self.client() for _ in range(16)]
+        requests = [await self.request() for _ in range(16)]
+        self.assertEqual(len({id(ws) for ws, _ in requests}), 1)
+        for _, writer in clients:
+            writer.close()
+        await until(lambda: self.broker.slots._value == 16)
+        task, capture = self.call()
+        ws, body = await self.request()
+        self.assertIsNot(ws, requests[0][0])
+        await self.send(ws, completed(body["stream_id"]))
+        self.assertEqual(await asyncio.wait_for(task, 5), 0)
+        self.assertEqual(len(self.received), 17)
+
+    async def test_abandonment_fails_other_current_calls_without_recreation(self):
+        _, writer = await self.client()
+        await self.request()
+        task, capture = self.call()
+        await self.request()
+        writer.close()
+        self.assertEqual(await asyncio.wait_for(task, 5), 1)
+        self.assertEqual(capture.events[-1]["error"]["code"], "outcome_unknown")
+        self.assertEqual(len(self.received), 2)
+
+    async def test_delayed_old_terminal_and_reader_cleanup_cannot_reach_new_lane(self):
+        close_gate = asyncio.Event()
+        real_close = self.broker._close
+
+        async def delayed_close(ws):
+            await close_gate.wait()
+            await real_close(ws)
+
+        self.broker._close = delayed_close
+        try:
+            reader, writer = await self.client()
+            old_ws, old_body = await self.request()
+            old_generation = self.broker.connection
+            await self.send(old_ws, {"type": "response.output_text.delta", "stream_id": old_body["stream_id"], "delta": "partial"})
+            await asyncio.wait_for(reader.readline(), 5)
+            writer.close()
+            await until(lambda: old_generation.retired)
+            task, capture = self.call()
+            new_ws, new_body = await self.request()
+            new_generation = self.broker.connection
+            self.assertEqual(old_body["stream_id"], new_body["stream_id"])
+            await self.send(old_ws, completed(old_body["stream_id"], "resp_abandoned", "WRONG ANSWER"))
+            # Old reader consumes its late event and runs finally while the
+            # new generation owns an identically named lane.
+            await asyncio.sleep(.05)
+            self.assertIs(self.broker.connection, new_generation)
+            self.assertFalse(task.done())
+            close_gate.set()
+            await real_close(old_ws)
+            await self.send(new_ws, completed(new_body["stream_id"], "resp_new", "correct"))
+            self.assertEqual(await asyncio.wait_for(task, 5), 0)
+            self.assertEqual(capture.events[-1]["response"]["id"], "resp_new")
+            self.assertEqual(len(self.received), 2)
+        finally:
+            close_gate.set()
+
+    async def test_queued_disconnected_client_is_never_dispatched(self):
+        clients = [await self.client() for _ in range(16)]
+        requests = [await self.request() for _ in range(16)]
+        _, waiting_writer = await self.client()
+        waiting_writer.close()
+        await asyncio.sleep(.05)
+        for index, (ws, body) in enumerate(requests):
+            await self.send(ws, completed(body["stream_id"], f"resp_{index}"))
+        for reader, _ in clients:
+            await asyncio.wait_for(reader.readline(), 5)
+        await until(lambda: self.broker.slots._value == 16)
+        self.assertEqual(len(self.received), 16)
+
+    async def test_untagged_error_fans_out_original_diagnostic(self):
+        a, ca = self.call()
+        b, cb = self.call()
+        ws, _ = await self.request()
+        await self.request()
+        error = {"type": "error", "error": {"code": "connection_limit", "message": "synthetic connection failure"}}
+        await self.send(ws, error)
+        self.assertEqual(await asyncio.wait_for(asyncio.gather(a, b), 5), [1, 1])
+        self.assertEqual(ca.events[-1], error)
+        self.assertEqual(cb.events[-1], error)
+
+    async def test_local_client_admission_is_bounded(self):
+        with patch.dict(G, MAX_CLIENTS=2):
+            await self.client()
+            await self.client()
+            await self.request()
+            await self.request()
+            reader, writer = await asyncio.open_unix_connection(self.path, limit=LIMIT + 1)
+            self.writers.append(writer)
+            result = json.loads(await asyncio.wait_for(reader.readline(), 5))
+            self.assertIn("broker_busy", result["message"])
+            self.assertEqual(len(self.received), 2)
+
+    async def test_received_terminal_survives_immediate_upstream_close(self):
+        task, capture = self.call()
+        ws, body = await self.request()
+        await self.send(ws, completed(body["stream_id"]))
+        await ws.close()
+        self.assertEqual(await asyncio.wait_for(task, 5), 0)
+        self.assertEqual(capture.events[-1]["response"]["id"], "resp_ok")
+
+    async def test_cross_lane_response_id_is_rejected(self):
+        a, ca = self.call()
+        b, cb = self.call()
+        ws, first = await self.request()
+        _, second = await self.request()
+        for body in (first, second):
+            await self.send(ws, {"type": "response.created", "stream_id": body["stream_id"], "response": {"id": "resp_same"}})
+        self.assertEqual(await asyncio.wait_for(asyncio.gather(a, b), 5), [1, 1])
+        self.assertIn("another stream_id", ca.events[-1]["error"]["message"])
+        self.assertIn("another stream_id", cb.events[-1]["error"]["message"])
+
+    async def test_idle_age_rotation_precedes_admission(self):
+        a, _ = self.call()
+        old_ws, body = await self.request()
+        await self.send(old_ws, completed(body["stream_id"]))
+        self.assertEqual(await asyncio.wait_for(a, 5), 0)
+        await until(lambda: not self.broker.connection.lanes)
+        self.broker.connection.opened_at -= M["CONNECTION_MAX_AGE"] + 1
+        b, _ = self.call()
+        new_ws, body = await self.request()
+        self.assertIsNot(old_ws, new_ws)
+        await self.send(new_ws, completed(body["stream_id"], "resp_new"))
+        self.assertEqual(await asyncio.wait_for(b, 5), 0)
+
+    async def test_response_id_mismatch_fails_not_success(self):
+        task, capture = self.call()
+        ws, body = await self.request()
+        await self.send(ws, {"type": "response.created", "stream_id": body["stream_id"], "response": {"id": "resp_owned"}})
+        await self.send(ws, completed(body["stream_id"], "resp_wrong"))
+        self.assertEqual(await asyncio.wait_for(task, 5), 1)
+        self.assertIn("response ID mismatch", capture.events[-1]["error"]["message"])
+
+    async def test_large_input_terminal_unicode_escapes_and_encrypted_reasoning(self):
+        text = ('λ\\\"\n' * 30000)
+        body = {"type": "response.create", "input": [{"role": "user", "content": text}]}
+        output = io.StringIO()
+        sidecar = Path(self.tmp.name) / "response.json"
+        usage = Path(self.tmp.name) / "usage.json"
+        with patch.dict(os.environ, LLM_RESPONSE_FILE=str(sidecar), LLM_USAGE_FILE=str(usage)), contextlib.redirect_stdout(output):
+            task, _ = self.call(body, M["Emitter"](False))
+            ws, request = await self.request()
+            self.assertEqual(request["input"], body["input"])
+            terminal = completed(request["stream_id"], text=text)
+            terminal["response"]["output"].append({"type": "reasoning", "encrypted_content": "opaque" * 30000, "summary": []})
+            terminal["response"]["usage"] = {"input_tokens": 100, "output_tokens": 200}
+            await self.send(ws, terminal)
+            self.assertEqual(await asyncio.wait_for(task, 5), 0)
+        self.assertEqual(output.getvalue(), text)
+        self.assertEqual(json.loads(sidecar.read_text()), terminal["response"])
+        self.assertEqual(sidecar.stat().st_mode & 0o777, 0o600)
+        self.assertEqual(json.loads(usage.read_text()), {"in_tok": 100, "out_tok": 200})
+
+    async def test_oversize_local_frame_clean_rejection_before_dispatch(self):
+        reader, writer = await asyncio.open_unix_connection(self.path, limit=LIMIT + 1)
+        self.writers.append(writer)
+        writer.write(b"x" * (LIMIT + 2) + b"\n")
+        with contextlib.suppress(ConnectionError):
+            await writer.drain()
+        result = json.loads(await asyncio.wait_for(reader.readline(), 5))
+        self.assertIn("frame_too_large", result["message"])
+        self.assertEqual(self.received, [])
+
+    async def test_oversize_upstream_frame_clean_failure(self):
+        task, capture = self.call()
+        ws, body = await self.request()
+        await self.send(ws, completed(body["stream_id"], text="x" * LIMIT))
+        self.assertEqual(await asyncio.wait_for(task, 5), 1)
+        self.assertEqual(capture.events[-1]["error"]["code"], "outcome_unknown")
+
+    async def test_malformed_upstream_fails_all_lanes(self):
+        task, capture = self.call()
+        ws, _ = await self.request()
+        await ws.send("not JSON")
+        self.assertEqual(await asyncio.wait_for(task, 5), 1)
+        self.assertEqual(capture.events[-1]["type"], "error")
+
+    async def test_slow_consumer_queue_overflow_retires_connection(self):
+        gate = asyncio.Event()
+        original = G["drain_line"]
+        blocked = asyncio.Event()
+
+        async def slow_drain(writer, obj):
+            if obj.get("op") == "event" and obj["event"].get("type") == "response.output_text.delta":
+                blocked.set()
+                await gate.wait()
+            await original(writer, obj)
+
+        with patch.dict(G, drain_line=slow_drain):
+            task, capture = self.call()
+            ws, body = await self.request()
+            generation = self.broker.connection
+            delta = {"type": "response.output_text.delta", "stream_id": body["stream_id"], "delta": "x"}
+            await self.send(ws, delta)
+            await asyncio.wait_for(blocked.wait(), 5)
+            for _ in range(M["MAX_QUEUE_EVENTS"] + 1):
+                await self.send(ws, delta)
+            await until(lambda: generation.retired)
+            gate.set()
+            self.assertEqual(await asyncio.wait_for(task, 5), 1)
+            self.assertIn("bounded event queue", capture.events[-1]["error"]["message"])
+
+    async def test_actual_endpoint_path_and_provider_headers(self):
+        for provider, expected in (("openai", "Bearer native-test-key"), ("openai-compatible", "Bearer compatible-test-key")):
+            with self.subTest(provider=provider), patch.dict(os.environ, {
+                "LLM_PROVIDER": "adapter", "RESPONSES_WS_PROVIDER": provider,
+                "LLM_API_URL": self.url.replace("ws:", "http:") + "?test=1",
+                "OPENAI_API_KEY": "native-test-key", "LLM_API_KEY": "compatible-test-key",
+            }, clear=True):
+                proc = await asyncio.create_subprocess_exec(sys.executable, str(ROOT / "tools/responses-ws"),
+                    "--model", "test-model", "--max-tokens", "32", "--api-format", "responses",
+                    stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+                communicate = asyncio.create_task(proc.communicate(b"[]"))
+                try:
+                    ws, _ = await self.request()
+                    self.assertEqual(ws.request.path, "/v1/responses?test=1")
+                    self.assertEqual(ws.request.headers["Authorization"], expected)
+                    await self.send(ws, completed(None))
+                    out, err = await asyncio.wait_for(communicate, 5)
+                    self.assertEqual(proc.returncode, 0, err)
+                    self.assertEqual(out, b"ok")
+                finally:
+                    if proc.returncode is None:
+                        proc.terminate()
+                        await proc.wait()
+                    await communicate
+
+    async def test_missing_configured_broker_does_not_fall_back(self):
+        with patch.dict(os.environ, RESPONSES_WS_URL=self.url, RESPONSES_WS_SOCKET=self.tmp.name + "/missing"):
+            proc = await asyncio.create_subprocess_exec(sys.executable, str(ROOT / "tools/responses-ws"),
+                "--model", "test-model", "--max-tokens", "32", "--api-format", "responses",
+                stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+            out, err = await asyncio.wait_for(proc.communicate(b"[]"), 5)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertNotIn(b"Traceback", err)
+            self.assertEqual(out, b"")
+            self.assertEqual(self.received, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -14,6 +14,25 @@ fail=0
 ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
 bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
 
+# Inspect the live run and durable home, including dotfiles. A failed inspector
+# is an error, never evidence that Responses state is absent.
+cat > "$WORK/check-chat-state" <<'CHECK'
+#!/usr/bin/env bash
+set -uo pipefail
+if [[ "${LLM_API_FORMAT:-}" != chat || -n "${LLM_PREVIOUS_RESPONSE_ID:-}" \
+      || -n "${LLM_RESPONSE_FILE:-}" || -n "${LLM_RESPONSES_CONVERSATION:-}" ]]; then
+    exit 1
+fi
+[[ -d "$1" && ! -L "$1" && -d "$2" && ! -L "$2" ]] || exit 2
+if ! find "$1" "$2" \( -name .last_response.json -o -name .responses-sent-ids.json \
+    -o -name .response-id -o -name .continuation-disabled -o -name .responses-replay.json \
+    -o -name .responses-conversations -o -name responses-conversations \) -print > "$3"; then
+    exit 2
+fi
+[[ ! -s "$3" ]]
+CHECK
+chmod +x "$WORK/check-chat-state"
+
 mkdir -p "$WORK/home" "$WORK/wd"
 cp -R "$REPO/bin" "$WORK/toolbin"
 mv "$WORK/toolbin/context" "$WORK/toolbin/context.real"
@@ -260,7 +279,16 @@ case "$LLM_STUB_MODE:$n" in
         printf '%s\n' '```bash' "touch '$LLM_STUB_DIR/executed'" '```'
         ;;
     chat:1)
-        [[ -z "${LLM_RESPONSE_FILE:-}" ]] || { echo "chat unexpectedly received LLM_RESPONSE_FILE" >&2; exit 2; }
+        chat_runs=( "${TEST_CHAT_TMP_ROOT:?}"/shellm-run.* )
+        [[ "${#chat_runs[@]}" -eq 1 && -d "${chat_runs[0]}" ]] || exit 2
+        printf '%s\n' "${chat_runs[0]}" > "$LLM_STUB_DIR/chat-rundir"
+        if [[ "${TEST_CHAT_INJECT_RESPONSE_STATE:-0}" == 1 ]]; then
+            : > "${chat_runs[0]}/.response-id"
+        fi
+        "${TEST_CHAT_STATE_CHECK:?}" "${chat_runs[0]}" "$HEADLONG_HOME" "$LLM_STUB_DIR/chat-state-paths"
+        chat_state_rc=$?
+        printf '%s\n' "$chat_state_rc" > "$LLM_STUB_DIR/chat-state-rc"
+        [[ "$chat_state_rc" -eq 0 ]] || exit "$chat_state_rc"
         printf '%s\n' '```bash' 'FINAL=chat-done' '```'
         ;;
     *)
@@ -883,15 +911,92 @@ else
     bad "an id that is not a conversation is refused before the run starts" "rc=$rc stderr=$(cat "$WORK/err")"
 fi
 
-# Default chat mode does not create or pass Responses state.
-run_shellm chat chat
+# Default chat mode must be inspected in the llm stub while its run still exists.
+mkdir -p "$WORK/chat-tmp"
+TMPDIR="$WORK/chat-tmp" TEST_CHAT_TMP_ROOT="$WORK/chat-tmp" \
+    TEST_CHAT_STATE_CHECK="$WORK/check-chat-state" run_shellm chat chat
 rc=$?
 if [[ "$rc" -eq 0 && "$(cat "$WORK/stub/format-1")" == chat \
       && -z "$(cat "$WORK/stub/previous-1")" \
-      && -z "$(rg --files "$HEADLONG_HOME/trajectories" 2>/dev/null | rg '/responses/' | head -1)" ]]; then
+      && "$(cat "$WORK/stub/chat-state-rc")" == 0 ]]; then
     ok "default chat mode remains stateless"
 else
     bad "default chat mode remains stateless" "rc=$rc format=$(cat "$WORK/stub/format-1")"
+fi
+
+# A state file created in the actual live rundir must fail before cleanup hides it.
+TMPDIR="$WORK/chat-tmp" TEST_CHAT_TMP_ROOT="$WORK/chat-tmp" \
+    TEST_CHAT_STATE_CHECK="$WORK/check-chat-state" TEST_CHAT_INJECT_RESPONSE_STATE=1 \
+    run_shellm chat chat
+rc=$?
+if [[ "$rc" -ne 0 && "$(cat "$WORK/stub/chat-state-rc")" == 1 \
+      && -s "$WORK/stub/chat-state-paths" ]]; then
+    ok "chat oracle rejects an injected live Responses state file before cleanup"
+else
+    bad "chat oracle rejects an injected live Responses state file before cleanup" "rc=$rc"
+fi
+
+# Exercise the same inspector against every source-owned state name and config.
+chat_probe="$WORK/chat-oracle-control"
+mkdir -p "$chat_probe/run" "$chat_probe/home" "$chat_probe/no-tools"
+check_chat_probe() {
+    LLM_API_FORMAT="${1:-chat}" LLM_PREVIOUS_RESPONSE_ID="${2:-}" \
+        LLM_RESPONSE_FILE="${3:-}" LLM_RESPONSES_CONVERSATION="${4:-}" \
+        "$WORK/check-chat-state" "$chat_probe/run" "$chat_probe/home" "$chat_probe/found"
+}
+if check_chat_probe; then
+    ok "chat oracle accepts an inspected empty run and home"
+else
+    bad "chat oracle accepts an inspected empty run and home"
+fi
+for state_name in .last_response.json .responses-sent-ids.json .response-id \
+    .continuation-disabled .responses-replay.json; do
+    : > "$chat_probe/run/$state_name"
+    check_chat_probe
+    probe_rc=$?
+    if [[ "$probe_rc" -eq 1 ]]; then
+        ok "chat oracle rejects transient state $state_name"
+    else
+        bad "chat oracle rejects transient state $state_name" "rc=$probe_rc"
+    fi
+    rm "$chat_probe/run/$state_name"
+done
+for state_path in trajectories/.responses-conversations run/responses-conversations; do
+    mkdir -p "$chat_probe/home/$state_path"
+    check_chat_probe
+    probe_rc=$?
+    if [[ "$probe_rc" -eq 1 ]]; then
+        ok "chat oracle rejects durable state $state_path"
+    else
+        bad "chat oracle rejects durable state $state_path" "rc=$probe_rc"
+    fi
+    rm -rf "$chat_probe/home/$state_path"
+done
+for state_field in format previous response conversation; do
+    probe_format=chat; probe_previous=""; probe_response=""; probe_conversation=""
+    case "$state_field" in
+        format) probe_format=responses ;;
+        previous) probe_previous=resp_forbidden ;;
+        response) probe_response="$chat_probe/forbidden-response.json" ;;
+        conversation) probe_conversation=conv_forbidden ;;
+    esac
+    check_chat_probe "$probe_format" "$probe_previous" "$probe_response" "$probe_conversation"
+    probe_rc=$?
+    if [[ "$probe_rc" -eq 1 ]]; then
+        ok "chat oracle rejects Responses configuration $state_field"
+    else
+        bad "chat oracle rejects Responses configuration $state_field" "rc=$probe_rc"
+    fi
+done
+PATH="$chat_probe/no-tools" LLM_API_FORMAT=chat LLM_PREVIOUS_RESPONSE_ID= \
+    LLM_RESPONSE_FILE= LLM_RESPONSES_CONVERSATION= \
+    /bin/bash "$WORK/check-chat-state" "$chat_probe/run" "$chat_probe/home" "$chat_probe/found" \
+    > "$chat_probe/missing-tool.out" 2> "$chat_probe/missing-tool.err"
+probe_rc=$?
+if [[ "$probe_rc" -eq 2 ]]; then
+    ok "chat oracle fails closed when its inspection tool is unavailable"
+else
+    bad "chat oracle fails closed when its inspection tool is unavailable" "rc=$probe_rc"
 fi
 
 # Compaction in replay mode. Once a terminal response reports input tokens at

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -970,7 +970,7 @@ for state_path in trajectories/.responses-conversations run/responses-conversati
     else
         bad "chat oracle rejects durable state $state_path" "rc=$probe_rc"
     fi
-    rm -rf "$chat_probe/home/$state_path"
+    rm -rf "${chat_probe:?}/home/${state_path:?}"
 done
 for state_field in format previous response conversation; do
     probe_format=chat; probe_previous=""; probe_response=""; probe_conversation=""
@@ -988,8 +988,8 @@ for state_field in format previous response conversation; do
         bad "chat oracle rejects Responses configuration $state_field" "rc=$probe_rc"
     fi
 done
-PATH="$chat_probe/no-tools" LLM_API_FORMAT=chat LLM_PREVIOUS_RESPONSE_ID= \
-    LLM_RESPONSE_FILE= LLM_RESPONSES_CONVERSATION= \
+PATH="$chat_probe/no-tools" LLM_API_FORMAT=chat LLM_PREVIOUS_RESPONSE_ID='' \
+    LLM_RESPONSE_FILE='' LLM_RESPONSES_CONVERSATION='' \
     /bin/bash "$WORK/check-chat-state" "$chat_probe/run" "$chat_probe/home" "$chat_probe/found" \
     > "$chat_probe/missing-tool.out" 2> "$chat_probe/missing-tool.err"
 probe_rc=$?

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -37,6 +37,7 @@ n=$((n + 1))
 printf '%s\n' "$n" > "$LLM_STUB_DIR/calls"
 printf '%s\n' "${LLM_API_FORMAT:-}" > "$LLM_STUB_DIR/format-$n"
 printf '%s\n' "${LLM_PREVIOUS_RESPONSE_ID:-}" > "$LLM_STUB_DIR/previous-$n"
+printf '%s\n' "${LLM_RESPONSES_BACKGROUND-unset}" > "$LLM_STUB_DIR/background-$n"
 printf '%s\n' "${LLM_RESPONSE_FILE:-}" > "$LLM_STUB_DIR/response-file-$n"
 [[ -n "$messages_file" ]] && cp "$messages_file" "$LLM_STUB_DIR/messages-$n.json"
 if [[ -n "${LLM_RESPONSE_FILE:-}" ]]; then
@@ -359,6 +360,31 @@ if [[ "$rc" -ne 0 ]] \
     ok "invalid Responses format fails through shellm's error contract"
 else
     bad "invalid Responses format fails through shellm's error contract" "rc=$rc stderr=$(cat "$WORK/err")"
+fi
+
+# Background creates ride through to llm untouched; the continuation contract
+# is llm's terminal object either way, so nothing else changes.
+SHELLM_RESPONSES_BACKGROUND=1 run_shellm continue responses
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 \
+      && "$(cat "$WORK/stub/background-1")" == 1 && "$(cat "$WORK/stub/background-2")" == 1 \
+      && "$(cat "$WORK/stub/previous-2")" == resp_1 ]]; then
+    ok "SHELLM_RESPONSES_BACKGROUND passes through to every llm call"
+else
+    bad "SHELLM_RESPONSES_BACKGROUND passes through to every llm call" "rc=$rc calls=$(main_calls) bg1=$(cat "$WORK/stub/background-1" 2>/dev/null) bg2=$(cat "$WORK/stub/background-2" 2>/dev/null)"
+fi
+run_shellm continue responses
+if [[ "$(cat "$WORK/stub/background-1")" == unset ]]; then
+    ok "an unset SHELLM_RESPONSES_BACKGROUND leaves llm's default alone"
+else
+    bad "an unset SHELLM_RESPONSES_BACKGROUND leaves llm's default alone" "bg1=$(cat "$WORK/stub/background-1" 2>/dev/null)"
+fi
+SHELLM_RESPONSES_BACKGROUND=sometimes "$WORK/toolbin/shellm" --help > "$WORK/out" 2> "$WORK/err"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'Invalid SHELLM_RESPONSES_BACKGROUND' "$WORK/err"; then
+    ok "an invalid SHELLM_RESPONSES_BACKGROUND fails through shellm's error contract"
+else
+    bad "an invalid SHELLM_RESPONSES_BACKGROUND fails through shellm's error contract" "rc=$rc stderr=$(cat "$WORK/err")"
 fi
 
 # Default chat mode does not create or pass Responses state.

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -16,6 +16,16 @@ bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
 
 mkdir -p "$WORK/home" "$WORK/wd"
 cp -R "$REPO/bin" "$WORK/toolbin"
+mv "$WORK/toolbin/context" "$WORK/toolbin/context.real"
+cat > "$WORK/toolbin/context" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${TEST_CONTEXT_FAIL:-0}" == 1 ]]; then
+    echo "injected context renderer failure" >&2
+    exit 91
+fi
+exec "$(dirname "$0")/context.real" "$@"
+STUB
+chmod +x "$WORK/toolbin/context"
 cat > "$WORK/toolbin/llm" <<'STUB'
 #!/usr/bin/env bash
 main_loop=0
@@ -43,13 +53,29 @@ printf '%s\n' "${LLM_RESPONSES_COMPACT_THRESHOLD-unset}" > "$LLM_STUB_DIR/thresh
 printf '%s\n' "${LLM_RESPONSES_CONVERSATION-unset}" > "$LLM_STUB_DIR/conversation-$n"
 printf '%s\n' "${LLM_RESPONSE_FILE:-}" > "$LLM_STUB_DIR/response-file-$n"
 [[ -n "$messages_file" ]] && cp "$messages_file" "$LLM_STUB_DIR/messages-$n.json"
-if [[ "${TEST_LOCK_PROBE:-0}" == 1 && "$n" == 1 ]]; then
-    checkpoint="$HEADLONG_HOME/trajectories/.responses-conversations/conv_locked.json"
+if [[ "${TEST_LOCK_PROBE:-0}" != 0 && "$n" == 1 ]]; then
+    conversation_id="${LLM_RESPONSES_CONVERSATION:-}"
+    checkpoint="$HEADLONG_HOME/trajectories/.responses-conversations/$conversation_id.json"
     cp "$checkpoint" "$LLM_STUB_DIR/checkpoint-before"
     mkdir -p "$LLM_STUB_DIR/contender"
-    TEST_LOCK_PROBE=0 LLM_STUB_DIR="$LLM_STUB_DIR/contender" \
-        shellm --resume --max-iterations 1 "contending input" </dev/null \
-        > "$LLM_STUB_DIR/contender.out" 2> "$LLM_STUB_DIR/contender.err"
+    if [[ "$TEST_LOCK_PROBE" == cross-root ]]; then
+        TEST_LOCK_PROBE=0 LLM_STUB_DIR="$LLM_STUB_DIR/contender" \
+            SHELLM_TRAJ_DIR="$HEADLONG_HOME/other-trajectories" \
+            SHELLM_RESPONSES_CONVERSATION="$conversation_id" \
+            shellm --max-iterations 1 "contending input" </dev/null \
+            > "$LLM_STUB_DIR/contender.out" 2> "$LLM_STUB_DIR/contender.err"
+    elif [[ "$TEST_LOCK_PROBE" == equivalent-endpoint ]]; then
+        TEST_LOCK_PROBE=0 LLM_STUB_DIR="$LLM_STUB_DIR/contender" \
+            SHELLM_TRAJ_DIR="$HEADLONG_HOME/other-trajectories" \
+            SHELLM_API_URL="https://api.openai.com/v1/responses/" \
+            SHELLM_RESPONSES_CONVERSATION="$conversation_id" \
+            shellm --max-iterations 1 "contending input" </dev/null \
+            > "$LLM_STUB_DIR/contender.out" 2> "$LLM_STUB_DIR/contender.err"
+    else
+        TEST_LOCK_PROBE=0 LLM_STUB_DIR="$LLM_STUB_DIR/contender" \
+            shellm --resume --max-iterations 1 "contending input" </dev/null \
+            > "$LLM_STUB_DIR/contender.out" 2> "$LLM_STUB_DIR/contender.err"
+    fi
     printf '%s\n' "$?" > "$LLM_STUB_DIR/contender.rc"
     cp "$checkpoint" "$LLM_STUB_DIR/checkpoint-after"
 fi
@@ -115,11 +141,11 @@ write_response_server_compacted() {
 }
 
 case "$LLM_STUB_MODE:$n" in
-    compact:1|compact-window:1|compactfail:1|stateful-compact:1)
+    compact:1|compact-window:1|compact-malformed:1|compactfail:1|stateful-compact:1)
         write_response_usage resp_1 9000
         printf '%s\n' '```bash' 'printf "first output\n"' '```'
         ;;
-    compact:2|compact-window:2|stateful-compact:2)
+    compact:2|compact-window:2|compact-malformed:2|stateful-compact:2)
         write_response_usage resp_2 10
         printf '%s\n' '```bash' 'FINAL=done-after-compaction' '```'
         ;;
@@ -135,7 +161,18 @@ case "$LLM_STUB_MODE:$n" in
         write_response_server_compacted resp_1
         printf '%s\n' '```bash' 'printf "first output\n"' '```'
         ;;
+    server-compaction-malformed:1)
+        write_response resp_1
+        jq '.output |= ([.[0], {id:"cmp_bad", type:"compaction"}, .[1]])' \
+            "$LLM_RESPONSE_FILE" > "$LLM_RESPONSE_FILE.tmp"
+        mv "$LLM_RESPONSE_FILE.tmp" "$LLM_RESPONSE_FILE"
+        printf '%s\n' '```bash' 'printf "first output\n"' '```'
+        ;;
     server-compaction:2)
+        write_response resp_2
+        printf '%s\n' '```bash' 'FINAL=done-after-server-compaction' '```'
+        ;;
+    server-compaction-malformed:2)
         write_response resp_2
         printf '%s\n' '```bash' 'FINAL=done-after-server-compaction' '```'
         ;;
@@ -268,6 +305,10 @@ case "${1:-}" in
         fi
         if [[ "$LLM_STUB_MODE" == compact-window ]]; then
             printf '%s\n' '{"output":[{"role":"user","content":"retained prefix"},{"type":"compaction","encrypted_content":"canonical"},{"role":"user","content":"retained suffix"}]}'
+            exit 0
+        fi
+        if [[ "$LLM_STUB_MODE" == compact-malformed ]]; then
+            printf '%s\n' '{"output":[{"type":"compaction"}]}'
             exit 0
         fi
         jq -nc '{
@@ -695,15 +736,23 @@ else
 fi
 
 cp "$checkpoint" "$WORK/checkpoint-locked"
-mkdir "${checkpoint%.json}.lock"
+lock_identity=$(jq -c '[.provider,.endpoint,.conversation]' "$checkpoint")
+if command -v sha256sum >/dev/null 2>&1; then
+    lock_digest=$(printf '%s' "$lock_identity" | sha256sum)
+else
+    lock_digest=$(printf '%s' "$lock_identity" | shasum -a 256)
+fi
+lock_digest=${lock_digest%%[[:space:]]*}
+lock_path="$HEADLONG_HOME/run/responses-conversations/conv_locked-$lock_digest.lock"
+mkdir "$lock_path"
 resume_shellm continue
-if [[ "$?" != 0 && "$(main_calls)" == 0 && -d "${checkpoint%.json}.lock" ]] \
+if [[ "$?" != 0 && "$(main_calls)" == 0 && -d "$lock_path" ]] \
     && cmp -s "$checkpoint" "$WORK/checkpoint-locked"; then
     ok "a stale crash lock is never stolen or released by a contender"
 else
     bad "a stale crash lock is never stolen or released by a contender"
 fi
-rmdir "${checkpoint%.json}.lock"
+rmdir "$lock_path"
 
 LLM_PROVIDER=openai-compatible resume_shellm continue
 if [[ "$?" != 0 && "$(main_calls)" == 0 ]] && cmp -s "$checkpoint" "$WORK/checkpoint-locked"; then
@@ -722,6 +771,30 @@ else
     bad "a different trajectory cannot overwrite a shared Conversation acknowledgement"
 fi
 
+TEST_LOCK_PROBE=cross-root SHELLM_RESPONSES_CONVERSATION=conv_cross_root \
+    run_shellm continue responses
+rc=$?
+if [[ "$rc" == 0 && "$(cat "$WORK/stub/contender.rc")" != 0 \
+    && ! -e "$WORK/stub/contender/calls" ]] \
+    && cmp -s "$WORK/stub/checkpoint-before" "$WORK/stub/checkpoint-after" \
+    && grep -q 'Conversation is locked' "$WORK/stub/contender.err"; then
+    ok "a Conversation lock holds across different trajectory roots"
+else
+    bad "a Conversation lock holds across different trajectory roots" "rc=$rc contender=$(cat "$WORK/stub/contender.rc" 2>/dev/null) calls=$(cat "$WORK/stub/contender/calls" 2>/dev/null) stderr=$(tail -3 "$WORK/stub/contender.err" 2>/dev/null | tr '\n' ' ')"
+fi
+
+TEST_LOCK_PROBE=equivalent-endpoint \
+    SHELLM_RESPONSES_CONVERSATION=conv_equivalent_endpoint run_shellm continue responses
+rc=$?
+if [[ "$rc" == 0 && "$(cat "$WORK/stub/contender.rc")" != 0 \
+    && ! -e "$WORK/stub/contender/calls" ]] \
+    && cmp -s "$WORK/stub/checkpoint-before" "$WORK/stub/checkpoint-after" \
+    && grep -q 'Conversation is locked' "$WORK/stub/contender.err"; then
+    ok "an explicit default endpoint shares the unset endpoint's Conversation lock"
+else
+    bad "an explicit default endpoint shares the unset endpoint's Conversation lock" "rc=$rc contender=$(cat "$WORK/stub/contender.rc" 2>/dev/null) calls=$(cat "$WORK/stub/contender/calls" 2>/dev/null) stderr=$(tail -3 "$WORK/stub/contender.err" 2>/dev/null | tr '\n' ' ')"
+fi
+
 SHELLM_RESPONSES_CONVERSATION=conv_unknown run_shellm no-terminal responses
 checkpoint="$HEADLONG_HOME/trajectories/.responses-conversations/conv_unknown.json"
 cp "$checkpoint" "$WORK/checkpoint-unknown"
@@ -733,6 +806,19 @@ if [[ "$rc" != 0 && "$(main_calls)" == 0 ]] \
     ok "ambiguous delivery remains unacknowledged and resume fails closed without resending"
 else
     bad "ambiguous delivery remains unacknowledged and resume fails closed without resending"
+fi
+
+SHELLM_RESPONSES_CONVERSATION=conv_context_fail run_shellm continue responses
+checkpoint="$HEADLONG_HOME/trajectories/.responses-conversations/conv_context_fail.json"
+cp "$checkpoint" "$WORK/checkpoint-context-fail"
+TEST_CONTEXT_FAIL=1 resume_shellm continue
+rc=$?
+if [[ "$rc" != 0 && "$(main_calls)" == 0 ]] \
+    && cmp -s "$checkpoint" "$WORK/checkpoint-context-fail" \
+    && grep -q 'could not render Conversation context' "$WORK/err"; then
+    ok "Conversation context rendering fails closed before dispatch or acknowledgement"
+else
+    bad "Conversation context rendering fails closed before dispatch or acknowledgement" "rc=$rc calls=$(main_calls) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
 fi
 
 SHELLM_RESPONSES_CONVERSATION=conv_missing run_shellm continue responses
@@ -910,6 +996,17 @@ else
     bad "a compaction item in a terminal output truncates the replay chain" "rc=$rc calls=$(main_calls) compacts=$(compact_calls) m2=$(jq -c 'map(.type // .role)' "$WORK/stub/messages-2.json" 2>/dev/null)"
 fi
 
+run_shellm server-compaction-malformed responses openrouter openai/o4-mini
+if [[ "$?" == 0 ]] \
+   && jq -e 'any(.[]; .encrypted_content == "enc_resp_1")
+        and all(.[]; .id? != "cmp_bad")' \
+        "$WORK/stub/messages-2.json" >/dev/null 2>&1 \
+   && grep -q 'unusable compaction item' "$WORK/err"; then
+    ok "an unusable server compaction marker cannot prune known-good replay"
+else
+    bad "an unusable server compaction marker cannot prune known-good replay" "m2=$(jq -c 'map(.type // .role)' "$WORK/stub/messages-2.json" 2>/dev/null) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
+fi
+
 run_shellm multiple-compactions responses openrouter openai/o4-mini
 if [[ "$?" == 0 ]] && jq -e '.[0].id == "cmp_resp_2"
     and all(.[]; .id != "cmp_resp_1" and .id != "msg_resp_1")
@@ -926,6 +1023,16 @@ if [[ "$?" == 0 ]] && jq -e '.[0:3] == [{role:"user",content:"retained prefix"},
     ok "standalone compact.output is preserved as-is including items before the marker"
 else
     bad "standalone compact.output is preserved as-is including items before the marker"
+fi
+
+SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 run_shellm compact-malformed responses openrouter openai/o4-mini
+if [[ "$?" == 0 && "$(compact_calls)" == 1 ]] \
+    && jq -e 'any(.[]; .encrypted_content == "enc_resp_1")' \
+        "$WORK/stub/messages-2.json" >/dev/null 2>&1 \
+    && grep -q 'unusable compaction item' "$WORK/err"; then
+    ok "an unusable standalone compact reply keeps known-good replay"
+else
+    bad "an unusable standalone compact reply keeps known-good replay" "calls=$(compact_calls) m2=$(jq -c 'map(.type // .role)' "$WORK/stub/messages-2.json" 2>/dev/null) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
 fi
 if [[ "$(cat "$WORK/stub/compact-provider-1")" == openrouter \
     && -s "$WORK/stub/compact-instructions-1" ]]; then
@@ -970,9 +1077,10 @@ done
 # Exercise the actual upkeep function without a model, so elapsed completion
 # time can be pinned rather than relying on slow wall-clock test fixtures.
 if (
+    eval "$(sed -n '/^has_usable_compaction_window() {/,/^}/p' "$REPO/bin/shellm")"
     eval "$(sed -n '/^compact_replay_chain() {/,/^}/p' "$REPO/bin/shellm")"
     progress() { :; }
-    responses() { printf '%s' "$LLM_MAX_TIME" > "$WORK/compact-budget"; printf '{"output":[{"type":"compaction"}]}'; }
+    responses() { printf '%s' "$LLM_MAX_TIME" > "$WORK/compact-budget"; printf '{"output":[{"type":"compaction","encrypted_content":"opaque"}]}'; }
     _SHELLM_COMPACT_MODE=standalone
     _SHELLM_HOST_PROVIDER=openai
     # Used by the sourced upkeep function above.
@@ -991,7 +1099,10 @@ if (
     LLM_MAX_TIME=100
     _call_started=$((SECONDS-5))
     compact_replay_chain "$replay" "$WORK/compact-response" 1
-    [[ "$(cat "$WORK/compact-budget")" -gt 0 && "$(cat "$WORK/compact-budget")" -le 95 ]]
+    [[ "$(cat "$WORK/compact-budget")" -gt 0 \
+        && "$(cat "$WORK/compact-budget")" -le 95 ]] || exit 1
+    jq -e 'length == 1 and .[0].type == "compaction"
+        and .[0].encrypted_content == "opaque"' "$replay" >/dev/null
 ); then
     ok "standalone compaction only spends remaining completion deadline budget"
 else

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -27,6 +27,7 @@ for arg in "$@"; do
     prev="$arg"
 done
 if [[ "$main_loop" -ne 1 ]]; then
+    printf '%s\n' "${LLM_RESPONSES_CONVERSATION:-}" > "$LLM_STUB_DIR/summary-conversation"
     printf '{}\n'
     exit 0
 fi
@@ -42,6 +43,16 @@ printf '%s\n' "${LLM_RESPONSES_COMPACT_THRESHOLD-unset}" > "$LLM_STUB_DIR/thresh
 printf '%s\n' "${LLM_RESPONSES_CONVERSATION-unset}" > "$LLM_STUB_DIR/conversation-$n"
 printf '%s\n' "${LLM_RESPONSE_FILE:-}" > "$LLM_STUB_DIR/response-file-$n"
 [[ -n "$messages_file" ]] && cp "$messages_file" "$LLM_STUB_DIR/messages-$n.json"
+if [[ "${TEST_LOCK_PROBE:-0}" == 1 && "$n" == 1 ]]; then
+    checkpoint="$HEADLONG_HOME/trajectories/.responses-conversations/conv_locked.json"
+    cp "$checkpoint" "$LLM_STUB_DIR/checkpoint-before"
+    mkdir -p "$LLM_STUB_DIR/contender"
+    TEST_LOCK_PROBE=0 LLM_STUB_DIR="$LLM_STUB_DIR/contender" \
+        shellm --resume --max-iterations 1 "contending input" </dev/null \
+        > "$LLM_STUB_DIR/contender.out" 2> "$LLM_STUB_DIR/contender.err"
+    printf '%s\n' "$?" > "$LLM_STUB_DIR/contender.rc"
+    cp "$checkpoint" "$LLM_STUB_DIR/checkpoint-after"
+fi
 if [[ -n "${LLM_RESPONSE_FILE:-}" ]]; then
     state_dir=$(dirname "$LLM_RESPONSE_FILE")
     if [[ -f "$state_dir/.response-id" ]]; then
@@ -97,22 +108,30 @@ write_response_server_compacted() {
         status: "completed",
         output: [
             {id:("rs_" + $id), type:"reasoning", summary:[], encrypted_content:("enc_" + $id)},
-            {id:"cmp_server", type:"compaction", encrypted_content:"enc_server_compaction"},
+            {id:("cmp_" + $id), type:"compaction", encrypted_content:"enc_server_compaction"},
             {id:("msg_" + $id), type:"message", role:"assistant", status:"completed", phase:"final_answer", content:[{type:"output_text", text:("text_" + $id)}]}
         ]
     }' > "$LLM_RESPONSE_FILE" )
 }
 
 case "$LLM_STUB_MODE:$n" in
-    compact:1|compactfail:1|stateful-compact:1)
+    compact:1|compact-window:1|compactfail:1|stateful-compact:1)
         write_response_usage resp_1 9000
         printf '%s\n' '```bash' 'printf "first output\n"' '```'
         ;;
-    compact:2|compactfail:2|stateful-compact:2)
+    compact:2|compact-window:2|stateful-compact:2)
         write_response_usage resp_2 10
         printf '%s\n' '```bash' 'FINAL=done-after-compaction' '```'
         ;;
-    server-compaction:1)
+    compactfail:2)
+        write_response_usage resp_2 9000
+        printf '%s\n' '```bash' 'echo second' '```'
+        ;;
+    compactfail:3)
+        write_response_usage resp_3 9000
+        printf '%s\n' '```bash' 'FINAL=done-after-compaction' '```'
+        ;;
+    server-compaction:1|multiple-compactions:1)
         write_response_server_compacted resp_1
         printf '%s\n' '```bash' 'printf "first output\n"' '```'
         ;;
@@ -120,7 +139,21 @@ case "$LLM_STUB_MODE:$n" in
         write_response resp_2
         printf '%s\n' '```bash' 'FINAL=done-after-server-compaction' '```'
         ;;
-    continue:1|fallback:1|stateless:1)
+    multiple-compactions:2)
+        write_response_server_compacted resp_2
+        printf '%s\n' '```bash' 'echo second' '```'
+        ;;
+    multiple-compactions:3)
+        write_response resp_3
+        printf '%s\n' '```bash' 'FINAL=done' '```'
+        ;;
+    nested:1)
+        write_response resp_1
+        printf '%s\n' '```bash' \
+            'printf "%s|%s|%s|%s\n" "$SHELLM_RESPONSES_CONVERSATION" "$LLM_RESPONSES_CONVERSATION" "$LLM_PREVIOUS_RESPONSE_ID" "$SHELLM_API_TRANSPORT" > "$LLM_STUB_DIR/child-state"' \
+            'FINAL=done' '```'
+        ;;
+    continue:1|fallback:1|stateless:1|unknown:1)
         write_response resp_1
         printf '%s\n' '```bash' 'printf "first output\n"' '```'
         ;;
@@ -131,6 +164,10 @@ case "$LLM_STUB_MODE:$n" in
     fallback:2)
         ( umask 077; printf '%s' '{"error":{"message":"previous response is unavailable","param":"previous_response_id","code":"previous_response_not_found"}}' > "$LLM_RESPONSE_FILE" )
         printf '%s\n' 'llm: error: API error (HTTP 400): previous response is unavailable' >&2
+        exit 1
+        ;;
+    unknown:2)
+        ( umask 077; printf '%s' '{"error":{"message":"transport lost while continuing previous response","code":"outcome_unknown"}}' > "$LLM_RESPONSE_FILE" )
         exit 1
         ;;
     partial:1)
@@ -211,17 +248,27 @@ case "${1:-}" in
         printf '%s\n' "$n" > "$LLM_STUB_DIR/compact-calls"
         model=""
         input_file=""
+        provider=""
+        instructions=""
         prev=""
         for arg in "$@"; do
             [[ "$prev" == --model ]] && model="$arg"
             [[ "$prev" == --input-file ]] && input_file="$arg"
+            [[ "$prev" == --provider ]] && provider="$arg"
+            [[ "$prev" == --instructions ]] && instructions="$arg"
             prev="$arg"
         done
         printf '%s\n' "$model" > "$LLM_STUB_DIR/compact-model-$n"
+        printf '%s\n' "$provider" > "$LLM_STUB_DIR/compact-provider-$n"
+        printf '%s\n' "$instructions" > "$LLM_STUB_DIR/compact-instructions-$n"
         [[ -n "$input_file" ]] && cp "$input_file" "$LLM_STUB_DIR/compact-input-$n.json"
         if [[ "$LLM_STUB_MODE" == compactfail ]]; then
             echo "responses: error: compaction is unavailable" >&2
             exit 1
+        fi
+        if [[ "$LLM_STUB_MODE" == compact-window ]]; then
+            printf '%s\n' '{"output":[{"role":"user","content":"retained prefix"},{"type":"compaction","encrypted_content":"canonical"},{"role":"user","content":"retained suffix"}]}'
+            exit 0
         fi
         jq -nc '{
             id: "resp_compacted",
@@ -266,7 +313,7 @@ run_shellm() {
     mkdir -p "$WORK/stub" "$WORK/wd"
     LLM_STUB_DIR="$WORK/stub" LLM_STUB_MODE="$mode" SHELLM_API_FORMAT="$format" \
         LLM_PROVIDER="$provider" SHELLM_MODEL="$model" \
-        "$WORK/toolbin/shellm" --workdir "$WORK/wd" --max-iterations 3 "do the task" \
+        "$WORK/toolbin/shellm" --workdir "$WORK/wd" --max-iterations "${TEST_MAX_ITERATIONS:-3}" "do the task" \
         > "$WORK/out" 2> "$WORK/err" < /dev/null
 }
 
@@ -279,11 +326,13 @@ export RESPONSES_STUB_DIR="$WORK/rstub"
 # reused conversation shows up as a second run without a second create.
 resume_shellm() {
     local mode="$1"
+    local resume_args=(--resume)
+    [[ -z "${TEST_RESUME_TARGET:-}" ]] || resume_args=(--traj "$TEST_RESUME_TARGET")
     rm -rf "$WORK/stub"
     mkdir -p "$WORK/stub"
     LLM_STUB_DIR="$WORK/stub" LLM_STUB_MODE="$mode" SHELLM_API_FORMAT=responses \
         SHELLM_RESPONSES_CONVERSATION="${SHELLM_RESPONSES_CONVERSATION:-}" \
-        "$WORK/toolbin/shellm" --resume --workdir "$WORK/wd" --max-iterations 3 "keep going" \
+        "$WORK/toolbin/shellm" "${resume_args[@]}" --workdir "$WORK/wd" --max-iterations 3 "keep going" \
         > "$WORK/out" 2> "$WORK/err" < /dev/null
 }
 
@@ -446,6 +495,17 @@ else
     bad "row ids never reach the provider" "$(grep -l 'step_ids' "$WORK/stub"/messages-*.json | tr '\n' ' ')"
 fi
 
+# Mentioning a previous response in an unknown-outcome diagnostic is not
+# evidence of a pre-generation rejection.
+run_shellm unknown responses
+rc=$?
+if [[ "$rc" -ne 0 && "$(main_calls)" -eq 2 ]] \
+   && ! grep -q 'retrying once with exact replay' "$WORK/err"; then
+    ok "unknown continuation outcome never falls back to a new create"
+else
+    bad "unknown continuation outcome never falls back to a new create" "rc=$rc calls=$(main_calls)"
+fi
+
 # A rejection can only precede generation. An error naming
 # previous_response_id after text was streamed is a failed call, not a cue to
 # replay, and the partial text is never executed.
@@ -561,6 +621,136 @@ if [[ "$rc" -eq 0 && "$(create_calls)" -eq 1 \
 else
     bad "a resumed run reuses the conversation from its header instead of creating one" "rc=$rc creates=$(create_calls) conv1=$(cat "$WORK/stub/conversation-1" 2>/dev/null) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
 fi
+if jq -e 'all(.[]; .role != "assistant" and (.content | contains("do the task") or contains("first output") | not))
+          and any(.[]; .content | contains("keep going"))' "$WORK/stub/messages-1.json" >/dev/null; then
+    ok "Conversation resume does not reappend the old prompt, delivered output, or assistant turns"
+else
+    bad "Conversation resume does not reappend the old prompt, delivered output, or assistant turns"
+fi
+
+# Empty/unset is also resume, not a silent switch to a fresh response chain.
+resume_shellm continue
+rc=$?
+if [[ "$rc" == 0 && "$(cat "$WORK/stub/conversation-1")" == conv_created ]] \
+    && jq -e 'all(.[]; .role != "assistant" and (.content | contains("do the task") | not))' \
+        "$WORK/stub/messages-1.json" >/dev/null; then
+    ok "default environment resumes the Conversation and its sent-step acknowledgement"
+else
+    bad "default environment resumes the Conversation and its sent-step acknowledgement"
+fi
+
+checkpoint="$HEADLONG_HOME/trajectories/.responses-conversations/conv_created.json"
+mode=$(stat -c %a "$checkpoint" 2>/dev/null || stat -f %Lp "$checkpoint" 2>/dev/null)
+if [[ "$mode" == 600 ]] && jq -e '.state == "ready" and .version == 1
+    and (.sent | length > 0) and (.trajectory | endswith("trajectory.jsonl"))' "$checkpoint" >/dev/null; then
+    ok "durable acknowledgement is mode 0600 and binds the actual trajectory"
+else
+    bad "durable acknowledgement is mode 0600 and binds the actual trajectory"
+fi
+
+SHELLM_RESPONSES_CONVERSATION=conv_different resume_shellm continue
+rc=$?
+if [[ "$rc" == 0 && "$(cat "$WORK/stub/conversation-1")" == conv_different ]] \
+    && jq -e 'any(.[]; .content | contains("do the task")) and any(.[]; .role == "assistant")' \
+        "$WORK/stub/messages-1.json" >/dev/null; then
+    ok "a different Conversation receives the initial rendered history, not the old acknowledgement"
+else
+    bad "a different Conversation receives the initial rendered history, not the old acknowledgement"
+fi
+
+# The last execution output is genuinely unsent when an iteration limit ends
+# the run. It must survive resume even though earlier input was acknowledged.
+TEST_MAX_ITERATIONS=1 SHELLM_RESPONSES_CONVERSATION=conv_unsent run_shellm continue responses
+resume_shellm continue
+rc=$?
+if [[ "$rc" == 0 ]] && jq -e 'any(.[]; .content | contains("first output"))
+    and any(.[]; .content | contains("keep going"))
+    and all(.[]; .role != "assistant" and (.content | contains("do the task") | not))' \
+    "$WORK/stub/messages-1.json" >/dev/null; then
+    ok "resume preserves genuinely unsent last tool output"
+else
+    bad "resume preserves genuinely unsent last tool output"
+fi
+
+TEST_LOCK_PROBE=1 SHELLM_RESPONSES_CONVERSATION=conv_locked run_shellm continue responses
+rc=$?
+if [[ "$rc" == 0 && "$(cat "$WORK/stub/contender.rc")" != 0 \
+    && ! -e "$WORK/stub/contender/calls" ]] \
+    && cmp -s "$WORK/stub/checkpoint-before" "$WORK/stub/checkpoint-after" \
+    && jq -e '.state == "in_flight"' "$WORK/stub/checkpoint-before" >/dev/null; then
+    ok "a concurrent run cannot dispatch or overwrite the in-flight acknowledgement"
+else
+    bad "a concurrent run cannot dispatch or overwrite the in-flight acknowledgement"
+fi
+
+checkpoint="$HEADLONG_HOME/trajectories/.responses-conversations/conv_locked.json"
+trajectory=$(jq -r .trajectory "$checkpoint")
+jq -nc 'range(0;60) | {type:"observation",step_id:("padding-" + tostring)}' >> "$trajectory"
+TEST_RESUME_TARGET="$(basename "$(dirname "$trajectory")")" resume_shellm continue
+if [[ "$?" == 0 && "$(cat "$WORK/stub/conversation-1")" == conv_locked ]] \
+    && jq -e 'all(.[]; .content | contains("do the task") | not)' "$WORK/stub/messages-1.json" >/dev/null; then
+    ok "trajectory aliases and a header beyond the last 50 rows restore the same acknowledgement"
+else
+    bad "trajectory aliases and a header beyond the last 50 rows restore the same acknowledgement"
+fi
+
+cp "$checkpoint" "$WORK/checkpoint-locked"
+mkdir "${checkpoint%.json}.lock"
+resume_shellm continue
+if [[ "$?" != 0 && "$(main_calls)" == 0 && -d "${checkpoint%.json}.lock" ]] \
+    && cmp -s "$checkpoint" "$WORK/checkpoint-locked"; then
+    ok "a stale crash lock is never stolen or released by a contender"
+else
+    bad "a stale crash lock is never stolen or released by a contender"
+fi
+rmdir "${checkpoint%.json}.lock"
+
+LLM_PROVIDER=openai-compatible resume_shellm continue
+if [[ "$?" != 0 && "$(main_calls)" == 0 ]] && cmp -s "$checkpoint" "$WORK/checkpoint-locked"; then
+    ok "changing the effective provider cannot reuse or overwrite a Conversation acknowledgement"
+else
+    bad "changing the effective provider cannot reuse or overwrite a Conversation acknowledgement"
+fi
+
+LLM_STUB_DIR="$WORK/stub" LLM_STUB_MODE=continue SHELLM_API_FORMAT=responses \
+    SHELLM_RESPONSES_CONVERSATION=conv_locked "$WORK/toolbin/shellm" \
+    --workdir "$WORK/wd" --max-iterations 1 "another trajectory" \
+    </dev/null > "$WORK/out" 2> "$WORK/err"
+if [[ "$?" != 0 && "$(main_calls)" == 0 ]] && cmp -s "$checkpoint" "$WORK/checkpoint-locked"; then
+    ok "a different trajectory cannot overwrite a shared Conversation acknowledgement"
+else
+    bad "a different trajectory cannot overwrite a shared Conversation acknowledgement"
+fi
+
+SHELLM_RESPONSES_CONVERSATION=conv_unknown run_shellm no-terminal responses
+checkpoint="$HEADLONG_HOME/trajectories/.responses-conversations/conv_unknown.json"
+cp "$checkpoint" "$WORK/checkpoint-unknown"
+resume_shellm continue
+rc=$?
+if [[ "$rc" != 0 && "$(main_calls)" == 0 ]] \
+    && jq -e '.state == "in_flight" and .sent == {}' "$checkpoint" >/dev/null \
+    && cmp -s "$checkpoint" "$WORK/checkpoint-unknown"; then
+    ok "ambiguous delivery remains unacknowledged and resume fails closed without resending"
+else
+    bad "ambiguous delivery remains unacknowledged and resume fails closed without resending"
+fi
+
+SHELLM_RESPONSES_CONVERSATION=conv_missing run_shellm continue responses
+rm "$HEADLONG_HOME/trajectories/.responses-conversations/conv_missing.json"
+resume_shellm continue
+if [[ "$?" != 0 && "$(main_calls)" == 0 ]] && grep -q 'acknowledgement is missing' "$WORK/err"; then
+    ok "a missing acknowledgement for a previously used Conversation fails closed"
+else
+    bad "a missing acknowledgement for a previously used Conversation fails closed"
+fi
+
+SHELLM_RESPONSES_CONVERSATION=conv_nested run_shellm nested responses
+if [[ "$?" == 0 && "$(cat "$WORK/stub/child-state")" == '|||https' \
+    && -z "$(cat "$WORK/stub/summary-conversation")" ]]; then
+    ok "generated code and summaries do not silently share the parent's Conversation"
+else
+    bad "generated code and summaries do not silently share the parent's Conversation"
+fi
 
 # A literal id is used as given and never creates.
 rm -rf "$WORK/rstub"
@@ -661,10 +851,10 @@ fi
 SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 \
     run_shellm compactfail responses openrouter openai/o4-mini
 rc=$?
-if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 && "$(compact_calls)" -eq 1 ]] \
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 3 && "$(compact_calls)" -eq 1 ]] \
    && jq -e 'any(.[]; .encrypted_content == "enc_resp_1")' "$WORK/stub/messages-2.json" >/dev/null 2>&1 \
    && grep -q 'compaction failed' "$WORK/err"; then
-    ok "a failed compact call warns and keeps the replay chain"
+    ok "a failed compact call warns, keeps the chain, and is not repeated on later crossings"
 else
     bad "a failed compact call warns and keeps the replay chain" "rc=$rc calls=$(main_calls) compacts=$(compact_calls) stderr=$(tail -5 "$WORK/err" | tr '\n' ' ')"
 fi
@@ -718,6 +908,94 @@ if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 && "$(compact_calls)" -eq 0 ]] \
     ok "a compaction item in a terminal output truncates the replay chain"
 else
     bad "a compaction item in a terminal output truncates the replay chain" "rc=$rc calls=$(main_calls) compacts=$(compact_calls) m2=$(jq -c 'map(.type // .role)' "$WORK/stub/messages-2.json" 2>/dev/null)"
+fi
+
+run_shellm multiple-compactions responses openrouter openai/o4-mini
+if [[ "$?" == 0 ]] && jq -e '.[0].id == "cmp_resp_2"
+    and all(.[]; .id != "cmp_resp_1" and .id != "msg_resp_1")
+    and any(.[]; .content? | strings | contains("second"))' "$WORK/stub/messages-3.json" >/dev/null; then
+    ok "repeated server compaction prunes to the most recent marker"
+else
+    bad "repeated server compaction prunes to the most recent marker"
+fi
+
+SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 run_shellm compact-window responses openrouter openai/o4-mini
+if [[ "$?" == 0 ]] && jq -e '.[0:3] == [{role:"user",content:"retained prefix"},
+    {type:"compaction",encrypted_content:"canonical"},{role:"user",content:"retained suffix"}]' \
+    "$WORK/stub/messages-2.json" >/dev/null; then
+    ok "standalone compact.output is preserved as-is including items before the marker"
+else
+    bad "standalone compact.output is preserved as-is including items before the marker"
+fi
+if [[ "$(cat "$WORK/stub/compact-provider-1")" == openrouter \
+    && -s "$WORK/stub/compact-instructions-1" ]]; then
+    ok "standalone lifecycle call names the effective provider and supplies system instructions"
+else
+    bad "standalone lifecycle call names the effective provider and supplies system instructions"
+fi
+
+printf '%s\n' '{"store":false}' > "$WORK/body.json"
+SHELLM_RESPONSES_BODY_FILE="$WORK/body.json" SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 \
+    run_shellm stateful-compact responses openai
+if [[ "$?" == 0 && "$(compact_calls)" == 0 \
+    && "$(cat "$WORK/stub/threshold-1")" == 1000 && "$(cat "$WORK/stub/threshold-2")" == 1000 \
+    && -z "$(cat "$WORK/stub/previous-2")" ]] \
+    && jq -e 'any(.[]; .encrypted_content == "enc_resp_1")' "$WORK/stub/messages-2.json" >/dev/null; then
+    ok "native OpenAI store=false uses stateless replay with server compaction"
+else
+    bad "native OpenAI store=false uses stateless replay with server compaction"
+fi
+
+SHELLM_RESPONSES_COMPACT_MODE=server SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 \
+    run_shellm stateful-compact responses openai-compatible
+if [[ "$?" == 0 && "$(compact_calls)" == 0 && "$(cat "$WORK/stub/threshold-1")" == 1000 ]]; then
+    ok "a compatible endpoint can explicitly declare server compaction support"
+else
+    bad "a compatible endpoint can explicitly declare server compaction support"
+fi
+
+for body in '{"conversation":"conv_body"}' '{"conversation":{"id":"conv_body"}}'; do
+    printf '%s\n' "$body" > "$WORK/body.json"
+    rm -rf "$WORK/rstub"
+    SHELLM_RESPONSES_BODY_FILE="$WORK/body.json" SHELLM_RESPONSES_CONVERSATION=new \
+        run_shellm continue responses
+    if [[ "$?" != 0 && "$(main_calls)" == 0 && "$(create_calls)" == 0 ]] \
+        && grep -q 'use SHELLM_RESPONSES_CONVERSATION' "$WORK/err"; then
+        ok "body-file Conversation is refused before spending: $body"
+    else
+        bad "body-file Conversation is refused before spending: $body"
+    fi
+done
+
+# Exercise the actual upkeep function without a model, so elapsed completion
+# time can be pinned rather than relying on slow wall-clock test fixtures.
+if (
+    eval "$(sed -n '/^compact_replay_chain() {/,/^}/p' "$REPO/bin/shellm")"
+    progress() { :; }
+    responses() { printf '%s' "$LLM_MAX_TIME" > "$WORK/compact-budget"; printf '{"output":[{"type":"compaction"}]}'; }
+    _SHELLM_COMPACT_MODE=standalone
+    _SHELLM_HOST_PROVIDER=openai
+    # Used by the sourced upkeep function above.
+    # shellcheck disable=SC2034
+    SHELLM_RESPONSES_COMPACT_THRESHOLD=10
+    # shellcheck disable=SC2034
+    system_prompt="test"
+    mkdir -p "$WORK/compact-deadline"
+    replay="$WORK/compact-deadline/replay"
+    printf '[]' > "$replay"
+    printf '{"usage":{"input_tokens":100}}' > "$WORK/compact-response"
+    LLM_MAX_TIME=1
+    _call_started=$((SECONDS-2))
+    compact_replay_chain "$replay" "$WORK/compact-response" 1
+    [[ ! -e "$WORK/compact-budget" ]] || exit 1
+    LLM_MAX_TIME=100
+    _call_started=$((SECONDS-5))
+    compact_replay_chain "$replay" "$WORK/compact-response" 1
+    [[ "$(cat "$WORK/compact-budget")" -gt 0 && "$(cat "$WORK/compact-budget")" -le 95 ]]
+); then
+    ok "standalone compaction only spends remaining completion deadline budget"
+else
+    bad "standalone compaction only spends remaining completion deadline budget"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -67,7 +67,7 @@ write_response() {
 }
 
 case "$LLM_STUB_MODE:$n" in
-    continue:1|fallback:1|stateless:1)
+    continue:1|fallback:1|stateless:1|unknown:1)
         write_response resp_1
         printf '%s\n' '```bash' 'printf "first output\n"' '```'
         ;;
@@ -78,6 +78,10 @@ case "$LLM_STUB_MODE:$n" in
     fallback:2)
         ( umask 077; printf '%s' '{"error":{"message":"previous response is unavailable","param":"previous_response_id","code":"previous_response_not_found"}}' > "$LLM_RESPONSE_FILE" )
         printf '%s\n' 'llm: error: API error (HTTP 400): previous response is unavailable' >&2
+        exit 1
+        ;;
+    unknown:2)
+        ( umask 077; printf '%s' '{"error":{"message":"transport lost while continuing previous response","code":"outcome_unknown"}}' > "$LLM_RESPONSE_FILE" )
         exit 1
         ;;
     partial:1)
@@ -316,6 +320,17 @@ if ! grep -q 'step_ids' "$WORK/stub"/messages-*.json; then
     ok "row ids never reach the provider"
 else
     bad "row ids never reach the provider" "$(grep -l 'step_ids' "$WORK/stub"/messages-*.json | tr '\n' ' ')"
+fi
+
+# Mentioning a previous response in an unknown-outcome diagnostic is not
+# evidence of a pre-generation rejection.
+run_shellm unknown responses
+rc=$?
+if [[ "$rc" -ne 0 && "$(main_calls)" -eq 2 ]] \
+   && ! grep -q 'retrying once with exact replay' "$WORK/err"; then
+    ok "unknown continuation outcome never falls back to a new create"
+else
+    bad "unknown continuation outcome never falls back to a new create" "rc=$rc calls=$(main_calls)"
 fi
 
 # A rejection can only precede generation. An error naming

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -38,6 +38,7 @@ printf '%s\n' "$n" > "$LLM_STUB_DIR/calls"
 printf '%s\n' "${LLM_API_FORMAT:-}" > "$LLM_STUB_DIR/format-$n"
 printf '%s\n' "${LLM_PREVIOUS_RESPONSE_ID:-}" > "$LLM_STUB_DIR/previous-$n"
 printf '%s\n' "${LLM_RESPONSES_BACKGROUND-unset}" > "$LLM_STUB_DIR/background-$n"
+printf '%s\n' "${LLM_RESPONSES_COMPACT_THRESHOLD-unset}" > "$LLM_STUB_DIR/threshold-$n"
 printf '%s\n' "${LLM_RESPONSE_FILE:-}" > "$LLM_STUB_DIR/response-file-$n"
 [[ -n "$messages_file" ]] && cp "$messages_file" "$LLM_STUB_DIR/messages-$n.json"
 if [[ -n "${LLM_RESPONSE_FILE:-}" ]]; then
@@ -67,7 +68,57 @@ write_response() {
     }' > "$LLM_RESPONSE_FILE" )
 }
 
+# Same terminal object plus a usage block, so the caller can drive shellm's
+# compaction threshold from the reported input tokens.
+write_response_usage() {
+    local id="$1" input_tokens="$2"
+    [[ -n "${LLM_RESPONSE_FILE:-}" ]] || return 0
+    ( umask 077; jq -nc --arg id "$id" --argjson in_tok "$input_tokens" '{
+        id: $id,
+        object: "response",
+        status: "completed",
+        output: [
+            {id:("rs_" + $id), type:"reasoning", summary:[], encrypted_content:("enc_" + $id)},
+            {id:("msg_" + $id), type:"message", role:"assistant", status:"completed", phase:"final_answer", content:[{type:"output_text", text:("text_" + $id)}]}
+        ],
+        usage: {input_tokens: $in_tok, output_tokens: 4}
+    }' > "$LLM_RESPONSE_FILE" )
+}
+
+# A turn the server compacted for us: the terminal output carries a compaction
+# item, and everything before it is no longer part of the next window.
+write_response_server_compacted() {
+    local id="$1"
+    [[ -n "${LLM_RESPONSE_FILE:-}" ]] || return 0
+    ( umask 077; jq -nc --arg id "$id" '{
+        id: $id,
+        object: "response",
+        status: "completed",
+        output: [
+            {id:("rs_" + $id), type:"reasoning", summary:[], encrypted_content:("enc_" + $id)},
+            {id:"cmp_server", type:"compaction", encrypted_content:"enc_server_compaction"},
+            {id:("msg_" + $id), type:"message", role:"assistant", status:"completed", phase:"final_answer", content:[{type:"output_text", text:("text_" + $id)}]}
+        ]
+    }' > "$LLM_RESPONSE_FILE" )
+}
+
 case "$LLM_STUB_MODE:$n" in
+    compact:1|compactfail:1|stateful-compact:1)
+        write_response_usage resp_1 9000
+        printf '%s\n' '```bash' 'printf "first output\n"' '```'
+        ;;
+    compact:2|compactfail:2|stateful-compact:2)
+        write_response_usage resp_2 10
+        printf '%s\n' '```bash' 'FINAL=done-after-compaction' '```'
+        ;;
+    server-compaction:1)
+        write_response_server_compacted resp_1
+        printf '%s\n' '```bash' 'printf "first output\n"' '```'
+        ;;
+    server-compaction:2)
+        write_response resp_2
+        printf '%s\n' '```bash' 'FINAL=done-after-server-compaction' '```'
+        ;;
     continue:1|fallback:1|stateless:1)
         write_response resp_1
         printf '%s\n' '```bash' 'printf "first output\n"' '```'
@@ -145,6 +196,38 @@ esac
 STUB
 chmod +x "$WORK/toolbin/llm"
 
+# The compaction endpoint, stubbed. It records the window it was handed and
+# answers with the canonical next window: one compaction item, nothing else.
+cat > "$WORK/toolbin/responses" <<'STUB'
+#!/usr/bin/env bash
+[[ "${1:-}" == compact ]] || { echo "unexpected responses command ${1:-}" >&2; exit 2; }
+n=0
+[[ -f "$LLM_STUB_DIR/compact-calls" ]] && read -r n < "$LLM_STUB_DIR/compact-calls"
+n=$((n + 1))
+printf '%s\n' "$n" > "$LLM_STUB_DIR/compact-calls"
+model=""
+input_file=""
+prev=""
+for arg in "$@"; do
+    [[ "$prev" == --model ]] && model="$arg"
+    [[ "$prev" == --input-file ]] && input_file="$arg"
+    prev="$arg"
+done
+printf '%s\n' "$model" > "$LLM_STUB_DIR/compact-model-$n"
+[[ -n "$input_file" ]] && cp "$input_file" "$LLM_STUB_DIR/compact-input-$n.json"
+if [[ "$LLM_STUB_MODE" == compactfail ]]; then
+    echo "responses: error: compaction is unavailable" >&2
+    exit 1
+fi
+jq -nc '{
+    id: "resp_compacted",
+    object: "response",
+    status: "completed",
+    output: [{id: "cmp_1", type: "compaction", encrypted_content: "enc_compacted"}]
+}'
+STUB
+chmod +x "$WORK/toolbin/responses"
+
 export PATH="$WORK/toolbin:$PATH"
 export HOME="$WORK/home"
 export HEADLONG_HOME="$WORK/home/.headlong"
@@ -165,6 +248,7 @@ run_shellm() {
 }
 
 main_calls() { cat "$WORK/stub/calls" 2>/dev/null || echo 0; }
+compact_calls() { cat "$WORK/stub/compact-calls" 2>/dev/null || echo 0; }
 
 # A successful terminal response becomes the next request's continuation ID;
 # only the messages after the last assistant turn are sent as new input.
@@ -396,6 +480,108 @@ if [[ "$rc" -eq 0 && "$(cat "$WORK/stub/format-1")" == chat \
     ok "default chat mode remains stateless"
 else
     bad "default chat mode remains stateless" "rc=$rc format=$(cat "$WORK/stub/format-1")"
+fi
+
+# Compaction in replay mode. Once a terminal response reports input tokens at
+# or above the threshold, shellm compacts the chain itself and the next request
+# opens with the window the compact endpoint returned, nothing before it.
+SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 \
+    run_shellm compact responses openrouter openai/o4-mini
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 && "$(compact_calls)" -eq 1 \
+      && "$(cat "$WORK/stub/compact-model-1")" == openai/o4-mini ]]; then
+    ok "a crossed compaction threshold compacts the replay chain once"
+else
+    bad "a crossed compaction threshold compacts the replay chain once" "rc=$rc calls=$(main_calls) compacts=$(compact_calls) model=$(cat "$WORK/stub/compact-model-1" 2>/dev/null) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
+fi
+
+if jq -e '
+    .[0].type == "compaction" and .[0].encrypted_content == "enc_compacted" and
+    all(.[]; .encrypted_content != "enc_resp_1") and
+    any(.[]; .role == "user" and (.content | contains("first output")))
+' "$WORK/stub/messages-2.json" >/dev/null 2>&1; then
+    ok "the compacted window replaces the chain and opens the next request"
+else
+    bad "the compacted window replaces the chain and opens the next request" "$(jq -c 'map(if .content? then (.content |= (. | tostring)[0:40]) else . end)' "$WORK/stub/messages-2.json" 2>/dev/null)"
+fi
+
+if jq -e '
+    any(.[]; .encrypted_content == "enc_resp_1") and
+    any(.[]; .role == "user" and (.content | contains("do the task")))
+' "$WORK/stub/compact-input-1.json" >/dev/null 2>&1; then
+    ok "the compact call is handed the whole replay chain"
+else
+    bad "the compact call is handed the whole replay chain" "$(jq -c 'map(.type // .role)' "$WORK/stub/compact-input-1.json" 2>/dev/null)"
+fi
+
+if grep -q 'compacting the Responses replay chain' "$WORK/err"; then
+    ok "compaction logs one progress line"
+else
+    bad "compaction logs one progress line" "stderr=$(tail -5 "$WORK/err" | tr '\n' ' ')"
+fi
+
+# A compact call that fails is not fatal: the chain is kept exactly as it was
+# and the run carries on.
+SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 \
+    run_shellm compactfail responses openrouter openai/o4-mini
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 && "$(compact_calls)" -eq 1 ]] \
+   && jq -e 'any(.[]; .encrypted_content == "enc_resp_1")' "$WORK/stub/messages-2.json" >/dev/null 2>&1 \
+   && grep -q 'compaction failed' "$WORK/err"; then
+    ok "a failed compact call warns and keeps the replay chain"
+else
+    bad "a failed compact call warns and keeps the replay chain" "rc=$rc calls=$(main_calls) compacts=$(compact_calls) stderr=$(tail -5 "$WORK/err" | tr '\n' ' ')"
+fi
+
+# Stateful mode leaves compaction to the server: llm gets the threshold and
+# shellm never calls the compact endpoint.
+SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 run_shellm stateful-compact responses
+rc=$?
+if [[ "$rc" -eq 0 && "$(compact_calls)" -eq 0 \
+      && "$(cat "$WORK/stub/threshold-1")" == 1000 \
+      && "$(cat "$WORK/stub/threshold-2")" == 1000 ]]; then
+    ok "stateful mode passes the threshold to llm and compacts nothing itself"
+else
+    bad "stateful mode passes the threshold to llm and compacts nothing itself" "rc=$rc compacts=$(compact_calls) t1=$(cat "$WORK/stub/threshold-1" 2>/dev/null) t2=$(cat "$WORK/stub/threshold-2" 2>/dev/null)"
+fi
+
+SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 \
+    run_shellm compact responses openrouter openai/o4-mini
+if [[ "$(cat "$WORK/stub/threshold-1")" == unset ]]; then
+    ok "replay mode compacts locally and does not ask llm for server compaction"
+else
+    bad "replay mode compacts locally and does not ask llm for server compaction" "t1=$(cat "$WORK/stub/threshold-1" 2>/dev/null)"
+fi
+
+run_shellm continue responses
+if [[ "$(cat "$WORK/stub/threshold-1")" == unset ]]; then
+    ok "an unset compaction threshold reaches llm as unset"
+else
+    bad "an unset compaction threshold reaches llm as unset" "t1=$(cat "$WORK/stub/threshold-1" 2>/dev/null)"
+fi
+
+SHELLM_RESPONSES_COMPACT_THRESHOLD=lots "$WORK/toolbin/shellm" --help \
+    > "$WORK/out" 2> "$WORK/err"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'Invalid SHELLM_RESPONSES_COMPACT_THRESHOLD' "$WORK/err"; then
+    ok "an invalid compaction threshold fails through shellm's error contract"
+else
+    bad "an invalid compaction threshold fails through shellm's error contract" "rc=$rc stderr=$(cat "$WORK/err")"
+fi
+
+# Server-side compaction inside an ordinary turn: the terminal output carries a
+# compaction item, so the chain is cut back to it with no threshold set and no
+# compact call of our own.
+run_shellm server-compaction responses openrouter openai/o4-mini
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 && "$(compact_calls)" -eq 0 ]] \
+   && jq -e '
+        .[0].type == "compaction" and .[0].encrypted_content == "enc_server_compaction" and
+        all(.[]; .encrypted_content != "enc_resp_1")
+   ' "$WORK/stub/messages-2.json" >/dev/null 2>&1; then
+    ok "a compaction item in a terminal output truncates the replay chain"
+else
+    bad "a compaction item in a terminal output truncates the replay chain" "rc=$rc calls=$(main_calls) compacts=$(compact_calls) m2=$(jq -c 'map(.type // .role)' "$WORK/stub/messages-2.json" 2>/dev/null)"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -38,6 +38,7 @@ printf '%s\n' "$n" > "$LLM_STUB_DIR/calls"
 printf '%s\n' "${LLM_API_FORMAT:-}" > "$LLM_STUB_DIR/format-$n"
 printf '%s\n' "${LLM_PREVIOUS_RESPONSE_ID:-}" > "$LLM_STUB_DIR/previous-$n"
 printf '%s\n' "${LLM_RESPONSES_BACKGROUND-unset}" > "$LLM_STUB_DIR/background-$n"
+printf '%s\n' "${LLM_RESPONSES_CONVERSATION-unset}" > "$LLM_STUB_DIR/conversation-$n"
 printf '%s\n' "${LLM_RESPONSE_FILE:-}" > "$LLM_STUB_DIR/response-file-$n"
 [[ -n "$messages_file" ]] && cp "$messages_file" "$LLM_STUB_DIR/messages-$n.json"
 if [[ -n "${LLM_RESPONSE_FILE:-}" ]]; then
@@ -145,6 +146,25 @@ esac
 STUB
 chmod +x "$WORK/toolbin/llm"
 
+# bin/responses is the lifecycle tool shellm asks for a conversation. The stub
+# records the create call and can refuse it, so the fail-closed path is
+# exercised without a network.
+cat > "$WORK/toolbin/responses" <<'STUB'
+#!/usr/bin/env bash
+mkdir -p "$RESPONSES_STUB_DIR"
+n=0
+[[ -f "$RESPONSES_STUB_DIR/creates" ]] && read -r n < "$RESPONSES_STUB_DIR/creates"
+n=$((n + 1))
+printf '%s\n' "$n" > "$RESPONSES_STUB_DIR/creates"
+printf '%s\n' "$@" > "$RESPONSES_STUB_DIR/create-args-$n"
+if [[ "${RESPONSES_STUB_MODE:-ok}" == reject ]]; then
+    printf '%s\n' 'responses: error: Conversation not found' >&2
+    exit 1
+fi
+printf '%s\n' '{"id":"conv_created","object":"conversation","created_at":1}'
+STUB
+chmod +x "$WORK/toolbin/responses"
+
 export PATH="$WORK/toolbin:$PATH"
 export HOME="$WORK/home"
 export HEADLONG_HOME="$WORK/home/.headlong"
@@ -165,6 +185,26 @@ run_shellm() {
 }
 
 main_calls() { cat "$WORK/stub/calls" 2>/dev/null || echo 0; }
+create_calls() { cat "$WORK/rstub/creates" 2>/dev/null || echo 0; }
+export RESPONSES_STUB_DIR="$WORK/rstub"
+
+# Resume the run just made: same trajectory and the same create counter, so a
+# reused conversation shows up as a second run without a second create.
+resume_shellm() {
+    local mode="$1"
+    rm -rf "$WORK/stub"
+    mkdir -p "$WORK/stub"
+    LLM_STUB_DIR="$WORK/stub" LLM_STUB_MODE="$mode" SHELLM_API_FORMAT=responses \
+        SHELLM_RESPONSES_CONVERSATION="${SHELLM_RESPONSES_CONVERSATION:-}" \
+        "$WORK/toolbin/shellm" --resume --workdir "$WORK/wd" --max-iterations 3 "keep going" \
+        > "$WORK/out" 2> "$WORK/err" < /dev/null
+}
+
+# The shellm-run header row of the only trajectory this test wrote.
+run_header() {
+    cat "$HEADLONG_HOME"/trajectories/*/trajectory.jsonl 2>/dev/null \
+        | jq -cR 'fromjson? | select(.type == "shellm-run")' 2>/dev/null | tail -1
+}
 
 # A successful terminal response becomes the next request's continuation ID;
 # only the messages after the last assistant turn are sent as new input.
@@ -385,6 +425,99 @@ if [[ "$rc" -ne 0 ]] && grep -q 'Invalid SHELLM_RESPONSES_BACKGROUND' "$WORK/err
     ok "an invalid SHELLM_RESPONSES_BACKGROUND fails through shellm's error contract"
 else
     bad "an invalid SHELLM_RESPONSES_BACKGROUND fails through shellm's error contract" "rc=$rc stderr=$(cat "$WORK/err")"
+fi
+
+# Conversation mode moves the history to the server: shellm creates one at
+# run start, every call names it, and no response-id chain is kept.
+rm -rf "$WORK/rstub"
+SHELLM_RESPONSES_CONVERSATION=new run_shellm continue responses
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 && "$(create_calls)" -eq 1 \
+      && "$(cat "$WORK/stub/conversation-1")" == conv_created \
+      && "$(cat "$WORK/stub/conversation-2")" == conv_created \
+      && -z "$(cat "$WORK/stub/previous-1")" \
+      && -z "$(cat "$WORK/stub/previous-2")" \
+      && ! -e "$WORK/stub/id-value-2" ]]; then
+    ok "SHELLM_RESPONSES_CONVERSATION=new carries one conversation and no previous id"
+else
+    bad "SHELLM_RESPONSES_CONVERSATION=new carries one conversation and no previous id" "rc=$rc calls=$(main_calls) creates=$(create_calls) conv1=$(cat "$WORK/stub/conversation-1" 2>/dev/null) conv2=$(cat "$WORK/stub/conversation-2" 2>/dev/null) prev2=$(cat "$WORK/stub/previous-2" 2>/dev/null) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
+fi
+
+if grep -q 'conversations' "$WORK/rstub/create-args-1" \
+   && grep -q '^create$' "$WORK/rstub/create-args-1" \
+   && grep -q '^--metadata$' "$WORK/rstub/create-args-1"; then
+    ok "the conversation is created through bin/responses"
+else
+    bad "the conversation is created through bin/responses" "$(tr '\n' ' ' < "$WORK/rstub/create-args-1" 2>/dev/null)"
+fi
+
+if [[ "$(run_header | jq -r '.conversation // empty')" == conv_created ]]; then
+    ok "the conversation id is durable in the shellm-run header row"
+else
+    bad "the conversation id is durable in the shellm-run header row" "$(run_header)"
+fi
+
+if jq -e 'length == 1 and .[0].role == "user" and (.[0].content | contains("first output"))' \
+        "$WORK/stub/messages-2.json" >/dev/null 2>&1; then
+    ok "conversation mode sends only the new rows on later calls"
+else
+    bad "conversation mode sends only the new rows on later calls" "$(jq -c 'map(.content |= .[0:60])' "$WORK/stub/messages-2.json" 2>/dev/null)"
+fi
+
+# Resuming a run whose header carries a conversation reuses it: the operator
+# still says "new", and the durable id is what "new" resolves to.
+SHELLM_RESPONSES_CONVERSATION=new resume_shellm continue
+rc=$?
+if [[ "$rc" -eq 0 && "$(create_calls)" -eq 1 \
+      && "$(cat "$WORK/stub/conversation-1")" == conv_created ]]; then
+    ok "a resumed run reuses the conversation from its header instead of creating one"
+else
+    bad "a resumed run reuses the conversation from its header instead of creating one" "rc=$rc creates=$(create_calls) conv1=$(cat "$WORK/stub/conversation-1" 2>/dev/null) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
+fi
+
+# A literal id is used as given and never creates.
+rm -rf "$WORK/rstub"
+SHELLM_RESPONSES_CONVERSATION=conv_given run_shellm continue responses
+rc=$?
+if [[ "$rc" -eq 0 && "$(create_calls)" -eq 0 \
+      && "$(cat "$WORK/stub/conversation-1")" == conv_given \
+      && "$(run_header | jq -r '.conversation // empty')" == conv_given ]]; then
+    ok "a literal conversation id skips the create and is recorded as given"
+else
+    bad "a literal conversation id skips the create and is recorded as given" "rc=$rc creates=$(create_calls) conv1=$(cat "$WORK/stub/conversation-1" 2>/dev/null) header=$(run_header)"
+fi
+
+# Server state the operator asked for has no safe local substitute, so a
+# refused create ends the run before it spends a token.
+rm -rf "$WORK/rstub"
+RESPONSES_STUB_MODE=reject SHELLM_RESPONSES_CONVERSATION=new \
+    run_shellm continue responses
+rc=$?
+if [[ "$rc" -ne 0 && "$(main_calls)" -eq 0 ]] \
+   && grep -q 'could not create a Responses conversation' "$WORK/err" \
+   && grep -q 'Conversation not found' "$WORK/err"; then
+    ok "a refused conversation fails closed with the provider's message"
+else
+    bad "a refused conversation fails closed with the provider's message" "rc=$rc calls=$(main_calls) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
+fi
+
+SHELLM_RESPONSES_CONVERSATION=new SHELLM_API_FORMAT=chat \
+    "$WORK/toolbin/shellm" --help > "$WORK/out" 2> "$WORK/err"
+rc=$?
+if [[ "$rc" -ne 0 ]] \
+   && grep -q 'SHELLM_RESPONSES_CONVERSATION needs SHELLM_API_FORMAT=responses' "$WORK/err"; then
+    ok "a conversation under chat fails through shellm's error contract"
+else
+    bad "a conversation under chat fails through shellm's error contract" "rc=$rc stderr=$(cat "$WORK/err")"
+fi
+
+SHELLM_RESPONSES_CONVERSATION=resp_1 SHELLM_API_FORMAT=responses \
+    "$WORK/toolbin/shellm" --help > "$WORK/out" 2> "$WORK/err"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'Invalid SHELLM_RESPONSES_CONVERSATION' "$WORK/err"; then
+    ok "an id that is not a conversation is refused before the run starts"
+else
+    bad "an id that is not a conversation is refused before the run starts" "rc=$rc stderr=$(cat "$WORK/err")"
 fi
 
 # Default chat mode does not create or pass Responses state.

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# test_shellm_responses_continuation.sh — persisted Responses continuation and
+# one-time full-context fallback in shellm.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+mkdir -p "$WORK/home" "$WORK/wd"
+cp -R "$REPO/bin" "$WORK/toolbin"
+cat > "$WORK/toolbin/llm" <<'STUB'
+#!/usr/bin/env bash
+main_loop=0
+messages_file=""
+prev=""
+for arg in "$@"; do
+    [[ "$arg" == --thinking ]] && main_loop=1
+    [[ "$prev" == --messages-file ]] && messages_file="$arg"
+    prev="$arg"
+done
+if [[ "$main_loop" -ne 1 ]]; then
+    printf '{}\n'
+    exit 0
+fi
+
+n=0
+[[ -f "$LLM_STUB_DIR/calls" ]] && read -r n < "$LLM_STUB_DIR/calls"
+n=$((n + 1))
+printf '%s\n' "$n" > "$LLM_STUB_DIR/calls"
+printf '%s\n' "${LLM_API_FORMAT:-}" > "$LLM_STUB_DIR/format-$n"
+printf '%s\n' "${LLM_PREVIOUS_RESPONSE_ID:-}" > "$LLM_STUB_DIR/previous-$n"
+printf '%s\n' "${LLM_RESPONSE_FILE:-}" > "$LLM_STUB_DIR/response-file-$n"
+[[ -n "$messages_file" ]] && cp "$messages_file" "$LLM_STUB_DIR/messages-$n.json"
+if [[ -n "${LLM_RESPONSE_FILE:-}" ]]; then
+    state_dir=$(dirname "$LLM_RESPONSE_FILE")
+    if [[ -f "$state_dir/.response-id" ]]; then
+        cp "$state_dir/.response-id" "$LLM_STUB_DIR/id-value-$n"
+        (stat -c %a "$state_dir/.response-id" 2>/dev/null \
+            || stat -f %Lp "$state_dir/.response-id" 2>/dev/null) \
+            > "$LLM_STUB_DIR/id-mode-$n"
+    fi
+    [[ -e "$state_dir/.continuation-disabled" ]] \
+        && printf 'yes\n' > "$LLM_STUB_DIR/disabled-$n" \
+        || printf 'no\n' > "$LLM_STUB_DIR/disabled-$n"
+fi
+
+write_response() {
+    local id="$1"
+    [[ -n "${LLM_RESPONSE_FILE:-}" ]] || return 0
+    ( umask 077; jq -nc --arg id "$id" '{
+        id: $id,
+        object: "response",
+        status: "completed",
+        output: [
+            {id:("rs_" + $id), type:"reasoning", summary:[], encrypted_content:("enc_" + $id)},
+            {id:("msg_" + $id), type:"message", role:"assistant", status:"completed", phase:"final_answer", content:[{type:"output_text", text:("text_" + $id)}]}
+        ]
+    }' > "$LLM_RESPONSE_FILE" )
+}
+
+case "$LLM_STUB_MODE:$n" in
+    continue:1|fallback:1|stateless:1)
+        write_response resp_1
+        printf '%s\n' '```bash' 'printf "first output\n"' '```'
+        ;;
+    continue:2|stateless:2)
+        write_response resp_2
+        printf '%s\n' '```bash' 'FINAL=done' '```'
+        ;;
+    fallback:2)
+        ( umask 077; printf '%s' '{"error":{"message":"previous response is unavailable","param":"previous_response_id","code":"previous_response_not_found"}}' > "$LLM_RESPONSE_FILE" )
+        printf '%s\n' 'llm: error: API error (HTTP 400): previous response is unavailable' >&2
+        exit 1
+        ;;
+    fallback:3)
+        write_response resp_3
+        printf '%s\n' '```bash' 'FINAL=done-after-fallback' '```'
+        ;;
+    chat:1)
+        [[ -z "${LLM_RESPONSE_FILE:-}" ]] || { echo "chat unexpectedly received LLM_RESPONSE_FILE" >&2; exit 2; }
+        printf '%s\n' '```bash' 'FINAL=chat-done' '```'
+        ;;
+    *)
+        echo "unexpected stub call $LLM_STUB_MODE:$n" >&2
+        exit 2
+        ;;
+esac
+STUB
+chmod +x "$WORK/toolbin/llm"
+
+export PATH="$WORK/toolbin:$PATH"
+export HOME="$WORK/home"
+export HEADLONG_HOME="$WORK/home/.headlong"
+export OPENAI_API_KEY="test-key"
+export OPENROUTER_API_KEY="test-router-key"
+export SHELLM_MODEL="gpt-5-test"
+export SHELLM_ENV=local
+export SHELLM_NO_BANNER=1
+
+run_shellm() {
+    local mode="$1" format="$2" provider="${3:-}" model="${4:-gpt-5-test}"
+    rm -rf "$WORK/stub" "$HEADLONG_HOME" "$WORK/wd"/*
+    mkdir -p "$WORK/stub" "$WORK/wd"
+    LLM_STUB_DIR="$WORK/stub" LLM_STUB_MODE="$mode" SHELLM_API_FORMAT="$format" \
+        LLM_PROVIDER="$provider" SHELLM_MODEL="$model" \
+        "$WORK/toolbin/shellm" --workdir "$WORK/wd" --max-iterations 3 "do the task" \
+        > "$WORK/out" 2> "$WORK/err" < /dev/null
+}
+
+main_calls() { cat "$WORK/stub/calls" 2>/dev/null || echo 0; }
+
+# A successful terminal response becomes the next request's continuation ID;
+# only the messages after the last assistant turn are sent as new input.
+run_shellm continue responses
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 && "$(cat "$WORK/stub/previous-2")" == resp_1 ]]; then
+    ok "later shellm iterations use the persisted previous_response_id"
+else
+    bad "later shellm iterations use the persisted previous_response_id" "rc=$rc calls=$(main_calls) previous=$(cat "$WORK/stub/previous-2" 2>/dev/null)"
+fi
+
+if [[ "$(cat "$WORK/stub/format-1")" == responses && -n "$(cat "$WORK/stub/response-file-1")" ]]; then
+    ok "shellm opts llm into Responses and requests a terminal sidecar"
+else
+    bad "shellm opts llm into Responses and requests a terminal sidecar"
+fi
+
+if jq -e 'length == 1 and .[0].role == "user" and (. [0].content | contains("first output"))' \
+        "$WORK/stub/messages-2.json" >/dev/null 2>&1; then
+    ok "continuation sends only input after the last assistant turn"
+else
+    bad "continuation sends only input after the last assistant turn" "$(jq -c . "$WORK/stub/messages-2.json" 2>/dev/null)"
+fi
+
+if [[ "$(cat "$WORK/stub/id-value-2" 2>/dev/null)" == resp_1 \
+    && "$(cat "$WORK/stub/id-mode-2" 2>/dev/null)" == 600 ]]; then
+    ok "successful Response ID persists in mode-600 process state"
+else
+    bad "successful Response ID persists in mode-600 process state" "value=$(cat "$WORK/stub/id-value-2" 2>/dev/null) mode=$(cat "$WORK/stub/id-mode-2" 2>/dev/null)"
+fi
+
+# A provider rejection tied to previous_response_id clears continuation and
+# retries once with the exact replay chain. It then stays disabled so the next
+# iteration cannot enter a fallback loop.
+run_shellm fallback responses
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 3 \
+      && "$(cat "$WORK/stub/previous-2")" == resp_1 \
+      && -z "$(cat "$WORK/stub/previous-3")" ]]; then
+    ok "rejected continuation retries once without previous_response_id"
+else
+    bad "rejected continuation retries once without previous_response_id" "rc=$rc calls=$(main_calls) prev2=$(cat "$WORK/stub/previous-2" 2>/dev/null) prev3=$(cat "$WORK/stub/previous-3" 2>/dev/null)"
+fi
+
+if jq -e '
+    length >= 4 and
+    any(.role == "user" and (.content | contains("do the task"))) and
+    any(.type == "reasoning" and .encrypted_content == "enc_resp_1") and
+    any(.type == "message" and .role == "assistant" and .phase == "final_answer") and
+    any(.role == "user" and (.content | contains("first output")))
+' "$WORK/stub/messages-3.json" >/dev/null 2>&1; then
+    ok "continuation fallback replays exact typed Responses items"
+else
+    bad "continuation fallback replays exact typed Responses items" "$(jq -c . "$WORK/stub/messages-3.json" 2>/dev/null)"
+fi
+
+if [[ ! -e "$WORK/stub/id-value-3" \
+    && "$(cat "$WORK/stub/disabled-3" 2>/dev/null)" == yes ]] \
+    && grep -q 'retrying once with exact replay context' "$WORK/err"; then
+    ok "fallback clears persisted continuation state and disables reuse"
+else
+    bad "fallback clears persisted continuation state and disables reuse" "id=$(cat "$WORK/stub/id-value-3" 2>/dev/null) disabled=$(cat "$WORK/stub/disabled-3" 2>/dev/null) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
+fi
+
+# OpenRouter documents its Responses endpoint as stateless. It must replay
+# exact output items from the first turn without first paying for a rejected
+# previous_response_id request.
+run_shellm stateless responses openrouter openai/o4-mini
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 \
+    && -z "$(cat "$WORK/stub/previous-1")" \
+    && -z "$(cat "$WORK/stub/previous-2")" ]]; then
+    ok "OpenRouter Responses starts in stateless replay mode"
+else
+    bad "OpenRouter Responses starts in stateless replay mode" "rc=$rc calls=$(main_calls) prev1=$(cat "$WORK/stub/previous-1" 2>/dev/null) prev2=$(cat "$WORK/stub/previous-2" 2>/dev/null)"
+fi
+
+if jq -e '
+    length >= 4 and
+    any(.type == "reasoning" and .encrypted_content == "enc_resp_1") and
+    any(.type == "message" and .phase == "final_answer") and
+    any(.role == "user" and (.content | contains("first output")))
+' "$WORK/stub/messages-2.json" >/dev/null 2>&1; then
+    ok "OpenRouter replay preserves reasoning and assistant phase items"
+else
+    bad "OpenRouter replay preserves reasoning and assistant phase items" "$(jq -c . "$WORK/stub/messages-2.json" 2>/dev/null)"
+fi
+
+# Invalid protocol configuration fails through shellm's normal error contract,
+# rather than calling the error helper before it has been defined.
+SHELLM_API_FORMAT=invalid "$WORK/toolbin/shellm" --help \
+    > "$WORK/out" 2> "$WORK/err"
+rc=$?
+if [[ "$rc" -ne 0 ]] \
+    && grep -q 'Invalid SHELLM_API_FORMAT: invalid' "$WORK/err" \
+    && ! grep -q 'command not found' "$WORK/err"; then
+    ok "invalid Responses format fails through shellm's error contract"
+else
+    bad "invalid Responses format fails through shellm's error contract" "rc=$rc stderr=$(cat "$WORK/err")"
+fi
+
+# Default chat mode does not create or pass Responses state.
+run_shellm chat chat
+rc=$?
+if [[ "$rc" -eq 0 && "$(cat "$WORK/stub/format-1")" == chat \
+      && -z "$(cat "$WORK/stub/previous-1")" \
+      && -z "$(rg --files "$HEADLONG_HOME/trajectories" 2>/dev/null | rg '/responses/' | head -1)" ]]; then
+    ok "default chat mode remains stateless"
+else
+    bad "default chat mode remains stateless" "rc=$rc format=$(cat "$WORK/stub/format-1")"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -106,6 +106,9 @@ case "$LLM_STUB_MODE:$n" in
             output: [{id:"fc_1", type:"function_call", call_id:"call_1", name:"weather", arguments:"{}", status:"completed"}]
         }' > "$LLM_RESPONSE_FILE" )
         ;;
+    no-terminal:1)
+        printf '%s\n' '```bash' "touch '$LLM_STUB_DIR/executed'" '```'
+        ;;
     chat:1)
         [[ -z "${LLM_RESPONSE_FILE:-}" ]] || { echo "chat unexpectedly received LLM_RESPONSE_FILE" >&2; exit 2; }
         printf '%s\n' '```bash' 'FINAL=chat-done' '```'
@@ -257,6 +260,29 @@ if [[ "$rc" -ne 0 && "$(main_calls)" -eq 1 ]] \
     ok "function-only Response fails closed without an empty-output retry"
 else
     bad "function-only Response fails closed without an empty-output retry" "rc=$rc calls=$(main_calls) stderr=$(tail -5 "$WORK/err" | tr '\n' ' ')"
+fi
+
+# Defense in depth: even a malformed/custom llm that exits successfully after
+# visible output cannot make shellm execute without terminal Responses state.
+run_shellm no-terminal responses
+rc=$?
+if [[ "$rc" -ne 0 && "$(main_calls)" -eq 1 && ! -e "$WORK/stub/executed" ]] \
+    && grep -q 'without a terminal response' "$WORK/err"; then
+    ok "shellm rejects Responses output without terminal state before execution"
+else
+    bad "shellm rejects Responses output without terminal state before execution" "rc=$rc calls=$(main_calls) stderr=$(tail -5 "$WORK/err" | tr '\n' ' ')"
+fi
+
+# A bounded run context must never resend the pinned original prompt against an
+# existing continuation when its assistant boundary has fallen out of view.
+SHELLM_CONTEXT_SCOPE=run SHELLM_CONTEXT_RUN_TAIL=1 SHELLM_CONTEXT_RUN_TAIL_BLOCK=1 \
+    run_shellm continue responses
+rc=$?
+if [[ "$rc" -ne 0 && "$(main_calls)" -eq 1 ]] \
+    && grep -q 'continuation boundary fell outside' "$WORK/err"; then
+    ok "bounded context fails closed when its continuation boundary is absent"
+else
+    bad "bounded context fails closed when its continuation boundary is absent" "rc=$rc calls=$(main_calls) stderr=$(tail -5 "$WORK/err" | tr '\n' ' ')"
 fi
 
 # Invalid protocol configuration fails through shellm's normal error contract,

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -80,6 +80,29 @@ case "$LLM_STUB_MODE:$n" in
         printf '%s\n' 'llm: error: API error (HTTP 400): previous response is unavailable' >&2
         exit 1
         ;;
+    partial:1)
+        write_response resp_1
+        printf '%s\n' '```bash' 'printf "first output\n"' '```'
+        ;;
+    partial:2)
+        # Text was already streamed when the error arrived: not a rejection.
+        printf '%s\n' '```bash' 'echo partial'
+        ( umask 077; printf '%s' '{"error":{"message":"previous response is unavailable","param":"previous_response_id","code":"previous_response_not_found"}}' > "$LLM_RESPONSE_FILE" )
+        printf '%s\n' 'llm: error: API stream error: previous response is unavailable' >&2
+        exit 1
+        ;;
+    long:1)
+        write_response resp_1
+        printf '%s\n' '```bash' "printf '%03000d\\n' 1" '```'
+        ;;
+    long:2)
+        write_response resp_2
+        printf '%s\n' '```bash' 'echo second' '```'
+        ;;
+    long:3)
+        write_response resp_3
+        printf '%s\n' '```bash' 'FINAL=done-after-long' '```'
+        ;;
     fallback:3)
         write_response resp_3
         printf '%s\n' '```bash' 'FINAL=done-after-fallback' '```'
@@ -273,16 +296,56 @@ else
     bad "shellm rejects Responses output without terminal state before execution" "rc=$rc calls=$(main_calls) stderr=$(tail -5 "$WORK/err" | tr '\n' ' ')"
 fi
 
-# A bounded run context must never resend the pinned original prompt against an
-# existing continuation when its assistant boundary has fallen out of view.
+# The render shrinks an output once it ages out of the newest block, so the
+# earlier context is not a byte prefix of the later one. New rows are told
+# apart by id, and the run reaches its third call with only the new output.
+run_shellm long responses
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 3 && "$(cat "$WORK/stub/previous-3")" == resp_2 ]] \
+   && jq -e '
+        length == 1 and .[0].role == "user"
+        and (.[0].content | contains("second"))
+        and (.[0].content | contains("000000") | not)
+   ' "$WORK/stub/messages-3.json" >/dev/null 2>&1 \
+   && jq -e 'any(.[]; .content | contains("000000"))' "$WORK/stub/messages-2.json" >/dev/null 2>&1; then
+    ok "continuation survives an older output shrinking in the render"
+else
+    bad "continuation survives an older output shrinking in the render" "rc=$rc calls=$(main_calls) prev3=$(cat "$WORK/stub/previous-3" 2>/dev/null) m3=$(jq -c 'map(.content |= .[0:60])' "$WORK/stub/messages-3.json" 2>/dev/null) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
+fi
+if ! grep -q 'step_ids' "$WORK/stub"/messages-*.json; then
+    ok "row ids never reach the provider"
+else
+    bad "row ids never reach the provider" "$(grep -l 'step_ids' "$WORK/stub"/messages-*.json | tr '\n' ' ')"
+fi
+
+# A rejection can only precede generation. An error naming
+# previous_response_id after text was streamed is a failed call, not a cue to
+# replay, and the partial text is never executed.
+run_shellm partial responses
+rc=$?
+if [[ "$rc" -ne 0 && "$(main_calls)" -eq 2 ]] \
+   && ! grep -q 'retrying once with exact replay' "$WORK/err" \
+   && grep -q 'llm failed' "$WORK/err"; then
+    ok "continuation fallback requires a call that emitted nothing"
+else
+    bad "continuation fallback requires a call that emitted nothing" "rc=$rc calls=$(main_calls) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
+fi
+
+# A bounded run context keeps working after its earlier rows scroll out of
+# view: the pinned prompt is never resent against an existing continuation,
+# and the run does not fail closed for it.
 SHELLM_CONTEXT_SCOPE=run SHELLM_CONTEXT_RUN_TAIL=1 SHELLM_CONTEXT_RUN_TAIL_BLOCK=1 \
     run_shellm continue responses
 rc=$?
-if [[ "$rc" -ne 0 && "$(main_calls)" -eq 1 ]] \
-    && grep -q 'continuation boundary fell outside' "$WORK/err"; then
-    ok "bounded context fails closed when its continuation boundary is absent"
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 && "$(cat "$WORK/stub/previous-2")" == resp_1 ]] \
+   && jq -e '
+        length >= 1
+        and all(.[]; .role == "user" and (.content | contains("do the task") | not))
+        and any(.[]; .content | contains("first output"))
+   ' "$WORK/stub/messages-2.json" >/dev/null 2>&1; then
+    ok "bounded run context sends only new rows, never the pinned prompt"
 else
-    bad "bounded context fails closed when its continuation boundary is absent" "rc=$rc calls=$(main_calls) stderr=$(tail -5 "$WORK/err" | tr '\n' ' ')"
+    bad "bounded run context sends only new rows, never the pinned prompt" "rc=$rc calls=$(main_calls) m2=$(jq -c 'map(.content |= .[0:60])' "$WORK/stub/messages-2.json" 2>/dev/null) stderr=$(tail -3 "$WORK/err" | tr '\n' ' ')"
 fi
 
 # Invalid protocol configuration fails through shellm's normal error contract,

--- a/tests/test_shellm_responses_continuation.sh
+++ b/tests/test_shellm_responses_continuation.sh
@@ -84,6 +84,28 @@ case "$LLM_STUB_MODE:$n" in
         write_response resp_3
         printf '%s\n' '```bash' 'FINAL=done-after-fallback' '```'
         ;;
+    empty:1)
+        ( umask 077; jq -nc '{
+            id: "resp_incomplete",
+            object: "response",
+            status: "incomplete",
+            incomplete_details: {reason: "max_output_tokens"},
+            output: [{id:"rs_incomplete", type:"reasoning", summary:[], encrypted_content:"enc_incomplete"}]
+        }' > "$LLM_RESPONSE_FILE" )
+        printf '%s\n' 'llm: warning: output truncated (max_output_tokens)' >&2
+        ;;
+    empty:2)
+        write_response resp_after_incomplete
+        printf '%s\n' '```bash' 'FINAL=done-after-incomplete' '```'
+        ;;
+    function:1)
+        ( umask 077; jq -nc '{
+            id: "resp_function",
+            object: "response",
+            status: "completed",
+            output: [{id:"fc_1", type:"function_call", call_id:"call_1", name:"weather", arguments:"{}", status:"completed"}]
+        }' > "$LLM_RESPONSE_FILE" )
+        ;;
     chat:1)
         [[ -z "${LLM_RESPONSE_FILE:-}" ]] || { echo "chat unexpectedly received LLM_RESPONSE_FILE" >&2; exit 2; }
         printf '%s\n' '```bash' 'FINAL=chat-done' '```'
@@ -202,6 +224,39 @@ if jq -e '
     ok "OpenRouter replay preserves reasoning and assistant phase items"
 else
     bad "OpenRouter replay preserves reasoning and assistant phase items" "$(jq -c . "$WORK/stub/messages-2.json" 2>/dev/null)"
+fi
+
+# A reasoning-only incomplete Response continues from the terminal Response
+# state. Its reasoning summary is never fabricated as an assistant message.
+run_shellm empty responses
+rc=$?
+if [[ "$rc" -eq 0 && "$(main_calls)" -eq 2 \
+    && "$(cat "$WORK/stub/previous-2")" == resp_incomplete ]]; then
+    ok "reasoning-only incomplete Response continues by response ID"
+else
+    bad "reasoning-only incomplete Response continues by response ID" "rc=$rc calls=$(main_calls) previous=$(cat "$WORK/stub/previous-2" 2>/dev/null)"
+fi
+
+if jq -e '
+    length == 1 and
+    .[0].role == "user" and
+    (. [0].content | contains("Continue from the incomplete response")) and
+    all(.[]; .role != "assistant")
+' "$WORK/stub/messages-2.json" >/dev/null 2>&1; then
+    ok "Responses retry does not fabricate assistant reasoning context"
+else
+    bad "Responses retry does not fabricate assistant reasoning context" "$(jq -c . "$WORK/stub/messages-2.json" 2>/dev/null)"
+fi
+
+# shellm cannot execute Responses-native function calls. It fails closed
+# instead of treating empty stdout as another model turn.
+run_shellm function responses
+rc=$?
+if [[ "$rc" -ne 0 && "$(main_calls)" -eq 1 ]] \
+    && grep -q 'function calls without visible shellm output' "$WORK/err"; then
+    ok "function-only Response fails closed without an empty-output retry"
+else
+    bad "function-only Response fails closed without an empty-output retry" "rc=$rc calls=$(main_calls) stderr=$(tail -5 "$WORK/err" | tr '\n' ' ')"
 fi
 
 # Invalid protocol configuration fails through shellm's normal error contract,

--- a/tests/test_shellm_ws_transport.sh
+++ b/tests/test_shellm_ws_transport.sh
@@ -40,6 +40,10 @@ for arg in "$@"; do
 done
 case "${1:-}" in
     serve)
+        printf '%s\n' "${RESPONSES_WS_PROVIDER:-}" > "$WS_STUB_DIR/broker-provider"
+        printf '%s\n' "${LLM_PROVIDER:-}" > "$WS_STUB_DIR/broker-llm-provider"
+        printf '%s\n' "${LLM_API_URL:-}" > "$WS_STUB_DIR/broker-api-url"
+        [[ "${WS_STUB_REJECT:-0}" != 1 ]] || exit 2
         printf '%s' "$sock" > "$WS_STUB_DIR/socket"
         : > "$sock"
         trap 'rm -f "$sock"; exit 0' TERM INT
@@ -58,6 +62,7 @@ chmod +x "$WORK/tools/responses-ws"
 # a final block so the run ends after one iteration.
 cat > "$WORK/toolbin/llm" <<'STUB'
 #!/usr/bin/env bash
+printf 'called\n' >> "$WS_STUB_DIR/model-calls"
 main_loop=0
 for arg in "$@"; do
     [[ "$arg" == --thinking ]] && main_loop=1
@@ -70,11 +75,13 @@ fi
     printf 'LLM_PROVIDER=%s\n' "${LLM_PROVIDER:-}"
     printf 'LLM_ADAPTER=%s\n' "${LLM_ADAPTER:-}"
     printf 'RESPONSES_WS_SOCKET=%s\n' "${RESPONSES_WS_SOCKET:-}"
+    printf 'RESPONSES_WS_PROVIDER=%s\n' "${RESPONSES_WS_PROVIDER:-}"
     printf 'LLM_API_FORMAT=%s\n' "${LLM_API_FORMAT:-}"
 } > "$WS_STUB_DIR/llm-env"
 if [[ -n "${LLM_RESPONSE_FILE:-}" ]]; then
     ( umask 077; jq -nc '{
         id: "resp_1", object: "response", status: "completed",
+        usage: {input_tokens:9000, output_tokens:1},
         output: [{id:"msg_1", type:"message", role:"assistant", status:"completed",
                   content:[{type:"output_text", text:"done"}]}]
     }' > "$LLM_RESPONSE_FILE" )
@@ -82,6 +89,26 @@ fi
 printf '%s\n' '```bash' 'FINAL=done' '```'
 STUB
 chmod +x "$WORK/toolbin/llm"
+
+# Lifecycle requests must never inherit the transport's adapter as provider.
+cat > "$WORK/toolbin/responses" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$WS_STUB_DIR/lifecycle-args"
+provider=""
+previous=""
+for arg in "$@"; do
+    [[ "$previous" == --provider ]] && provider="$arg"
+    previous="$arg"
+done
+printf '%s\n' "$provider" > "$WS_STUB_DIR/lifecycle-provider"
+[[ "$provider" == openai || "$provider" == openai-compatible ]] || exit 2
+case "$1" in
+    conversations) printf '%s\n' '{"id":"conv_ws"}' ;;
+    compact) printf '%s\n' '{"output":[{"type":"compaction","encrypted_content":"opaque"}]}' ;;
+    *) exit 2 ;;
+esac
+STUB
+chmod +x "$WORK/toolbin/responses"
 
 export PATH="$WORK/toolbin:$PATH"
 export HOME="$WORK/home"
@@ -164,6 +191,101 @@ if [[ -n "$sock" && ! -e "$sock" ]]; then
     ok "the socket is gone when the run is"
 else
     bad "the socket is gone when the run is" "socket=$sock"
+fi
+
+if [[ "$(cat "$WS_STUB_DIR/broker-provider")" == openai \
+    && "$(cat "$WS_STUB_DIR/broker-llm-provider")" != adapter ]] \
+    && grep -qx 'RESPONSES_WS_PROVIDER=openai' "$WS_STUB_DIR/llm-env"; then
+    ok "underlying provider is exported before the adapter override and reaches llm"
+else
+    bad "underlying provider is exported before the adapter override and reaches llm"
+fi
+
+LLM_PROVIDER=openai-compatible LLM_API_URL=https://compatible.example/v1/responses \
+    SHELLM_RESPONSES_CONVERSATION=new run_shellm responses websocket
+if [[ "$?" == 0 && "$(cat "$WS_STUB_DIR/broker-provider")" == openai-compatible \
+    && "$(cat "$WS_STUB_DIR/broker-api-url")" == https://compatible.example/v1/responses \
+    && "$(cat "$WS_STUB_DIR/lifecycle-provider")" == openai-compatible ]] \
+    && grep -qx 'RESPONSES_WS_PROVIDER=openai-compatible' "$WS_STUB_DIR/llm-env"; then
+    ok "compatible transport preserves the endpoint and original Conversation lifecycle provider"
+else
+    bad "compatible transport preserves the endpoint and original Conversation lifecycle provider" "$(tail -3 "$WORK/err")"
+fi
+
+LLM_PROVIDER=openai-compatible SHELLM_API_URL=https://compatible.example/v1/responses \
+    SHELLM_RESPONSES_COMPACT_THRESHOLD=1000 SHELLM_RESPONSES_COMPACT_MODE=standalone \
+    run_shellm responses websocket
+if [[ "$?" == 0 && "$(cat "$WS_STUB_DIR/lifecycle-provider")" == openai-compatible ]] \
+    && grep -qx 'compact' "$WS_STUB_DIR/lifecycle-args" \
+    && grep -qx -- '--instructions' "$WS_STUB_DIR/lifecycle-args"; then
+    ok "standalone compaction uses the original provider even after WebSocket adapter selection"
+else
+    bad "standalone compaction uses the original provider even after WebSocket adapter selection" "$(tail -3 "$WORK/err")"
+fi
+
+no_dispatch() { [[ ! -e "$WS_STUB_DIR/model-calls" && ! -e "$WS_STUB_DIR/lifecycle-args" ]]; }
+for provider in anthropic openrouter adapter; do
+    LLM_PROVIDER="$provider" SHELLM_RESPONSES_CONVERSATION=new run_shellm responses websocket
+    if [[ "$?" != 0 ]] && no_dispatch; then
+        ok "unsupported WebSocket provider $provider fails before Conversation creation or any model"
+    else
+        bad "unsupported WebSocket provider $provider fails before Conversation creation or any model"
+    fi
+done
+
+SHELLM_RESPONSES_BACKGROUND=1 SHELLM_RESPONSES_CONVERSATION=new run_shellm responses websocket
+if [[ "$?" != 0 ]] && no_dispatch && grep -q background "$WORK/err"; then
+    ok "WebSocket background env fails preflight before any dispatch"
+else
+    bad "WebSocket background env fails preflight before any dispatch"
+fi
+
+printf '%s\n' '{"background":true}' > "$WORK/body.json"
+SHELLM_RESPONSES_BODY_FILE="$WORK/body.json" SHELLM_RESPONSES_CONVERSATION=new \
+    run_shellm responses websocket
+if [[ "$?" != 0 ]] && no_dispatch && grep -q background "$WORK/err"; then
+    ok "effective body-file background fails preflight before any dispatch"
+else
+    bad "effective body-file background fails preflight before any dispatch"
+fi
+SHELLM_RESPONSES_BODY_FILE="$WORK/body.json" SHELLM_RESPONSES_BACKGROUND=0 run_shellm responses websocket
+if [[ "$?" == 0 ]] && ! no_dispatch; then
+    ok "explicit foreground override matches HTTP body precedence"
+else
+    bad "explicit foreground override matches HTTP body precedence"
+fi
+
+for body in '{"provider":{"zdr":true}}' '{"stream_options":{}}'; do
+    printf '%s\n' "$body" > "$WORK/body.json"
+    SHELLM_RESPONSES_BODY_FILE="$WORK/body.json" SHELLM_RESPONSES_CONVERSATION=new \
+        run_shellm responses websocket
+    if [[ "$?" != 0 ]] && no_dispatch; then
+        ok "unsupported body policy fails before lifecycle or model dispatch: $body"
+    else
+        bad "unsupported body policy fails before lifecycle or model dispatch: $body"
+    fi
+done
+
+RESPONSES_WS_URL=wss://different.example/v1/responses SHELLM_RESPONSES_CONVERSATION=new \
+    run_shellm responses websocket
+if [[ "$?" != 0 ]] && no_dispatch; then
+    ok "a transport-only endpoint override cannot split lifecycle and completion destinations"
+else
+    bad "a transport-only endpoint override cannot split lifecycle and completion destinations"
+fi
+
+LLM_OR_ZDR=1 SHELLM_RESPONSES_CONVERSATION=new run_shellm responses websocket
+if [[ "$?" != 0 ]] && no_dispatch; then
+    ok "unsupported routing/privacy policy fails before any dispatch"
+else
+    bad "unsupported routing/privacy policy fails before any dispatch"
+fi
+
+WS_STUB_REJECT=1 SHELLM_RESPONSES_CONVERSATION=new run_shellm responses websocket
+if [[ "$?" != 0 ]] && no_dispatch; then
+    ok "broker startup validation failure cannot create a Conversation or execute a model"
+else
+    bad "broker startup validation failure cannot create a Conversation or execute a model"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/test_shellm_ws_transport.sh
+++ b/tests/test_shellm_ws_transport.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# test_shellm_ws_transport.sh — SHELLM_API_TRANSPORT=websocket wiring
+#
+# Usage: tests/test_shellm_ws_transport.sh
+#
+# The broker and the adapter are both stubbed, so this pins shellm's side of
+# the contract without uv, Python, or a socket: which transports are legal,
+# that the broker is started and stopped around the run, and that shellm's own
+# llm calls are pointed at tools/responses-ws through the run's socket. The
+# adapter itself is covered by tests/test_responses_ws.sh.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+# shellm resolves the tool through realpath, and on macOS /var is a symlink.
+WORK_REAL=$(cd "$WORK" && pwd -P)
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+mkdir -p "$WORK/home" "$WORK/wd" "$WORK/stub"
+cp -R "$REPO/bin" "$WORK/toolbin"
+mkdir -p "$WORK/tools"
+
+# Stub broker. "serve" creates the socket path and waits; "stop" removes it.
+# Both record their argv so the test can pin the socket shellm chose.
+cat > "$WORK/tools/responses-ws" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$WS_STUB_DIR/calls"
+sock=""
+prev=""
+for arg in "$@"; do
+    [[ "$prev" == "--socket" ]] && sock="$arg"
+    prev="$arg"
+done
+case "${1:-}" in
+    serve)
+        printf '%s' "$sock" > "$WS_STUB_DIR/socket"
+        : > "$sock"
+        trap 'rm -f "$sock"; exit 0' TERM INT
+        while [[ -e "$sock" ]]; do sleep 1; done
+        ;;
+    stop)
+        printf 'stopped\n' >> "$WS_STUB_DIR/calls"
+        rm -f "$sock"
+        ;;
+esac
+exit 0
+STUB
+chmod +x "$WORK/tools/responses-ws"
+
+# Stub llm. Records the adapter environment shellm exported, then answers with
+# a final block so the run ends after one iteration.
+cat > "$WORK/toolbin/llm" <<'STUB'
+#!/usr/bin/env bash
+main_loop=0
+for arg in "$@"; do
+    [[ "$arg" == --thinking ]] && main_loop=1
+done
+if [[ "$main_loop" -ne 1 ]]; then
+    printf '{}\n'
+    exit 0
+fi
+{
+    printf 'LLM_PROVIDER=%s\n' "${LLM_PROVIDER:-}"
+    printf 'LLM_ADAPTER=%s\n' "${LLM_ADAPTER:-}"
+    printf 'RESPONSES_WS_SOCKET=%s\n' "${RESPONSES_WS_SOCKET:-}"
+    printf 'LLM_API_FORMAT=%s\n' "${LLM_API_FORMAT:-}"
+} > "$WS_STUB_DIR/llm-env"
+if [[ -n "${LLM_RESPONSE_FILE:-}" ]]; then
+    ( umask 077; jq -nc '{
+        id: "resp_1", object: "response", status: "completed",
+        output: [{id:"msg_1", type:"message", role:"assistant", status:"completed",
+                  content:[{type:"output_text", text:"done"}]}]
+    }' > "$LLM_RESPONSE_FILE" )
+fi
+printf '%s\n' '```bash' 'FINAL=done' '```'
+STUB
+chmod +x "$WORK/toolbin/llm"
+
+export PATH="$WORK/toolbin:$PATH"
+export HOME="$WORK/home"
+export HEADLONG_HOME="$WORK/home/.headlong"
+export OPENAI_API_KEY="test-key"
+export SHELLM_MODEL="gpt-5-test"
+export SHELLM_ENV=local
+export SHELLM_NO_BANNER=1
+export WS_STUB_DIR="$WORK/stub"
+
+run_shellm() {   # run_shellm FORMAT TRANSPORT
+    rm -rf "$WS_STUB_DIR" "$HEADLONG_HOME" "$WORK/wd"
+    mkdir -p "$WS_STUB_DIR" "$WORK/wd"
+    SHELLM_API_FORMAT="$1" SHELLM_API_TRANSPORT="$2" \
+        "$WORK/toolbin/shellm" --workdir "$WORK/wd" --max-iterations 2 "do the task" \
+        > "$WORK/out" 2> "$WORK/err" < /dev/null
+}
+
+# ---------------------------------------------------------------------------
+# The transport is only meaningful with the Responses protocol
+# ---------------------------------------------------------------------------
+
+run_shellm chat websocket
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'SHELLM_API_TRANSPORT=websocket' "$WORK/err"; then
+    ok "websocket transport without Responses dies with a clear message"
+else
+    bad "websocket transport without Responses dies with a clear message" "rc=$rc: $(head -2 "$WORK/err")"
+fi
+
+run_shellm responses bogus
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'SHELLM_API_TRANSPORT' "$WORK/err"; then
+    ok "an unknown transport dies with a clear message"
+else
+    bad "an unknown transport dies with a clear message" "rc=$rc: $(head -2 "$WORK/err")"
+fi
+
+# ---------------------------------------------------------------------------
+# The broker runs for the length of the run and llm is pointed at it
+# ---------------------------------------------------------------------------
+
+run_shellm responses websocket
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    ok "a run completes on the websocket transport"
+else
+    bad "a run completes on the websocket transport" "rc=$rc: $(tail -3 "$WORK/err")"
+fi
+
+sock=$(cat "$WS_STUB_DIR/socket" 2>/dev/null)
+if [[ -n "$sock" ]] && grep -q "^serve --socket $sock" "$WS_STUB_DIR/calls" 2>/dev/null; then
+    ok "shellm starts the broker on a socket of its own"
+else
+    bad "shellm starts the broker on a socket of its own" "$(cat "$WS_STUB_DIR/calls" 2>/dev/null)"
+fi
+
+if [[ "$sock" == /*/shellm-run.*/* ]]; then
+    ok "the socket lives in the run's private rundir"
+else
+    bad "the socket lives in the run's private rundir" "socket=$sock"
+fi
+
+if grep -qx "LLM_PROVIDER=adapter" "$WS_STUB_DIR/llm-env" 2>/dev/null \
+   && grep -qx "LLM_ADAPTER=$WORK_REAL/tools/responses-ws" "$WS_STUB_DIR/llm-env" \
+   && grep -qx "RESPONSES_WS_SOCKET=$sock" "$WS_STUB_DIR/llm-env" \
+   && grep -qx "LLM_API_FORMAT=responses" "$WS_STUB_DIR/llm-env"; then
+    ok "shellm's llm calls go through the adapter and the run's socket"
+else
+    bad "shellm's llm calls go through the adapter and the run's socket" "$(tr '\n' ' ' < "$WS_STUB_DIR/llm-env" 2>/dev/null)"
+fi
+
+if grep -q "^stop --socket $sock" "$WS_STUB_DIR/calls" 2>/dev/null; then
+    ok "cleanup stops the broker"
+else
+    bad "cleanup stops the broker" "$(cat "$WS_STUB_DIR/calls" 2>/dev/null)"
+fi
+
+if [[ -n "$sock" && ! -e "$sock" ]]; then
+    ok "the socket is gone when the run is"
+else
+    bad "the socket is gone when the run is" "socket=$sock"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/test_uninstall.sh
+++ b/tests/test_uninstall.sh
@@ -47,6 +47,8 @@ make_install() {  # make_install <home>
     local home="$1" app="$1/.headlong/app"
     mkdir -p "$home/.headlong" "$home/.local/bin"
     git clone -q --local "$REPO" "$app" 2>/dev/null || { bad "local clone"; return 1; }
+    # Exercise the working-tree inventory too, before changes are committed.
+    cp "$REPO/install.sh" "$app/install.sh"
     rm -rf "$app/tui"   # no cargo build in a test
     ( cd "$app" && HOME="$home" HEADLONG_HOME="$home/.headlong" PREFIX="$home/.local/bin" \
         bash install.sh --symlinks --no-init >/dev/null 2>&1 ) || { bad "install.sh --symlinks"; return 1; }
@@ -61,6 +63,7 @@ make_install() {  # make_install <home>
 H1="$WORK/h1"
 make_install "$H1" || exit 1
 check "fixture: tools linked"            test -L "$H1/.local/bin/shellm"
+check "fixture: optional adapter linked" test -L "$H1/.local/bin/responses-ws"
 check "fixture: persona link"            test -L "$H1/.local/bin/ada"
 check "fixture: skills"                  test -d "$H1/.skills/core-skills"
 check "fixture: thinker templates"       test -d "$H1/.headlong-thinkers"
@@ -96,6 +99,7 @@ out=$(run_uninstall "$H1" --yes --no-stop 2>&1); rc=$?
 check "uninstall --yes exits 0"                  test "$rc" -eq 0
 check "state home gone"                          test ! -e "$H1/.headlong"
 check "tool links gone"                          test ! -e "$H1/.local/bin/shellm" -a ! -L "$H1/.local/bin/shellm"
+check "optional adapter link gone"               test ! -e "$H1/.local/bin/responses-ws" -a ! -L "$H1/.local/bin/responses-ws"
 check "persona link gone"                        test ! -L "$H1/.local/bin/ada"
 check "all our entries gone from prefix"         bash -c '[[ -z "$(ls -A "$1" 2>/dev/null)" ]]' _ "$H1/.local/bin"
 check "skills gone"                              test ! -e "$H1/.skills/core-skills"
@@ -122,6 +126,7 @@ check "--delete-identities: state home gone"     test ! -e "$H2/.headlong"
 H3="$WORK/h3"; CLONE="$WORK/myclone"
 mkdir -p "$H3/.local/bin"
 git clone -q --local "$REPO" "$CLONE" 2>/dev/null || { bad "clone for h3"; exit 1; }
+cp "$REPO/install.sh" "$CLONE/install.sh"
 rm -rf "$CLONE/tui"
 ( cd "$CLONE" && HOME="$H3" HEADLONG_HOME="$H3/.headlong" PREFIX="$H3/.local/bin" bash install.sh --symlinks --no-init >/dev/null 2>&1 ) || { bad "install from own clone"; exit 1; }
 ( cd "$CLONE" && HOME="$H3" PATH="$CLONE/bin:$CLONE/tools:$PATH" identity new bob --default >/dev/null 2>&1 ) || { bad "identity new bob"; exit 1; }

--- a/thinkers/README.md
+++ b/thinkers/README.md
@@ -13,4 +13,4 @@ thinker: a `step` executable that produces the next thought, and a
   marker. Updates preserve that per-identity choice.
 - `_lib/` holds shell helpers shared by the thinkers.
 
-Code here counts against the under-10K-lines core (`cloc bin/ thinkers/`).
+Code here counts against the under-11.5K-lines core (`cloc bin/ thinkers/`).

--- a/thinkers/README.md
+++ b/thinkers/README.md
@@ -13,4 +13,4 @@ thinker: a `step` executable that produces the next thought, and a
   marker. Updates preserve that per-identity choice.
 - `_lib/` holds shell helpers shared by the thinkers.
 
-Code here counts against the under-11.5K-lines core (`cloc bin/ thinkers/`).
+Code here counts against the under-10K-lines core (`cloc bin/ thinkers/`).

--- a/thinkers/_lib/common.sh
+++ b/thinkers/_lib/common.sh
@@ -87,10 +87,10 @@ _prompt_section() {  # _prompt_section <label> <cmd> [args...]
     printf '%s: error: wake prompt section "%s" failed: `%s` exited %s%s; the section is left out of this wakeup\n' \
         "${THINKER_NAME:-thinker}" "$label" "$*" "$rc" "${first:+ ($first)}" >&2
     if ! _prompt_section_reported "$label"; then
-        jq -nc --arg label "$label" --arg cmd "$*" --argjson rc "$rc" --arg err "$first" \
+        jq -nc --arg section "$label" --arg cmd "$*" --argjson rc "$rc" --arg err "$first" \
             --arg source "${THINKER_NAME:-thinker}" \
-            '{type:"error", content:("wake prompt section \"\($label)\" failed: `\($cmd)` exited \($rc)" + (if $err=="" then "" else ": "+$err end) + ". The section is missing from every wakeup until this is fixed."),
-              source:$source, reason:"prompt-section-failed", section:$label, rc:$rc}' \
+            '{type:"error", content:("wake prompt section \"\($section)\" failed: `\($cmd)` exited \($rc)" + (if $err=="" then "" else ": "+$err end) + ". The section is missing from every wakeup until this is fixed."),
+              source:$source, reason:"prompt-section-failed", section:$section, rc:$rc}' \
             | traj append >/dev/null 2>&1 || true
     fi
     return "$rc"

--- a/tools/README.md
+++ b/tools/README.md
@@ -14,6 +14,11 @@ tools live in [bin/](../bin/).
 - `headlong-skills` is the skills package manager (search, install, check,
   init, promote, kernel, remotes). The mind's own `skills` only lists,
   shows, and renders skills, and forwards those subcommands here.
+- `responses-ws` is the WebSocket transport for the OpenAI Responses API: a
+  `bin/llm` adapter, and a broker that holds one connection across a whole
+  shellm run. It is a `uv` script, which is exactly why it lives out here and
+  not in `bin/`. See the WebSocket mode section of
+  [docs/shellm.md](../docs/shellm.md).
 - `shellm-explore` visualizes run trees, `pr-committee` runs multi-model
   PR reviews, and `headlong-killall` stops every Headlong-related process.
 

--- a/tools/headlong-jobs
+++ b/tools/headlong-jobs
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""Local durable custody for an identity's exclusive application-job dispatcher.
+
+SQLite is the admission/attempt fence; a trajectory is an evidence projection.
+Only this dispatcher launches jobs. Applications retain all resource authority.
+"""
+import argparse
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import select
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+import uuid
+
+SELF = str(Path(__file__).resolve())
+TERMINAL = {"completed", "cancelled", "unknown"}
+LIMIT = 8 * 1024 * 1024
+
+
+def encode(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def digest(value):
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def read_json(stream):
+    raw = stream.read(LIMIT + 1)
+    if len(raw) > LIMIT:
+        raise ValueError("JSON exceeds admission limit")
+    return json.loads(raw)
+
+
+def sync_dir(path):
+    fd = os.open(str(path), os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def write_json(path, value):
+    temp = path.with_name(path.name + "." + uuid.uuid4().hex)
+    with temp.open("x") as out:
+        out.write(encode(value) + "\n")
+        out.flush()
+        os.fsync(out.fileno())
+    os.replace(temp, path)
+    sync_dir(path.parent)
+
+
+def nonempty(value, name):
+    if not isinstance(value, str) or not value or len(value) > 512 or "\0" in value:
+        raise ValueError("invalid " + name)
+    return value
+
+
+class Store:
+    def __init__(self):
+        identity = os.environ.get("IDENTITY_DIR")
+        if not identity or not Path(identity).is_dir():
+            raise ValueError("IDENTITY_DIR must name an existing identity")
+        self.identity = Path(identity).resolve()
+        self.root = self.identity / "jobs"
+        self.root.mkdir(mode=0o700, exist_ok=True)
+        self.work = self.root / "work"
+        self.work.mkdir(mode=0o700, exist_ok=True)
+        self.db = sqlite3.connect(self.root / "ledger.sqlite3", timeout=30, isolation_level=None)
+        self.db.row_factory = sqlite3.Row
+        self.db.execute("PRAGMA journal_mode=WAL")
+        self.db.execute("PRAGMA synchronous=FULL")
+        self.db.executescript("""
+          CREATE TABLE IF NOT EXISTS handlers(name TEXT PRIMARY KEY, spec TEXT NOT NULL, hash TEXT NOT NULL);
+          CREATE TABLE IF NOT EXISTS control(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+          CREATE TABLE IF NOT EXISTS jobs(
+            job_id TEXT PRIMARY KEY, envelope TEXT NOT NULL, envelope_hash TEXT NOT NULL,
+            handler TEXT NOT NULL, handler_hash TEXT NOT NULL, parent TEXT,
+            state TEXT NOT NULL, created REAL NOT NULL, execution TEXT, token TEXT,
+            worker_pid INTEGER, pgid INTEGER, cancel_requested INTEGER NOT NULL DEFAULT 0,
+            result TEXT, recovery TEXT);
+          CREATE TABLE IF NOT EXISTS attempts(
+            job_id TEXT NOT NULL, attempt_id TEXT NOT NULL, request_hash TEXT NOT NULL,
+            state TEXT NOT NULL, result TEXT, PRIMARY KEY(job_id,attempt_id));
+          CREATE TABLE IF NOT EXISTS events(
+            seq INTEGER PRIMARY KEY AUTOINCREMENT, job_id TEXT NOT NULL, type TEXT NOT NULL,
+            payload TEXT NOT NULL, created REAL NOT NULL);
+        """)
+        sync_dir(self.root)
+        sync_dir(self.identity)
+
+    @contextlib.contextmanager
+    def transaction(self):
+        self.db.execute("BEGIN IMMEDIATE")
+        try:
+            yield
+            self.db.execute("COMMIT")
+        except BaseException:
+            self.db.execute("ROLLBACK")
+            raise
+
+    def event(self, job_id, kind, payload):
+        self.db.execute("INSERT INTO events(job_id,type,payload,created) VALUES(?,?,?,?)",
+                        (job_id, kind, encode(payload), time.time()))
+
+    def job(self, job_id):
+        row = self.db.execute("SELECT * FROM jobs WHERE job_id=?", (job_id,)).fetchone()
+        if row is None:
+            raise ValueError("unknown job_id")
+        return row
+
+    def directory(self, job_id):
+        path = self.work / digest(job_id)
+        path.mkdir(mode=0o700, exist_ok=True)
+        return path
+
+    def receipt(self, row):
+        return {"version": 1, "job_id": row["job_id"], "custody": "durable",
+                "state": row["state"], "envelope_hash": row["envelope_hash"],
+                "handler_hash": row["handler_hash"], "execution_id": row["execution"],
+                "cancel_requested": bool(row["cancel_requested"]),
+                "result": json.loads(row["result"]) if row["result"] else None}
+
+    def finish(self, job_id, execution, result):
+        with self.transaction():
+            row = self.job(job_id)
+            if row["execution"] != execution or row["state"] in TERMINAL:
+                return
+            unsettled = self.db.execute("SELECT count(*) FROM attempts WHERE job_id=? AND state NOT IN ('completed','cancelled')", (job_id,)).fetchone()[0]
+            if unsettled and result["outcome"] != "unknown":
+                result = {"outcome": "unknown", "reason": "unsettled_model_attempts", "evidence": result}
+            if row["cancel_requested"] and result["outcome"] == "completed":
+                result = {"outcome": "unknown", "reason": "completion_after_cancel_fence", "evidence": result}
+            self.db.execute("UPDATE jobs SET state=?,result=? WHERE job_id=?",
+                            (result["outcome"], encode(result), job_id))
+            self.event(job_id, "job-terminal", result)
+
+
+def register(store, name, spec):
+    nonempty(name, "handler name")
+    if not isinstance(spec, dict) or set(spec) != {"version", "argv"}:
+        raise ValueError("handler spec requires exactly version and argv")
+    nonempty(spec["version"], "handler version")
+    argv = spec["argv"]
+    if not isinstance(argv, list) or not argv or any(not isinstance(x, str) or "\0" in x for x in argv):
+        raise ValueError("handler argv must be strings")
+    executable = Path(argv[0])
+    if not executable.is_absolute() or not executable.is_file() or not os.access(executable, os.X_OK):
+        raise ValueError("handler executable must be an absolute executable file")
+    # Pin the executable bytes as well as argv/version. Script dependencies are
+    # the operator's deployment unit and must be named by the version.
+    pinned = dict(spec, executable_sha256=hashlib.sha256(executable.read_bytes()).hexdigest())
+    raw = encode(pinned)
+    with store.transaction():
+        store.db.execute("INSERT OR REPLACE INTO handlers VALUES(?,?,?)", (name, raw, digest(raw)))
+    return {"handler": name, "handler_hash": digest(raw)}
+
+
+def admit(store, envelope):
+    required = {"version", "job_id", "trigger_step", "kind", "handler", "handler_hash", "admitted"}
+    if not isinstance(envelope, dict) or not required <= set(envelope):
+        raise ValueError("missing required admission fields")
+    if set(envelope) - required - {"parent_job_id"} or type(envelope["version"]) is not int or envelope["version"] != 1:
+        raise ValueError("unsupported admission fields/version")
+    for field in ("job_id", "trigger_step", "kind", "handler", "handler_hash"):
+        nonempty(envelope[field], field)
+    if not isinstance(envelope["admitted"], dict):
+        raise ValueError("admitted must be an opaque object of references/context")
+    parent = envelope.get("parent_job_id")
+    if parent is not None:
+        nonempty(parent, "parent_job_id")
+    raw, job_id = encode(envelope), envelope["job_id"]
+    with store.transaction():
+        old = store.db.execute("SELECT * FROM jobs WHERE job_id=?", (job_id,)).fetchone()
+        if old is not None:
+            if old["envelope"] != raw:
+                raise ValueError("job_id already admitted with a different envelope")
+            return store.receipt(old)
+        handler = store.db.execute("SELECT * FROM handlers WHERE name=?", (envelope["handler"],)).fetchone()
+        if handler is None or handler["hash"] != envelope["handler_hash"]:
+            raise ValueError("handler registration hash mismatch")
+        if parent is not None:
+            parent_row = store.job(parent)
+            if parent_row["cancel_requested"] or parent_row["state"] in {"cancelled", "unknown"}:
+                raise ValueError("parent no longer accepts child admissions")
+        store.db.execute("""INSERT INTO jobs(job_id,envelope,envelope_hash,handler,handler_hash,parent,state,created)
+                          VALUES(?,?,?,?,?,?,?,?)""",
+                         (job_id, raw, digest(raw), handler["spec"], handler["hash"], parent, "queued", time.time()))
+        store.event(job_id, "job-admitted", {"envelope_hash": digest(raw), "trigger_step": envelope["trigger_step"],
+                                           "kind": envelope["kind"], "parent_job_id": parent})
+    return store.receipt(store.job(job_id))
+
+
+def cancel(store, job_id):
+    with store.transaction():
+        store.job(job_id)
+        rows = store.db.execute("""WITH RECURSIVE family(id) AS (
+           SELECT job_id FROM jobs WHERE job_id=? UNION ALL
+           SELECT jobs.job_id FROM jobs JOIN family ON jobs.parent=family.id)
+           SELECT jobs.* FROM jobs JOIN family ON jobs.job_id=family.id""", (job_id,)).fetchall()
+        for row in rows:
+            if row["cancel_requested"]:
+                continue
+            state = "cancelled" if row["state"] == "queued" else row["state"]
+            result = encode({"outcome": "cancelled", "reason": "cancelled_before_start"}) if state == "cancelled" else row["result"]
+            store.db.execute("UPDATE jobs SET cancel_requested=1,state=?,result=? WHERE job_id=?",
+                             (state, result, row["job_id"]))
+            store.event(row["job_id"], "job-cancel-requested", {"root_job_id": job_id})
+            if state == "cancelled" and row["state"] == "queued":
+                store.event(row["job_id"], "job-terminal", json.loads(result))
+    # Workers poll the durable cancellation fence. No PID supplied by a client
+    # is ever signalled, and cancelling still works while the dispatcher is down.
+    return store.receipt(store.job(job_id))
+
+
+@contextlib.contextmanager
+def lock(path, blocking=False):
+    handle = path.open("a+")
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB))
+        yield handle
+    finally:
+        handle.close()
+
+
+def alive_worker(store, row):
+    try:
+        with lock(store.directory(row["job_id"]) / "worker.lock"):
+            return False
+    except BlockingIOError:
+        return True
+
+
+def terminal_result(path):
+    try:
+        with path.open() as stream:
+            value = read_json(stream)
+        if isinstance(value, dict) and isinstance(value.get("outcome"), str) and value["outcome"] in TERMINAL:
+            # A result file is evidence only after it has reached durable storage.
+            with path.open("rb") as stream:
+                os.fsync(stream.fileno())
+            return value
+    except (OSError, ValueError):
+        pass
+    return {"outcome": "unknown", "reason": "missing_or_invalid_handler_result"}
+
+
+def reconcile(store):
+    for row in store.db.execute("SELECT * FROM jobs WHERE state IN ('starting','running')").fetchall():
+        if alive_worker(store, row):
+            continue
+        reconcile_attempts(store, row["job_id"])
+        # Only the supervisor's receipt proves that the whole owned group was
+        # stopped. A handler file alone can race unfinished children/effects.
+        receipt = store.directory(row["job_id"]) / "execution-receipt.json"
+        result = terminal_result(receipt)
+        if result.get("execution_id") != row["execution"]:
+            result = {"outcome": "unknown", "reason": "execution_custody_lost"}
+        store.finish(row["job_id"], row["execution"], result)
+
+
+def project_events(store):
+    # A regenerable projection, not an admission acknowledgement. Dedicated
+    # job events never feed the legacy responder/monolith subscription path.
+    path = store.root / "trajectory.jsonl"
+    with lock(store.root / "projection.lock"):
+        temp = store.root / "trajectory.next"
+        with temp.open("w") as stream:
+            for event in store.db.execute("SELECT * FROM events ORDER BY seq"):
+                stream.write(encode({"step_id": "job-event-" + str(event["seq"]),
+                    "type": event["type"], "source": "dispatcher", "job_id": event["job_id"],
+                    "timestamp": event["created"], "content": json.loads(event["payload"])}) + "\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temp, path)
+        sync_dir(store.root)
+
+
+def dispatch(store, ready_fd=None):
+    if not (store.root / "mode.json").exists():
+        raise ValueError("select jobs-only mode through thinkers start --jobs-only")
+    with lock(store.root / "dispatcher.lock"):
+        # The lock is outside run/, which is intentionally disposable.
+        stop = [False]
+        signal.signal(signal.SIGTERM, lambda *_: stop.__setitem__(0, True))
+        signal.signal(signal.SIGINT, lambda *_: stop.__setitem__(0, True))
+        generation = uuid.uuid4().hex
+        store.db.execute("INSERT OR REPLACE INTO control VALUES('dispatcher',?)", (generation,))
+        run = store.identity / "run"
+        run.mkdir(exist_ok=True)
+        (run / "dispatcher.pid").write_text(str(os.getpid()))
+        if ready_fd is not None:
+            os.write(ready_fd, b"ready\n")
+            os.close(ready_fd)
+        children = []
+        last_projection = -1
+        try:
+            while not stop[0]:
+                if store.db.execute("SELECT value FROM control WHERE key='dispatcher'").fetchone()[0] != generation:
+                    break
+                reconcile(store)
+                running = store.db.execute("SELECT count(*) FROM jobs WHERE state IN ('starting','running')").fetchone()[0]
+                capacity = max(0, int(os.environ.get("HEADLONG_JOBS_MAX_CONCURRENT", "4")) - running)
+                queued = store.db.execute("SELECT job_id FROM jobs WHERE state='queued' ORDER BY created,job_id LIMIT ?", (capacity,)).fetchall()
+                for entry in queued:
+                    job_id, execution, token = entry["job_id"], uuid.uuid4().hex, uuid.uuid4().hex
+                    with lock(store.directory(job_id) / "worker.lock") as ownership:
+                        with store.transaction():
+                            changed = store.db.execute("UPDATE jobs SET state='starting',execution=?,token=? WHERE job_id=? AND state='queued' AND cancel_requested=0",
+                                                       (execution, token, job_id)).rowcount
+                            if changed:
+                                store.event(job_id, "job-starting", {"execution_id": execution})
+                        if changed:
+                            log = (store.directory(job_id) / "supervisor.log").open("ab")
+                            try:
+                                children.append(subprocess.Popen([sys.executable, SELF, "_worker", job_id, execution, str(ownership.fileno())],
+                                    stdin=subprocess.DEVNULL, stdout=log, stderr=log, start_new_session=True,
+                                    pass_fds=(ownership.fileno(),)))
+                            except OSError:
+                                store.finish(job_id, execution, {"outcome": "unknown", "reason": "worker_spawn_failed"})
+                            finally:
+                                log.close()
+                children = [child for child in children if child.poll() is None]
+                version = store.db.execute("SELECT coalesce(max(seq),0) FROM events").fetchone()[0]
+                if version != last_projection:
+                    project_events(store)
+                    last_projection = version
+                time.sleep(0.1)
+        finally:
+            # Stop pauses admission dispatch, preserving queued jobs and letting
+            # supervised work finish. Exact job cancellation is a separate fence.
+            pid_path = run / "dispatcher.pid"
+            if pid_path.exists() and pid_path.read_text() == str(os.getpid()):
+                pid_path.unlink()
+
+
+def start(store):
+    # Persist the identity's exclusive mode before starting. Legacy start fails
+    # closed for this identity even after run/ is removed by a restart wrapper.
+    with lock(store.root / "start.lock"):
+        pid_path = store.identity / "run" / "dispatcher.pid"
+        if pid_path.exists():
+            try:
+                os.kill(int(pid_path.read_text()), 0)
+                raise ValueError("identity dispatcher already running")
+            except ProcessLookupError:
+                pass
+        write_json(store.root / "mode.json", {"mode": "jobs-only", "version": 1})
+        read_fd, write_fd = os.pipe()
+        log = (store.root / "dispatcher.log").open("ab")
+        child = subprocess.Popen([sys.executable, SELF, "_dispatch", str(write_fd)],
+            stdin=subprocess.DEVNULL, stdout=log, stderr=log, start_new_session=True, pass_fds=(write_fd,))
+        log.close()
+        os.close(write_fd)
+        try:
+            if not select.select([read_fd], [], [], 10)[0] or os.read(read_fd, 64) != b"ready\n":
+                raise ValueError("job dispatcher did not acquire custody; inspect jobs/dispatcher.log")
+        finally:
+            os.close(read_fd)
+        return {"mode": "jobs-only", "dispatcher_pid": child.pid}
+
+
+def execute(store, job_id, execution):
+    # This process is the unreaped group leader. It stays alive after the
+    # handler exits until its supervisor kills the entire group and then waits.
+    # That ordering reserves the PGID, preventing PID reuse cancellation races.
+    signal.signal(signal.SIGTERM, lambda *_: None)
+    signal.signal(signal.SIGINT, lambda *_: None)
+    if sys.stdin.readline() != "go\n":
+        return
+    row = store.job(job_id)
+    if os.getpid() != os.getpgrp() or row["pgid"] != os.getpid() or row["worker_pid"] != os.getppid():
+        raise ValueError("execution requires the admitted supervisor's owned group")
+    if row["execution"] != execution or row["state"] != "running" or row["cancel_requested"]:
+        print("done", flush=True)
+    else:
+        spec, directory = json.loads(row["handler"]), store.directory(job_id)
+        if hashlib.sha256(Path(spec["argv"][0]).read_bytes()).hexdigest() != spec["executable_sha256"]:
+            write_json(directory / "result.json", {"outcome": "unknown", "reason": "registered_handler_bytes_changed"})
+        else:
+            env = dict(os.environ, HEADLONG_JOB_ID=job_id, HEADLONG_JOB_EXECUTION_ID=execution,
+                HEADLONG_JOB_EXECUTION_TOKEN=row["token"], HEADLONG_JOB_DIR=str(directory),
+                HEADLONG_JOB_RESULT_FILE=str(directory / "result.json"))
+            with (directory / "stdout").open("wb") as out, (directory / "stderr").open("wb") as err:
+                child = subprocess.Popen(spec["argv"], stdin=subprocess.PIPE, stdout=out, stderr=err, env=env)
+                # Stream input without blocking supervision on a handler that
+                # never reads stdin. The control pipe closes on worker death.
+                pending = memoryview((row["envelope"] + "\n").encode())
+                os.set_blocking(child.stdin.fileno(), False)
+                while child.poll() is None:
+                    readable, writable, _ = select.select([sys.stdin], [child.stdin] if pending else [], [], 0.05)
+                    if readable and not os.read(sys.stdin.fileno(), 64):
+                        os.killpg(os.getpgrp(), signal.SIGKILL)
+                    if writable:
+                        try:
+                            pending = pending[os.write(child.stdin.fileno(), pending):]
+                        except BrokenPipeError:
+                            pending = memoryview(b"")
+                        if not pending:
+                            child.stdin.close()
+                if not child.stdin.closed:
+                    child.stdin.close()
+                write_json(directory / "exit.json", {"returncode": child.returncode})
+        print("done", flush=True)
+    # No descendants can outlive the owned process group. Never exit before
+    # the supervisor's killpg, even if the handler forks and exits immediately.
+    while True:
+        if select.select([sys.stdin], [], [], 1)[0] and not os.read(sys.stdin.fileno(), 64):
+            os.killpg(os.getpgrp(), signal.SIGKILL)
+
+
+def worker(store, job_id, execution, lock_fd):
+    directory = store.directory(job_id)
+    with os.fdopen(lock_fd, "a+"):
+        with store.transaction():
+            row = store.job(job_id)
+            if row["execution"] != execution or row["state"] != "starting":
+                return
+            if row["cancel_requested"]:
+                result = {"outcome": "cancelled", "reason": "cancelled_before_start"}
+                store.db.execute("UPDATE jobs SET state='cancelled',result=? WHERE job_id=?",
+                                 (encode(result), job_id))
+                store.event(job_id, "job-terminal", result)
+                return
+            store.db.execute("UPDATE jobs SET state='running',worker_pid=? WHERE job_id=?", (os.getpid(), job_id))
+        group = subprocess.Popen([sys.executable, SELF, "_execute", job_id, execution],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, start_new_session=True)
+        cancel_at, done = None, False
+        stopping = [False]
+        signal.signal(signal.SIGTERM, lambda *_: stopping.__setitem__(0, True))
+        signal.signal(signal.SIGINT, lambda *_: stopping.__setitem__(0, True))
+        try:
+            with store.transaction():
+                store.db.execute("UPDATE jobs SET pgid=? WHERE job_id=?", (group.pid, job_id))
+                store.event(job_id, "job-running", {"execution_id": execution, "pgid": group.pid})
+            group.stdin.write(b"go\n")
+            group.stdin.flush()
+            while not done:
+                row = store.job(job_id)
+                if (row["cancel_requested"] or stopping[0]) and cancel_at is None:
+                    cancel_at = time.monotonic()
+                    os.killpg(group.pid, signal.SIGTERM)
+                if select.select([group.stdout], [], [], 0.05)[0]:
+                    done = bool(os.read(group.stdout.fileno(), 64) in (b"done\n", b""))
+                if cancel_at is not None and time.monotonic() - cancel_at >= 1:
+                    break
+        finally:
+            # Do not call poll()/wait() before killpg: keeping the child
+            # unreaped pins the group ID even when the group leader crashed.
+            try:
+                os.killpg(group.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            group.wait()
+            group.stdin.close()
+            group.stdout.close()
+        result = terminal_result(directory / "result.json")
+        if not done:
+            result = {"outcome": "unknown", "reason": "cancelled_without_terminal_handler_receipt"}
+        result["execution_id"] = execution
+        write_json(directory / "execution-receipt.json", result)
+        store.finish(job_id, execution, result)
+
+
+def authorize_attempt(store, job_id):
+    row = store.job(job_id)
+    if (os.environ.get("HEADLONG_JOB_ID") != job_id or row["state"] != "running"
+        or row["execution"] != os.environ.get("HEADLONG_JOB_EXECUTION_ID")
+        or row["token"] != os.environ.get("HEADLONG_JOB_EXECUTION_TOKEN")
+        or os.getpgrp() != row["pgid"] or row["cancel_requested"]):
+        raise ValueError("attempt requires the live admitted job's owned process group")
+
+
+def response_evidence(directory):
+    try:
+        with (directory / "response.json").open() as stream:
+            response = read_json(stream)
+        status = response.get("status")
+        if (not isinstance(response.get("id"), str) or not response["id"] or response.get("error")
+            or not isinstance(response.get("output"), list)):
+            status = "unknown"
+    except (OSError, ValueError, AttributeError):
+        status, response = "unknown", None
+    return status if isinstance(status, str) and status in {"completed", "cancelled"} else "unknown", response
+
+
+def reconcile_attempts(store, job_id):
+    for attempt_row in store.db.execute("SELECT * FROM attempts WHERE job_id=? AND state='started'", (job_id,)).fetchall():
+        directory = store.directory(job_id) / ("attempt-" + digest(attempt_row["attempt_id"]))
+        outcome, response = response_evidence(directory)
+        result = {"outcome": outcome, "response": response, "replayable": False,
+                  "reason": "reconciled_from_sidecar" if outcome != "unknown" else "attempt_custody_lost"}
+        with store.transaction():
+            store.db.execute("UPDATE attempts SET state=?,result=? WHERE job_id=? AND attempt_id=? AND state='started'",
+                             (outcome, encode(result), job_id, attempt_row["attempt_id"]))
+            store.event(job_id, "attempt-reconciled", {"attempt_id": attempt_row["attempt_id"], "outcome": outcome})
+
+
+def attempt(store, job_id, attempt_id, argv):
+    nonempty(attempt_id, "attempt_id")
+    if not argv:
+        raise ValueError("attempt requires an executable argv")
+    payload = sys.stdin.buffer.read(LIMIT + 1)
+    if len(payload) > LIMIT:
+        raise ValueError("attempt input too large")
+    controls = {key: value for key, value in os.environ.items()
+                if key.startswith(("LLM_", "SHELLM_")) and key != "LLM_RESPONSE_FILE"}
+    body_path = controls.get("LLM_RESPONSES_BODY_FILE")
+    body_bytes = Path(body_path).read_bytes() if body_path else None
+    request_hash = digest(encode({"argv": argv, "stdin_sha256": hashlib.sha256(payload).hexdigest(),
+        "controls": controls, "context": os.environ.get("HEADLONG_JOB_ATTEMPT_CONTEXT"),
+        "body_sha256": hashlib.sha256(body_bytes).hexdigest() if body_bytes is not None else None}))
+    directory = store.directory(job_id) / ("attempt-" + digest(attempt_id))
+    directory.mkdir(mode=0o700, exist_ok=True)
+    with store.transaction():
+        authorize_attempt(store, job_id)
+        old = store.db.execute("SELECT * FROM attempts WHERE job_id=? AND attempt_id=?", (job_id, attempt_id)).fetchone()
+        if old:
+            if old["request_hash"] != request_hash:
+                raise ValueError("attempt_id reused with different input/argv")
+        else:
+            store.db.execute("INSERT INTO attempts VALUES(?,?,?,'started',NULL)", (job_id, attempt_id, request_hash))
+            store.event(job_id, "attempt-started", {"attempt_id": attempt_id, "request_hash": request_hash})
+    if old:
+        if old["state"] == "completed" and json.loads(old["result"]).get("replayable"):
+            sys.stdout.buffer.write((directory / "stdout").read_bytes())
+            return 0
+        print(encode({"outcome": "unknown", "reason": "attempt_already_started", "attempt_id": attempt_id}), file=sys.stderr)
+        return 75
+    env = dict(os.environ, HEADLONG_JOB_ATTEMPT_ID=attempt_id, LLM_RESPONSE_FILE=str(directory / "response.json"))
+    if body_bytes is not None:
+        snapshot = directory / "body.json"
+        with snapshot.open("wb") as body:
+            body.write(body_bytes)
+            body.flush()
+            os.fsync(body.fileno())
+        sync_dir(directory)
+        env["LLM_RESPONSES_BODY_FILE"] = str(snapshot)
+    with (directory / "stdout").open("wb") as out, (directory / "stderr").open("wb") as err:
+        child = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=out, stderr=err, env=env)
+        child.communicate(payload)
+        out.flush()
+        os.fsync(out.fileno())
+        err.flush()
+        os.fsync(err.fileno())
+    sync_dir(directory)
+    sync_dir(directory.parent)
+    # PR1's typed sidecar, not stdout/exit status, proves a model terminal.
+    outcome, response = response_evidence(directory)
+    if child.returncode != 0 and outcome == "completed":
+        outcome = "unknown"
+    result = {"outcome": outcome, "returncode": child.returncode, "response": response, "replayable": outcome == "completed"}
+    with store.transaction():
+        store.db.execute("UPDATE attempts SET state=?,result=? WHERE job_id=? AND attempt_id=?",
+                         (outcome, encode(result), job_id, attempt_id))
+        store.event(job_id, "attempt-terminal", {"attempt_id": attempt_id, "outcome": outcome})
+    sys.stdout.buffer.write((directory / "stdout").read_bytes())
+    return 0 if outcome == "completed" else 75
+
+
+def recover(store, job_id, evidence):
+    # Recovery is an explicit operator adjudication. It never executes a
+    # handler or a CREATE, and never clears the immutable cancellation fence.
+    if (not isinstance(evidence, dict) or not isinstance(evidence.get("outcome"), str)
+        or evidence["outcome"] not in {"completed", "cancelled"}):
+        raise ValueError("recovery requires a completed/cancelled outcome")
+    nonempty(evidence.get("receipt_ref"), "receipt_ref")
+    receipt_hash = nonempty(evidence.get("receipt_sha256"), "receipt_sha256")
+    if len(receipt_hash) != 64 or any(c not in "0123456789abcdef" for c in receipt_hash):
+        raise ValueError("receipt_sha256 must be a lowercase SHA-256 digest")
+    with store.transaction():
+        row = store.job(job_id)
+        if row["state"] != "unknown" or alive_worker(store, row):
+            raise ValueError("only an unknown job without a live worker can be reconciled")
+        if evidence.get("execution_id") != row["execution"]:
+            raise ValueError("recovery execution_id mismatch")
+        store.db.execute("UPDATE jobs SET state=?,result=?,recovery=? WHERE job_id=?",
+                         (evidence["outcome"], encode(evidence), encode(evidence), job_id))
+        store.event(job_id, "job-reconciled", evidence)
+    return store.receipt(store.job(job_id))
+
+
+def main():
+    os.umask(0o077)
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    for name in ("admit", "list", "start", "stop"):
+        sub.add_parser(name)
+    for name in ("get", "cancel", "recover", "attempts"):
+        sub.add_parser(name).add_argument("job_id")
+    sub.add_parser("register").add_argument("handler")
+    p = sub.add_parser("attempt")
+    p.add_argument("job_id")
+    p.add_argument("attempt_id")
+    p.add_argument("argv", nargs=argparse.REMAINDER)
+    sub.add_parser("_dispatch").add_argument("ready_fd", type=int)
+    sub.add_parser("_legacy-start").add_argument("argv", nargs=argparse.REMAINDER)
+    for name in ("_worker", "_execute"):
+        p = sub.add_parser(name)
+        p.add_argument("job_id")
+        p.add_argument("execution")
+        if name == "_worker":
+            p.add_argument("lock_fd", type=int)
+    args = parser.parse_args()
+    store = Store()
+    if args.cmd == "register":
+        result = register(store, args.handler, read_json(sys.stdin))
+    elif args.cmd == "admit":
+        result = admit(store, read_json(sys.stdin))
+    elif args.cmd == "get":
+        result = store.receipt(store.job(args.job_id))
+    elif args.cmd == "attempts":
+        store.job(args.job_id)
+        result = [{"attempt_id": row["attempt_id"], "state": row["state"], "request_hash": row["request_hash"],
+                   "result": json.loads(row["result"]) if row["result"] else None}
+                  for row in store.db.execute("SELECT * FROM attempts WHERE job_id=? ORDER BY rowid", (args.job_id,))]
+    elif args.cmd == "list":
+        result = [store.receipt(row) for row in store.db.execute("SELECT * FROM jobs ORDER BY created,job_id")]
+    elif args.cmd == "cancel":
+        result = cancel(store, args.job_id)
+    elif args.cmd == "recover":
+        result = recover(store, args.job_id, read_json(sys.stdin))
+    elif args.cmd == "start":
+        result = start(store)
+    elif args.cmd == "stop":
+        store.db.execute("INSERT OR REPLACE INTO control VALUES('dispatcher','stopped')")
+        result = {"mode": "jobs-only", "dispatch": "stop_requested", "running_jobs": "preserved"}
+    elif args.cmd == "_legacy-start":
+        with lock(store.root / "start.lock", blocking=True):
+            if (store.root / "mode.json").exists():
+                raise ValueError("identity uses durable jobs; start with --jobs-only")
+            return subprocess.call(args.argv, env=dict(os.environ, HEADLONG_START_LOCKED="1"))
+    elif args.cmd == "_dispatch":
+        dispatch(store, getattr(args, "ready_fd", None))
+        return 0
+    elif args.cmd == "_worker":
+        worker(store, args.job_id, args.execution, args.lock_fd)
+        return 0
+    elif args.cmd == "_execute":
+        execute(store, args.job_id, args.execution)
+        return 0
+    else:
+        return attempt(store, args.job_id, args.attempt_id, args.argv[1:] if args.argv[:1] == ["--"] else args.argv)
+    print(encode(result))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (ValueError, OSError, sqlite3.Error) as exc:
+        print("headlong-jobs: " + str(exc), file=sys.stderr)
+        sys.exit(1)

--- a/tools/headlong-jobs
+++ b/tools/headlong-jobs
@@ -93,6 +93,19 @@ class Store:
             seq INTEGER PRIMARY KEY AUTOINCREMENT, job_id TEXT NOT NULL, type TEXT NOT NULL,
             payload TEXT NOT NULL, created REAL NOT NULL);
         """)
+        with self.transaction():
+            columns = {row["name"] for row in self.db.execute("PRAGMA table_info(attempts)")}
+            for name, kind in (("adapter_state", "TEXT"), ("adapter_pgid", "INTEGER"), ("adapter_owner", "INTEGER")):
+                if name not in columns:
+                    self.db.execute("ALTER TABLE attempts ADD COLUMN " + name + " " + kind)
+            if "waiting_on" not in {row["name"] for row in self.db.execute("PRAGMA table_info(jobs)")}:
+                self.db.execute("ALTER TABLE jobs ADD COLUMN waiting_on TEXT")
+        # Pre-upgrade identities never wrote a durable legacy ledger. Its
+        # absence cannot prove quiescence after run/ was lost or cleared.
+        if ((self.identity / "thinkers").exists() or (self.identity / "info.txt").exists()) and not (self.root / "mode.json").exists():
+            self.db.execute("""INSERT OR IGNORE INTO control(key,value)
+                SELECT 'legacy_execution',? WHERE NOT EXISTS(SELECT 1 FROM control WHERE key='legacy_retired')""",
+                ("untracked-" + uuid.uuid4().hex,))
         sync_dir(self.root)
         sync_dir(self.identity)
 
@@ -217,7 +230,77 @@ def cancel(store, job_id):
                 store.event(row["job_id"], "job-terminal", json.loads(result))
     # Workers poll the durable cancellation fence. No PID supplied by a client
     # is ever signalled, and cancelling still works while the dispatcher is down.
+    for row in rows:
+        wake_parent(store, row["job_id"])
     return store.receipt(store.job(job_id))
+
+
+def wake_parent(store, job_id):
+    try:
+        fd = os.open(store.directory(job_id) / "dependency.fifo", os.O_WRONLY | os.O_NONBLOCK)
+        try:
+            os.write(fd, b"wake\n")
+        finally:
+            os.close(fd)
+    except (FileNotFoundError, BlockingIOError, OSError):
+        pass
+
+
+def resume_dependencies(store, capacity):
+    ready = store.db.execute("""SELECT parent.job_id FROM jobs parent JOIN jobs child ON parent.waiting_on=child.job_id
+        WHERE parent.state='waiting' AND parent.cancel_requested=0 AND child.state IN ('completed','cancelled','unknown')
+        ORDER BY parent.created,parent.job_id""").fetchall()
+    for row in ready:
+        with store.transaction():
+            active = store.db.execute("SELECT count(*) FROM jobs WHERE state IN ('starting','running')").fetchone()[0]
+            if active >= capacity:
+                break
+            changed = store.db.execute("UPDATE jobs SET state='running' WHERE job_id=? AND state='waiting' AND cancel_requested=0", (row["job_id"],)).rowcount
+            if changed:
+                store.event(row["job_id"], "job-resumed", {"dependency": store.job(row["job_id"])["waiting_on"]})
+        if changed:
+            wake_parent(store, row["job_id"])
+
+
+def wait_child(store, job_id, child_id):
+    directory = store.directory(job_id)
+    with lock(directory / "dependency.lock"):
+        fifo = directory / "dependency.fifo"
+        if not fifo.exists():
+            os.mkfifo(fifo, 0o600)
+        fd = os.open(fifo, os.O_RDWR | os.O_NONBLOCK)
+        try:
+            with store.transaction():
+                authorize_attempt(store, job_id)
+                child = store.job(child_id)
+                if child["parent"] != job_id:
+                    raise ValueError("wait-child requires the exact admitted parent/child relationship")
+                if (store.db.execute("SELECT count(*) FROM attempts WHERE job_id=? AND state='started'", (job_id,)).fetchone()[0]
+                    or adapter_custody_alive(store, job_id)):
+                    raise ValueError("finish in-flight model attempts before yielding job capacity")
+                waiting = store.db.execute("SELECT count(*) FROM jobs WHERE state='waiting'").fetchone()[0]
+                if waiting >= int(os.environ.get("HEADLONG_JOBS_MAX_WAITING", "32")):
+                    raise ValueError("dependency wait capacity exhausted")
+                store.db.execute("UPDATE jobs SET state='waiting',waiting_on=? WHERE job_id=?", (child_id, job_id))
+                store.event(job_id, "job-waiting", {"child_job_id": child_id})
+            # The dispatcher alone reacquires execution capacity. The FIFO is
+            # a notification, while the ledger is truth; the bounded timeout
+            # recovers a lost notification without a CPU polling loop.
+            while True:
+                parent = store.job(job_id)
+                if parent["cancel_requested"] or parent["state"] in TERMINAL:
+                    raise ValueError("parent custody ended during dependency wait")
+                if parent["state"] == "running":
+                    child = store.job(child_id)
+                    if child["state"] not in TERMINAL or parent["waiting_on"] != child_id:
+                        raise ValueError("dependency resumed without a terminal child receipt")
+                    with store.transaction():
+                        store.db.execute("UPDATE jobs SET waiting_on=NULL WHERE job_id=? AND waiting_on=?", (job_id, child_id))
+                    return store.receipt(child)
+                if select.select([fd], [], [], 10)[0]:
+                    os.read(fd, 4096)
+        finally:
+            os.close(fd)
 
 
 @contextlib.contextmanager
@@ -253,8 +336,10 @@ def terminal_result(path):
 
 
 def reconcile(store):
-    for row in store.db.execute("SELECT * FROM jobs WHERE state IN ('starting','running')").fetchall():
+    for row in store.db.execute("SELECT * FROM jobs WHERE state IN ('starting','running','waiting')").fetchall():
         if alive_worker(store, row):
+            continue
+        if adapter_custody_alive(store, row["job_id"]):
             continue
         reconcile_attempts(store, row["job_id"])
         # Only the supervisor's receipt proves that the whole owned group was
@@ -306,9 +391,13 @@ def dispatch(store, ready_fd=None):
                 if store.db.execute("SELECT value FROM control WHERE key='dispatcher'").fetchone()[0] != generation:
                     break
                 reconcile(store)
+                limit = int(os.environ.get("HEADLONG_JOBS_MAX_CONCURRENT", "4"))
+                resume_dependencies(store, limit)
                 running = store.db.execute("SELECT count(*) FROM jobs WHERE state IN ('starting','running')").fetchone()[0]
-                capacity = max(0, int(os.environ.get("HEADLONG_JOBS_MAX_CONCURRENT", "4")) - running)
-                queued = store.db.execute("SELECT job_id FROM jobs WHERE state='queued' ORDER BY created,job_id LIMIT ?", (capacity,)).fetchall()
+                capacity = max(0, limit - running)
+                queued = store.db.execute("""SELECT queued.job_id FROM jobs queued WHERE queued.state='queued'
+                    ORDER BY EXISTS(SELECT 1 FROM jobs parent WHERE parent.state='waiting' AND parent.waiting_on=queued.job_id) DESC,
+                    queued.created,queued.job_id LIMIT ?""", (capacity,)).fetchall()
                 for entry in queued:
                     job_id, execution, token = entry["job_id"], uuid.uuid4().hex, uuid.uuid4().hex
                     with lock(store.directory(job_id) / "worker.lock") as ownership:
@@ -345,6 +434,9 @@ def start(store):
     # Persist the identity's exclusive mode before starting. Legacy start fails
     # closed for this identity even after run/ is removed by a restart wrapper.
     with lock(store.root / "start.lock"):
+        legacy = store.db.execute("SELECT value FROM control WHERE key='legacy_execution'").fetchone()
+        if legacy is not None:
+            raise ValueError("legacy execution has not been reconciled; retire-legacy requires verified quiescence evidence")
         pid_path = store.identity / "run" / "dispatcher.pid"
         if pid_path.exists():
             try:
@@ -430,9 +522,12 @@ def worker(store, job_id, execution, lock_fd):
                 store.event(job_id, "job-terminal", result)
                 return
             store.db.execute("UPDATE jobs SET state='running',worker_pid=? WHERE job_id=?", (os.getpid(), job_id))
+        cancel_at, done = None, False
+        grace = float(os.environ.get("HEADLONG_JOB_CANCEL_GRACE", "6"))
+        if not 0 <= grace <= 60:
+            raise ValueError("HEADLONG_JOB_CANCEL_GRACE must be between 0 and 60 seconds")
         group = subprocess.Popen([sys.executable, SELF, "_execute", job_id, execution],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, start_new_session=True)
-        cancel_at, done = None, False
         stopping = [False]
         signal.signal(signal.SIGTERM, lambda *_: stopping.__setitem__(0, True))
         signal.signal(signal.SIGINT, lambda *_: stopping.__setitem__(0, True))
@@ -442,15 +537,19 @@ def worker(store, job_id, execution, lock_fd):
                 store.event(job_id, "job-running", {"execution_id": execution, "pgid": group.pid})
             group.stdin.write(b"go\n")
             group.stdin.flush()
-            while not done:
+            while True:
                 row = store.job(job_id)
                 if (row["cancel_requested"] or stopping[0]) and cancel_at is None:
                     cancel_at = time.monotonic()
                     os.killpg(group.pid, signal.SIGTERM)
-                if select.select([group.stdout], [], [], 0.05)[0]:
+                if not done and select.select([group.stdout], [], [], 0.05)[0]:
                     done = bool(os.read(group.stdout.fileno(), 64) in (b"done\n", b""))
-                if cancel_at is not None and time.monotonic() - cancel_at >= 1:
+                if done and cancel_at is None:
                     break
+                if cancel_at is not None and time.monotonic() - cancel_at >= grace:
+                    break
+                if done:
+                    time.sleep(0.05)
         finally:
             # Do not call poll()/wait() before killpg: keeping the child
             # unreaped pins the group ID even when the group leader crashed.
@@ -461,7 +560,20 @@ def worker(store, job_id, execution, lock_fd):
             group.wait()
             group.stdin.close()
             group.stdout.close()
+        # Attempt subgroups have their own pipe guardians. Root-group death
+        # closes those pipes, but custody is not terminal until those guardians
+        # have swept their own groups and released their inherited locks.
+        while adapter_custody_alive(store, job_id):
+            time.sleep(0.05)
+        reconcile_attempts(store, job_id)
         result = terminal_result(directory / "result.json")
+        if result["outcome"] == "completed":
+            try:
+                exit_code = json.loads((directory / "exit.json").read_text())["returncode"]
+            except (OSError, ValueError, KeyError):
+                exit_code = None
+            if exit_code != 0:
+                result = {"outcome": "unknown", "reason": "handler_did_not_exit_successfully", "evidence": result}
         if not done:
             result = {"outcome": "unknown", "reason": "cancelled_without_terminal_handler_receipt"}
         result["execution_id"] = execution
@@ -476,6 +588,110 @@ def authorize_attempt(store, job_id):
         or row["token"] != os.environ.get("HEADLONG_JOB_EXECUTION_TOKEN")
         or os.getpgrp() != row["pgid"] or row["cancel_requested"]):
         raise ValueError("attempt requires the live admitted job's owned process group")
+
+
+def adapter_custody_alive(store, job_id):
+    for row in store.db.execute("SELECT attempt_id FROM attempts WHERE job_id=? AND adapter_state IS NOT NULL", (job_id,)):
+        directory = store.directory(job_id) / ("attempt-" + digest(row["attempt_id"]))
+        try:
+            with lock(directory / "adapter.lock"):
+                pass
+        except BlockingIOError:
+            return True
+    return False
+
+
+def adapter_guard(store, job_id, attempt_id, out_fd, err_fd, lock_fd):
+    with os.fdopen(lock_fd, "a+"):
+        signal.signal(signal.SIGTERM, lambda *_: None)
+        signal.signal(signal.SIGINT, lambda *_: None)
+        if sys.stdin.readline() != "go\n":
+            return
+        row = store.db.execute("SELECT * FROM attempts WHERE job_id=? AND attempt_id=?", (job_id, attempt_id)).fetchone()
+        if row is None or row["adapter_pgid"] != os.getpid() or row["adapter_owner"] != os.getppid() or os.getpgrp() != os.getpid():
+            raise ValueError("adapter requires its admitted attempt guardian")
+        directory = store.directory(job_id) / ("attempt-" + digest(attempt_id))
+        spec = json.loads((directory / "adapter-spec.json").read_text())
+        with (directory / "adapter-input").open("rb") as payload:
+            child = subprocess.Popen(spec["argv"], stdin=payload, stdout=out_fd, stderr=err_fd)
+        while child.poll() is None:
+            if select.select([sys.stdin], [], [], 0.05)[0] and not os.read(sys.stdin.fileno(), 64):
+                os.killpg(os.getpgrp(), signal.SIGKILL)
+        print(str(child.returncode), flush=True)
+        # Keep the group leader unreaped and reserved until its controller
+        # kills the whole group; EOF also handles controller/root-job death.
+        while True:
+            if select.select([sys.stdin], [], [], 1)[0] and not os.read(sys.stdin.fileno(), 64):
+                os.killpg(os.getpgrp(), signal.SIGKILL)
+
+
+def run_adapter(store, argv, deadline):
+    job_id = nonempty(os.environ.get("HEADLONG_JOB_ID"), "HEADLONG_JOB_ID")
+    attempt_id = nonempty(os.environ.get("HEADLONG_JOB_ATTEMPT_ID"), "HEADLONG_JOB_ATTEMPT_ID")
+    if not argv or deadline < 0:
+        raise ValueError("adapter argv and nonnegative deadline required")
+    payload = sys.stdin.buffer.read(LIMIT + 1)
+    if len(payload) > LIMIT:
+        raise ValueError("adapter input too large")
+    directory = store.directory(job_id) / ("attempt-" + digest(attempt_id))
+    with lock(directory / "adapter.lock") as ownership:
+        with store.transaction():
+            authorize_attempt(store, job_id)
+            row = store.db.execute("SELECT * FROM attempts WHERE job_id=? AND attempt_id=?", (job_id, attempt_id)).fetchone()
+            if row is None or row["state"] != "started" or row["adapter_state"] is not None:
+                raise ValueError("adapter execution requires an unused admitted attempt")
+            store.db.execute("UPDATE attempts SET adapter_state='starting' WHERE job_id=? AND attempt_id=?", (job_id, attempt_id))
+            store.event(job_id, "attempt-group-starting", {"attempt_id": attempt_id})
+        write_json(directory / "adapter-spec.json", {"argv": argv, "deadline": deadline})
+        with (directory / "adapter-input").open("wb") as incoming:
+            incoming.write(payload)
+            incoming.flush()
+            os.fsync(incoming.fileno())
+        out_fd, err_fd = os.dup(sys.stdout.fileno()), os.dup(sys.stderr.fileno())
+        group = subprocess.Popen([sys.executable, SELF, "_adapter-guard", job_id, attempt_id,
+            str(out_fd), str(err_fd), str(ownership.fileno())], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            start_new_session=True, pass_fds=(out_fd, err_fd, ownership.fileno()))
+        os.close(out_fd)
+        os.close(err_fd)
+        stopping, signalled, timed_out, result = [False], None, False, None
+        signal.signal(signal.SIGTERM, lambda *_: stopping.__setitem__(0, True))
+        signal.signal(signal.SIGINT, lambda *_: stopping.__setitem__(0, True))
+        begun = time.monotonic()
+        buffer = b""
+        try:
+            with store.transaction():
+                store.db.execute("UPDATE attempts SET adapter_state='running',adapter_pgid=?,adapter_owner=? WHERE job_id=? AND attempt_id=?",
+                                 (group.pid, os.getpid(), job_id, attempt_id))
+            group.stdin.write(b"go\n")
+            group.stdin.flush()
+            while True:
+                elapsed = time.monotonic() - begun
+                if signalled is None and (stopping[0] or (deadline > 0 and elapsed >= deadline)):
+                    timed_out = not stopping[0]
+                    signalled = time.monotonic()
+                    os.killpg(group.pid, signal.SIGTERM)
+                if select.select([group.stdout], [], [], 0.05)[0]:
+                    chunk = os.read(group.stdout.fileno(), 64)
+                    buffer += chunk
+                    if b"\n" in buffer:
+                        result = int(buffer.split(b"\n", 1)[0])
+                        break
+                    if not chunk:
+                        break
+                if signalled is not None and time.monotonic() - signalled >= 5:
+                    break
+        finally:
+            try:
+                os.killpg(group.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            group.wait()
+            group.stdin.close()
+            group.stdout.close()
+        code = 124 if timed_out else (result if result is not None and result >= 0 else 75)
+        write_json(directory / "adapter-exit.json", {"returncode": code, "timed_out": timed_out, "pgid": group.pid})
+        store.db.execute("UPDATE attempts SET adapter_state='stopped' WHERE job_id=? AND attempt_id=?", (job_id, attempt_id))
+        return code
 
 
 def response_evidence(directory):
@@ -526,7 +742,7 @@ def attempt(store, job_id, attempt_id, argv):
             if old["request_hash"] != request_hash:
                 raise ValueError("attempt_id reused with different input/argv")
         else:
-            store.db.execute("INSERT INTO attempts VALUES(?,?,?,'started',NULL)", (job_id, attempt_id, request_hash))
+            store.db.execute("INSERT INTO attempts(job_id,attempt_id,request_hash,state,result) VALUES(?,?,?,'started',NULL)", (job_id, attempt_id, request_hash))
             store.event(job_id, "attempt-started", {"attempt_id": attempt_id, "request_hash": request_hash})
     if old:
         if old["state"] == "completed" and json.loads(old["result"]).get("replayable"):
@@ -534,7 +750,8 @@ def attempt(store, job_id, attempt_id, argv):
             return 0
         print(encode({"outcome": "unknown", "reason": "attempt_already_started", "attempt_id": attempt_id}), file=sys.stderr)
         return 75
-    env = dict(os.environ, HEADLONG_JOB_ATTEMPT_ID=attempt_id, LLM_RESPONSE_FILE=str(directory / "response.json"))
+    env = dict(os.environ, HEADLONG_JOB_ATTEMPT_ID=attempt_id, HEADLONG_JOB_CONTROL_TOOL=SELF,
+               LLM_RESPONSE_FILE=str(directory / "response.json"))
     if body_bytes is not None:
         snapshot = directory / "body.json"
         with snapshot.open("wb") as body:
@@ -565,16 +782,43 @@ def attempt(store, job_id, attempt_id, argv):
     return 0 if outcome == "completed" else 75
 
 
+def recovery_reference(evidence):
+    if not isinstance(evidence, dict):
+        raise ValueError("recovery evidence must be an object")
+    nonempty(evidence.get("receipt_ref"), "receipt_ref")
+    receipt_hash = nonempty(evidence.get("receipt_sha256"), "receipt_sha256")
+    if len(receipt_hash) != 64 or any(c not in "0123456789abcdef" for c in receipt_hash):
+        raise ValueError("receipt_sha256 must be a lowercase SHA-256 digest")
+
+
+def retire_legacy(store, evidence):
+    recovery_reference(evidence)
+    if evidence.get("quiescent") is not True:
+        raise ValueError("retiring legacy execution requires explicit verified quiescence")
+    with lock(store.root / "start.lock"):
+        pid_path = store.identity / "run" / "dispatcher.pid"
+        if pid_path.exists():
+            try:
+                os.kill(int(pid_path.read_text()), 0)
+                raise ValueError("stop the existing dispatcher before retiring legacy execution")
+            except ProcessLookupError:
+                pass
+        with store.transaction():
+            epoch = store.db.execute("SELECT value FROM control WHERE key='legacy_execution'").fetchone()
+            if epoch is None or evidence.get("legacy_execution") != epoch["value"]:
+                raise ValueError("quiescence evidence must bind the current legacy_execution epoch")
+            store.db.execute("INSERT OR REPLACE INTO control VALUES('legacy_retired',?)", (encode(evidence),))
+            store.db.execute("DELETE FROM control WHERE key='legacy_execution'")
+    return {"legacy_execution": "retired", "evidence": evidence}
+
+
 def recover(store, job_id, evidence):
     # Recovery is an explicit operator adjudication. It never executes a
     # handler or a CREATE, and never clears the immutable cancellation fence.
     if (not isinstance(evidence, dict) or not isinstance(evidence.get("outcome"), str)
         or evidence["outcome"] not in {"completed", "cancelled"}):
         raise ValueError("recovery requires a completed/cancelled outcome")
-    nonempty(evidence.get("receipt_ref"), "receipt_ref")
-    receipt_hash = nonempty(evidence.get("receipt_sha256"), "receipt_sha256")
-    if len(receipt_hash) != 64 or any(c not in "0123456789abcdef" for c in receipt_hash):
-        raise ValueError("receipt_sha256 must be a lowercase SHA-256 digest")
+    recovery_reference(evidence)
     with store.transaction():
         row = store.job(job_id)
         if row["state"] != "unknown" or alive_worker(store, row):
@@ -591,15 +835,26 @@ def main():
     os.umask(0o077)
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="cmd", required=True)
-    for name in ("admit", "list", "start", "stop"):
+    for name in ("admit", "list", "start", "stop", "legacy-status", "retire-legacy"):
         sub.add_parser(name)
     for name in ("get", "cancel", "recover", "attempts"):
         sub.add_parser(name).add_argument("job_id")
+    p = sub.add_parser("wait-child")
+    p.add_argument("job_id")
+    p.add_argument("child_id")
     sub.add_parser("register").add_argument("handler")
     p = sub.add_parser("attempt")
     p.add_argument("job_id")
     p.add_argument("attempt_id")
     p.add_argument("argv", nargs=argparse.REMAINDER)
+    p = sub.add_parser("adapter-run")
+    p.add_argument("--deadline", type=int, default=0)
+    p.add_argument("argv", nargs=argparse.REMAINDER)
+    p = sub.add_parser("_adapter-guard")
+    for field in ("job_id", "attempt_id"):
+        p.add_argument(field)
+    for field in ("out_fd", "err_fd", "lock_fd"):
+        p.add_argument(field, type=int)
     sub.add_parser("_dispatch").add_argument("ready_fd", type=int)
     sub.add_parser("_legacy-start").add_argument("argv", nargs=argparse.REMAINDER)
     for name in ("_worker", "_execute"):
@@ -625,10 +880,17 @@ def main():
         result = [store.receipt(row) for row in store.db.execute("SELECT * FROM jobs ORDER BY created,job_id")]
     elif args.cmd == "cancel":
         result = cancel(store, args.job_id)
+    elif args.cmd == "wait-child":
+        result = wait_child(store, args.job_id, args.child_id)
     elif args.cmd == "recover":
         result = recover(store, args.job_id, read_json(sys.stdin))
     elif args.cmd == "start":
         result = start(store)
+    elif args.cmd == "retire-legacy":
+        result = retire_legacy(store, read_json(sys.stdin))
+    elif args.cmd == "legacy-status":
+        epoch = store.db.execute("SELECT value FROM control WHERE key='legacy_execution'").fetchone()
+        result = {"legacy_execution": epoch["value"] if epoch else None}
     elif args.cmd == "stop":
         store.db.execute("INSERT OR REPLACE INTO control VALUES('dispatcher','stopped')")
         result = {"mode": "jobs-only", "dispatch": "stop_requested", "running_jobs": "preserved"}
@@ -636,6 +898,7 @@ def main():
         with lock(store.root / "start.lock", blocking=True):
             if (store.root / "mode.json").exists():
                 raise ValueError("identity uses durable jobs; start with --jobs-only")
+            store.db.execute("INSERT OR REPLACE INTO control VALUES('legacy_execution',?)", (uuid.uuid4().hex,))
             return subprocess.call(args.argv, env=dict(os.environ, HEADLONG_START_LOCKED="1"))
     elif args.cmd == "_dispatch":
         dispatch(store, getattr(args, "ready_fd", None))
@@ -646,6 +909,11 @@ def main():
     elif args.cmd == "_execute":
         execute(store, args.job_id, args.execution)
         return 0
+    elif args.cmd == "_adapter-guard":
+        adapter_guard(store, args.job_id, args.attempt_id, args.out_fd, args.err_fd, args.lock_fd)
+        return 0
+    elif args.cmd == "adapter-run":
+        return run_adapter(store, args.argv[1:] if args.argv[:1] == ["--"] else args.argv, args.deadline)
     else:
         return attempt(store, args.job_id, args.attempt_id, args.argv[1:] if args.argv[:1] == ["--"] else args.argv)
     print(encode(result))

--- a/tools/responses-ws
+++ b/tools/responses-ws
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["websockets>=13"]
+# dependencies = ["websockets==17.1"]
 # ///
 """WebSocket transport for the OpenAI Responses API, as a headlong adapter.
 
@@ -33,6 +33,7 @@ import socket
 import sys
 import time
 import uuid
+from urllib.parse import urlsplit, urlunsplit
 
 import websockets
 from websockets.asyncio.client import connect as ws_connect
@@ -50,8 +51,13 @@ DEFAULT_URL = "wss://api.openai.com/v1/responses"
 MAX_IN_FLIGHT = 16
 MAX_LANES = 32
 CONNECTION_MAX_AGE = 55 * 60
+MAX_FRAME = 16 * 1024 * 1024  # UTF-8 bytes, excluding the local newline
+MAX_QUEUE_EVENTS = 64
+MAX_QUEUE_BYTES = MAX_FRAME
+MAX_CLIENTS = 32  # Active plus queued local calls; reject excess admission.
+IO_TIMEOUT = 30
 
-TERMINAL_EVENTS = ("response.completed", "response.incomplete", "response.failed")
+TERMINAL_EVENTS = ("response.completed", "response.incomplete", "response.failed", "response.cancelled")
 
 
 def die(message: str) -> None:
@@ -82,15 +88,27 @@ def build_create(args, input_items) -> dict:
     Mirrors bin/llm's build_payload_responses so the two transports send the
     same request: the caller's extra body is the base, llm owns the fields
     coupled to its CLI, and encrypted reasoning content is always requested so
-    a stateless replay keeps exact reasoning items. Fields that belong to the
-    HTTP transport rather than the request (stream, background) are dropped,
-    because in WebSocket mode every response streams and the connection is the
-    thing that stays open.
+    a stateless replay keeps exact reasoning items. WebSocket responses always
+    stream; unsupported lifecycle and policy settings are rejected, not dropped.
     """
     body = {}
     body_file = os.environ.get("LLM_RESPONSES_BODY_FILE", "")
     if body_file:
         body.update(read_body_file(body_file))
+    background = os.environ.get("LLM_RESPONSES_BACKGROUND", "")
+    if background not in ("", "0", "1"):
+        die("LLM_RESPONSES_BACKGROUND must be 0 or 1")
+    # An explicit foreground override has the same precedence as HTTP. Only
+    # an effectively background request is unsupported; never silently drop it.
+    if background == "0":
+        body.pop("background", None)
+    if background == "1" or body.get("background") is True:
+        die("background responses are not supported over WebSocket; use HTTP")
+    if body.get("background") is not None and body.get("background") is not False:
+        die("background must be a boolean")
+    for field in ("stream_options", "provider"):
+        if field in body:
+            die("%s is not supported over WebSocket" % field)
     body.pop("stream", None)
     body.pop("background", None)
 
@@ -104,10 +122,16 @@ def build_create(args, input_items) -> dict:
                 body["instructions"] = handle.read()
         except OSError as exc:
             die("cannot read --system-prompt-file: %s" % exc)
+    else:
+        body.pop("instructions", None)
+    if not body.get("instructions"):
+        body.pop("instructions", None)
 
     previous = os.environ.get("LLM_PREVIOUS_RESPONSE_ID", "")
     if previous:
         body["previous_response_id"] = previous
+    else:
+        body.pop("previous_response_id", None)
 
     # Server-held conversation state, the alternative to the id chain. llm
     # refuses the pair before it reaches an adapter, so this is a plain
@@ -115,14 +139,26 @@ def build_create(args, input_items) -> dict:
     conversation = os.environ.get("LLM_RESPONSES_CONVERSATION", "")
     if conversation:
         body["conversation"] = conversation
+    if previous and body.get("conversation") is not None:
+        die("conversation and previous_response_id cannot both be set; pick one")
+
+    threshold = os.environ.get("LLM_RESPONSES_COMPACT_THRESHOLD", "")
+    if threshold:
+        if not threshold.isascii() or not threshold.isdecimal() or int(threshold) <= 0:
+            die("LLM_RESPONSES_COMPACT_THRESHOLD must be a positive integer")
+        body["context_management"] = [{"type": "compaction", "compact_threshold": int(threshold)}]
 
     effort = args.thinking if args.thinking else args.effort
     if effort:
+        if body.get("reasoning") is not None and not isinstance(body["reasoning"], dict):
+            die("reasoning must be an object")
         reasoning = dict(body.get("reasoning") or {})
         reasoning["effort"] = effort
         reasoning["summary"] = "auto"
         body["reasoning"] = reasoning
 
+    if body.get("include") is not None and not isinstance(body["include"], list):
+        die("include must be an array")
     include = list(body.get("include") or [])
     if "reasoning.encrypted_content" not in include:
         include.append("reasoning.encrypted_content")
@@ -239,10 +275,10 @@ class Emitter:
         if kind in ("response.completed", "response.incomplete"):
             self._finish(event.get("response") or {}, kind)
             return True
-        if kind == "response.failed":
+        if kind in ("response.failed", "response.cancelled"):
             response = event.get("response") or {}
             write_sidecar(response)
-            message = ((response.get("error") or {}).get("message")) or "response failed"
+            message = ((response.get("error") or {}).get("message")) or kind
             sys.stderr.write("responses-ws: error: %s\n" % message)
             self.terminal = True
             self.exit_code = 1
@@ -261,6 +297,12 @@ class Emitter:
         return False
 
     def _finish(self, response, kind: str) -> None:
+        if (not isinstance(response, dict) or response.get("error") is not None
+                or response.get("status") != kind.removeprefix("response.")
+                or not isinstance(response.get("id"), str) or not response["id"]
+                or not isinstance(response.get("output"), list)):
+            self.feed(transport_error("invalid terminal response"))
+            return
         self.terminal = True
         write_sidecar(response)
         write_usage(response)
@@ -285,13 +327,40 @@ class Emitter:
 # ---------------------------------------------------------------------------
 
 
+def encode_frame(obj) -> bytes:
+    raw = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    if len(raw) > MAX_FRAME:
+        raise ValueError("frame_too_large: maximum JSON frame is 16 MiB")
+    return raw
+
+
+async def read_line(reader):
+    try:
+        raw = await reader.readline()
+    except ValueError:
+        raise ValueError("frame_too_large: maximum JSON frame is 16 MiB") from None
+    if len(raw.rstrip(b"\n")) > MAX_FRAME:
+        raise ValueError("frame_too_large: maximum JSON frame is 16 MiB")
+    if raw and not raw.endswith(b"\n"):
+        raise ValueError("incomplete JSON frame")
+    return raw
+
+
 def send_line(writer, obj) -> None:
-    writer.write((json.dumps(obj, separators=(",", ":")) + "\n").encode("utf-8"))
+    writer.write(encode_frame(obj) + b"\n")
 
 
 async def drain_line(writer, obj) -> None:
     send_line(writer, obj)
-    await writer.drain()
+    await asyncio.wait_for(writer.drain(), IO_TIMEOUT)
+
+
+async def close_writer(writer):
+    writer.close()
+    try:
+        await asyncio.wait_for(writer.wait_closed(), IO_TIMEOUT)
+    except (OSError, asyncio.TimeoutError):
+        writer.transport.abort()
 
 
 def socket_is_live(path: str) -> bool:
@@ -313,45 +382,86 @@ def socket_is_live(path: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def endpoint_config():
+    """Resolve the underlying provider before choosing destination or credentials.
+
+    An explicit URL is authoritative (including its path and query). Merely
+    selecting this adapter must never turn a compatible request into OpenAI.
+    """
+    provider = os.environ.get("RESPONSES_WS_PROVIDER", "")
+    if not provider:
+        provider = os.environ.get("LLM_PROVIDER", "")
+        if provider == "adapter":
+            provider = ""
+    configured_url = os.environ.get("LLM_API_URL") or os.environ.get("SHELLM_API_URL")
+    provider = provider or ("openai-compatible" if configured_url else "openai")
+    if provider not in ("openai", "openai-compatible"):
+        die("provider %s is not supported over WebSocket; use HTTP" % provider)
+    for setting in ("LLM_OR_ONLY", "LLM_OR_DATA_COLLECTION", "LLM_OR_ZDR"):
+        if os.environ.get(setting):
+            die("%s policy cannot be enforced over this WebSocket transport" % setting)
+    if os.environ.get("LLM_STOP_AFTER_CODE_BLOCK", "0") != "0":
+        die("LLM_STOP_AFTER_CODE_BLOCK is not supported over WebSocket")
+    url = os.environ.get("RESPONSES_WS_URL") or configured_url
+    if not url:
+        if provider == "openai-compatible":
+            die("LLM_API_URL is required for openai-compatible (or RESPONSES_WS_URL)")
+        url = DEFAULT_URL
+    try:
+        parts = urlsplit(url)
+        scheme = {"http": "ws", "https": "wss"}.get(parts.scheme, parts.scheme)
+        if scheme not in ("ws", "wss") or not parts.hostname or parts.username or parts.password or parts.fragment:
+            raise ValueError()
+        url = urlunsplit((scheme, parts.netloc, parts.path, parts.query, ""))
+    except ValueError:
+        die("invalid WebSocket endpoint: expected http(s) or ws(s), without userinfo or fragment")
+    key = os.environ.get("OPENAI_API_KEY" if provider == "openai" else "LLM_API_KEY", "")
+    return url, key
+
+
 def connect_kwargs():
-    key = os.environ.get("OPENAI_API_KEY", "")
+    _, key = endpoint_config()
     headers = {}
     if key:
         # The key travels in a header, never on argv, for the same reason
         # bin/llm's add_auth_header exists: argv is world readable.
         headers["Authorization"] = "Bearer %s" % key
-    return {"additional_headers": headers, "max_size": None}
+    return {"additional_headers": headers, "max_size": MAX_FRAME, "max_queue": 16,
+            "open_timeout": 10, "close_timeout": 5}
 
 
 async def run_one_shot(url: str, create: dict, emitter: Emitter) -> int:
+    identity = ResponseIdentity()
     try:
+        payload = encode_frame(create).decode("utf-8")
         async with ws_connect(url, **connect_kwargs()) as ws:
-            await ws.send(json.dumps(create, separators=(",", ":")))
+            await ws.send(payload)
             async for raw in ws:
-                try:
-                    event = json.loads(raw)
-                except ValueError:
-                    continue
+                event = json.loads(raw)
+                identity.validate(event)
                 if emitter.feed(event):
                     break
-    except OSError as exc:
-        sys.stderr.write("responses-ws: error: cannot reach %s: %s\n" % (url, exc))
-        return 1
-    except websockets.exceptions.WebSocketException as exc:
-        sys.stderr.write("responses-ws: error: websocket failed: %s\n" % exc)
+    except (OSError, ValueError, websockets.exceptions.WebSocketException) as exc:
+        error = transport_error("WebSocket failure; response outcome unknown: %s" % exc)
+        if identity.response_id:
+            error["id"] = identity.response_id
+        emitter.feed(error)
         return 1
     if not emitter.terminal:
-        sys.stderr.write("responses-ws: error: connection closed before a terminal event\n")
+        error = transport_error("connection closed before a terminal event")
+        if identity.response_id:
+            error["id"] = identity.response_id
+        emitter.feed(error)
         return 1
     return emitter.exit_code
 
 
 async def run_via_broker(path: str, create: dict, emitter: Emitter) -> int:
-    reader, writer = await asyncio.open_unix_connection(path)
+    reader, writer = await asyncio.open_unix_connection(path, limit=MAX_FRAME + 1)
     try:
         await drain_line(writer, {"op": "create", "body": create})
         while True:
-            raw = await reader.readline()
+            raw = await read_line(reader)
             if not raw:
                 break
             try:
@@ -359,18 +469,16 @@ async def run_via_broker(path: str, create: dict, emitter: Emitter) -> int:
             except ValueError:
                 continue
             if message.get("op") == "error":
-                sys.stderr.write("responses-ws: error: %s\n" % message.get("message", "broker error"))
+                emitter.feed(transport_error(message.get("message", "broker error")))
                 return 1
             if message.get("op") != "event":
                 continue
             if emitter.feed(message.get("event") or {}):
                 break
     finally:
-        writer.close()
-        with contextlib.suppress(Exception):
-            await writer.wait_closed()
+        await close_writer(writer)
     if not emitter.terminal:
-        sys.stderr.write("responses-ws: error: broker closed before a terminal event\n")
+        emitter.feed(transport_error("broker closed before a terminal event"))
         return 1
     return emitter.exit_code
 
@@ -378,7 +486,10 @@ async def run_via_broker(path: str, create: dict, emitter: Emitter) -> int:
 def run_adapter(args) -> int:
     if args.api_format != "responses":
         die("only --api-format responses is supported (this adapter speaks the Responses protocol)")
-    raw_input_items = sys.stdin.read()
+    url, _ = endpoint_config()  # Validate even when using a broker.
+    raw_input_items = sys.stdin.read(MAX_FRAME + 1)
+    if len(raw_input_items.encode("utf-8")) > MAX_FRAME:
+        die("frame_too_large: maximum input is 16 MiB")
     try:
         input_items = json.loads(raw_input_items) if raw_input_items.strip() else []
     except ValueError as exc:
@@ -387,9 +498,10 @@ def run_adapter(args) -> int:
     emitter = Emitter(stream=not args.no_stream)
 
     broker = os.environ.get("RESPONSES_WS_SOCKET", "")
-    if broker and socket_is_live(broker):
+    if broker:
+        # A configured broker is authoritative. Its absence is not permission
+        # to dispatch the model request through a new independent connection.
         return asyncio.run(run_via_broker(broker, create, emitter))
-    url = os.environ.get("RESPONSES_WS_URL", "") or DEFAULT_URL
     return asyncio.run(run_one_shot(url, create, emitter))
 
 
@@ -398,77 +510,171 @@ def run_adapter(args) -> int:
 # ---------------------------------------------------------------------------
 
 
+def transport_error(message, code="outcome_unknown"):
+    return {"type": "error", "error": {"code": code, "message": message}}
+
+
+class ResponseIdentity:
+    def __init__(self):
+        self.response_id = None
+
+    def validate(self, event):
+        if not isinstance(event, dict):
+            raise ValueError("malformed upstream event: expected an object")
+        response = event.get("response")
+        if response is not None and not isinstance(response, dict):
+            raise ValueError("malformed upstream response")
+        ids = [event.get("response_id"), (response or {}).get("id")]
+        for rid in ids:
+            if rid is None:
+                continue
+            if not isinstance(rid, str) or not rid:
+                raise ValueError("invalid response ID")
+            if self.response_id is not None and self.response_id != rid:
+                raise ValueError("response ID mismatch")
+            self.response_id = rid
+
+
+class Lane(ResponseIdentity):
+    def __init__(self):
+        super().__init__()
+        self.queue = asyncio.Queue(maxsize=MAX_QUEUE_EVENTS)
+        self.queued_bytes = 0
+        self.settled = False
+
+    def put(self, event):
+        size = len(encode_frame({"op": "event", "event": event}))
+        if self.queued_bytes + size > MAX_QUEUE_BYTES or self.queue.full():
+            raise ValueError("slow consumer: bounded event queue exceeded")
+        self.queue.put_nowait((event, size))
+        self.queued_bytes += size
+
+    def fail(self, event):
+        # Retirement must never wait on a slow downstream consumer.
+        while not self.queue.empty():
+            self.queue.get_nowait()
+        self.queued_bytes = 0
+        self.put(event)
+
+
+class Connection:
+    """An exact ownership generation, never shared with its replacement."""
+    def __init__(self, ws):
+        self.ws = ws
+        self.opened_at = time.monotonic()
+        self.lanes = {}
+        self.free_lanes = ["lane-%d" % i for i in range(MAX_LANES)]
+        self.retired = False
+
+
 class Broker:
     def __init__(self, url: str, idle_seconds: float):
         self.url = url
         self.idle_seconds = idle_seconds
-        self.ws = None
-        self.opened_at = 0.0
-        self.reader_task = None
+        self.connection = None
+        self.tasks = set()
         self.lock = asyncio.Lock()
-        self.lanes = {}
-        self.free_lanes = ["lane-%d" % i for i in range(MAX_LANES)]
         self.slots = asyncio.Semaphore(MAX_IN_FLIGHT)
+        self.clients = 0
         self.last_activity = time.monotonic()
         self.stopping = asyncio.Event()
 
+    def track(self, coroutine):
+        task = asyncio.create_task(coroutine)
+        self.tasks.add(task)
+        task.add_done_callback(self.tasks.discard)
+        return task
+
     async def ensure_connection(self):
-        async with self.lock:
-            stale = self.ws is not None and (time.monotonic() - self.opened_at) > CONNECTION_MAX_AGE
-            if stale and not self.lanes:
-                await self.close_connection()
-            if self.ws is None:
-                self.ws = await ws_connect(self.url, **connect_kwargs())
-                self.opened_at = time.monotonic()
-                self.reader_task = asyncio.create_task(self._read_forever(self.ws))
-            return self.ws
+        """Called under the admission lock, BEFORE inserting a lane."""
+        generation = self.connection
+        if generation and time.monotonic() - generation.opened_at > CONNECTION_MAX_AGE:
+            if not generation.lanes:
+                self.retire(generation, transport_error("idle connection rotated"))
+        if self.connection is None:
+            ws = await ws_connect(self.url, **connect_kwargs())
+            self.connection = Connection(ws)
+            self.track(self._read_forever(self.connection))
+        return self.connection
+
+    def retire(self, generation, error):
+        if generation.retired:
+            return
+        generation.retired = True
+        if self.connection is generation:
+            self.connection = None
+        try:
+            encode_frame({"op": "event", "event": error})
+        except ValueError:
+            error = transport_error("frame_too_large: upstream error exceeds local frame limit")
+        for state in generation.lanes.values():
+            # A valid terminal already received remains deliverable even if
+            # the server closes immediately afterward. It isn't in flight.
+            if not state.settled:
+                state.fail(error)
+        # Detach synchronously; old readers, relays and close callbacks only
+        # ever access their captured generation, even after new admission.
+        self.track(self._close(generation.ws))
+
+    async def _close(self, ws):
+        with contextlib.suppress(Exception):
+            await ws.close()
 
     async def close_connection(self):
-        ws, self.ws = self.ws, None
-        if ws is not None:
-            with contextlib.suppress(Exception):
-                await ws.close()
+        if self.connection:
+            self.retire(self.connection, transport_error("broker stopped; response outcome unknown"))
+        if self.tasks:
+            await asyncio.gather(*list(self.tasks), return_exceptions=True)
 
-    async def _read_forever(self, ws):
-        """One reader per connection, fanning events out to their lanes.
-
-        Events are routed by stream_id. A server that omits it while exactly
-        one lane is open still lands correctly, which keeps a single-caller
-        broker working without guessing when several lanes are in flight.
-        """
+    async def _read_forever(self, generation):
+        error = transport_error("connection closed before terminal settlement; response outcome unknown")
         try:
-            async for raw in ws:
-                try:
-                    event = json.loads(raw)
-                except ValueError:
-                    continue
+            async for raw in generation.ws:
+                if generation.retired:
+                    return
+                event = json.loads(raw)
+                if not isinstance(event, dict):
+                    raise ValueError("malformed upstream event")
                 lane = event.get("stream_id")
-                if lane is None and len(self.lanes) == 1:
-                    lane = next(iter(self.lanes))
-                queue = self.lanes.get(lane)
-                if queue is not None:
-                    await queue.put(event)
-        except Exception:
-            pass
+                if lane is None and event.get("type") == "error":
+                    error = event  # Connection errors retain the provider diagnostic.
+                    return
+                if lane is None and len(generation.lanes) == 1:
+                    lane = next(iter(generation.lanes))
+                state = generation.lanes.get(lane)
+                if state is None:
+                    raise ValueError("upstream event has no owned stream_id")
+                if state.settled:
+                    raise ValueError("upstream event after terminal settlement")
+                state.validate(event)
+                if state.response_id and any(
+                    other is not state and other.response_id == state.response_id
+                    for other in generation.lanes.values()
+                ):
+                    raise ValueError("response ID belongs to another stream_id")
+                state.put(event)
+                if event.get("type") in TERMINAL_EVENTS or event.get("type") == "error":
+                    state.settled = True
+        except Exception as exc:
+            error = transport_error("WebSocket failure; response outcome unknown: %s" % exc)
         finally:
-            # A closed connection is not an error for the broker, only for the
-            # calls riding it: tell them so they fail instead of hanging, and
-            # let the next call reconnect.
-            for queue in list(self.lanes.values()):
-                await queue.put({"__closed__": True})
-            if self.ws is ws:
-                self.ws = None
+            self.retire(generation, error)
 
     async def handle(self, reader, writer):
+        relay = disconnected = None
+        admitted = self.clients < MAX_CLIENTS
+        if admitted:
+            self.clients += 1
         try:
-            raw = await reader.readline()
+            if not admitted:
+                await drain_line(writer, {"op": "error", "message": "broker_busy: local client limit reached"})
+                return
+            raw = await asyncio.wait_for(read_line(reader), IO_TIMEOUT)
             if not raw:
                 return
-            try:
-                message = json.loads(raw)
-            except ValueError:
-                await drain_line(writer, {"op": "error", "message": "malformed request"})
-                return
+            message = json.loads(raw)
+            if not isinstance(message, dict):
+                raise ValueError("malformed request: expected an object")
             op = message.get("op")
             if op == "stop":
                 await drain_line(writer, {"op": "stopped"})
@@ -477,51 +683,62 @@ class Broker:
             if op != "create":
                 await drain_line(writer, {"op": "error", "message": "unknown op %r" % op})
                 return
-            await self._relay(message.get("body") or {}, writer)
-        except (ConnectionResetError, BrokenPipeError):
-            pass
+            body = message.get("body")
+            if not isinstance(body, dict) or body.get("type") != "response.create":
+                raise ValueError("malformed response.create body")
+            relay = asyncio.create_task(self._relay(body, writer))
+            # EOF (or unexpected extra input) is abandonment, even while a
+            # request is queued for admission or upstream remains silent.
+            disconnected = asyncio.create_task(reader.read(1))
+            done, _ = await asyncio.wait((relay, disconnected), return_when=asyncio.FIRST_COMPLETED)
+            if relay in done:
+                await relay
+        except (OSError, ValueError, asyncio.TimeoutError) as exc:
+            with contextlib.suppress(OSError, asyncio.TimeoutError):
+                await drain_line(writer, {"op": "error", "message": str(exc) or "local I/O timeout"})
         finally:
-            writer.close()
-            with contextlib.suppress(Exception):
-                await writer.wait_closed()
+            for task in (relay, disconnected):
+                if task is not None:
+                    task.cancel()
+            await asyncio.gather(*(t for t in (relay, disconnected) if t is not None), return_exceptions=True)
+            if admitted:
+                self.clients -= 1
+            await close_writer(writer)
 
     async def _relay(self, body, writer):
         self.last_activity = time.monotonic()
         await self.slots.acquire()
-        lane = None
-        queue = asyncio.Queue()
+        generation = state = lane = None
         try:
-            while not self.free_lanes:
-                await asyncio.sleep(0.01)
-            lane = self.free_lanes.pop(0)
-            self.lanes[lane] = queue
-            body = dict(body)
-            body["stream_id"] = lane
-            try:
-                ws = await self.ensure_connection()
-                await ws.send(json.dumps(body, separators=(",", ":")))
-            except Exception as exc:
-                await drain_line(writer, {"op": "error", "message": "connect failed: %s" % exc})
-                return
+            async with self.lock:
+                generation = await self.ensure_connection()
+                lane = generation.free_lanes.pop(0)
+                state = Lane()
+                generation.lanes[lane] = state
+                body = dict(body, stream_id=lane)
+                await generation.ws.send(encode_frame(body).decode("utf-8"))
             while True:
-                event = await queue.get()
-                if event.get("__closed__"):
-                    await drain_line(writer, {"op": "error", "message": "connection closed before a terminal event"})
-                    return
+                event, size = await state.queue.get()
+                state.queued_bytes -= size
                 await drain_line(writer, {"op": "event", "event": event})
                 if event.get("type") in TERMINAL_EVENTS or event.get("type") == "error":
                     return
+        except (OSError, ValueError, websockets.exceptions.WebSocketException) as exc:
+            await drain_line(writer, {"op": "event", "event": transport_error(str(exc))})
         finally:
-            if lane is not None:
-                self.lanes.pop(lane, None)
-                self.free_lanes.append(lane)
+            if state is not None:
+                if not state.settled:
+                    self.retire(generation, transport_error("caller abandoned or transport failed; response outcome unknown"))
+                if generation.lanes.get(lane) is state:
+                    del generation.lanes[lane]
+                    generation.free_lanes.append(lane)
             self.slots.release()
             self.last_activity = time.monotonic()
 
     async def watch_idle(self):
         while not self.stopping.is_set():
             await asyncio.sleep(1)
-            if self.lanes:
+            if self.connection and self.connection.lanes:
                 self.last_activity = time.monotonic()
                 continue
             if time.monotonic() - self.last_activity >= self.idle_seconds:
@@ -540,7 +757,7 @@ async def serve(path: str, idle_seconds: float, url: str) -> int:
     # chmod.
     previous_umask = os.umask(0o077)
     try:
-        server = await asyncio.start_unix_server(broker.handle, path=path)
+        server = await asyncio.start_unix_server(broker.handle, path=path, limit=MAX_FRAME + 1)
     finally:
         os.umask(previous_umask)
     with contextlib.suppress(OSError):
@@ -561,17 +778,17 @@ async def stop(path: str) -> int:
     if not socket_is_live(path):
         return 0
     try:
-        reader, writer = await asyncio.open_unix_connection(path)
+        reader, writer = await asyncio.open_unix_connection(path, limit=MAX_FRAME + 1)
     except OSError:
         return 0
     try:
         await drain_line(writer, {"op": "stop"})
-        with contextlib.suppress(Exception):
-            await asyncio.wait_for(reader.readline(), timeout=5)
+        raw = await asyncio.wait_for(read_line(reader), timeout=5)
+        if not raw or json.loads(raw).get("op") != "stopped":
+            sys.stderr.write("responses-ws: error: broker did not acknowledge stop\n")
+            return 1
     finally:
-        writer.close()
-        with contextlib.suppress(Exception):
-            await writer.wait_closed()
+        await close_writer(writer)
     return 0
 
 
@@ -587,8 +804,8 @@ def main(argv) -> int:
         if argv[0] == "serve":
             parser.add_argument("--idle", type=float, default=float(os.environ.get("RESPONSES_WS_IDLE", "10")))
         args = parser.parse_args(argv[1:])
-        url = os.environ.get("RESPONSES_WS_URL", "") or DEFAULT_URL
         if argv[0] == "serve":
+            url, _ = endpoint_config()
             return asyncio.run(serve(args.socket, max(args.idle, 0.1) * 60, url))
         return asyncio.run(stop(args.socket))
 
@@ -609,3 +826,5 @@ if __name__ == "__main__":
         raise SystemExit(main(sys.argv[1:]))
     except KeyboardInterrupt:
         raise SystemExit(130)
+    except (OSError, ValueError, asyncio.TimeoutError) as exc:
+        die(str(exc) or "local I/O timeout")

--- a/tools/responses-ws
+++ b/tools/responses-ws
@@ -564,6 +564,8 @@ class Connection:
         self.opened_at = time.monotonic()
         self.lanes = {}
         self.free_lanes = ["lane-%d" % i for i in range(MAX_LANES)]
+        self.drained = asyncio.Event()
+        self.drained.set()
         self.retired = False
 
 
@@ -587,12 +589,29 @@ class Broker:
 
     async def ensure_connection(self):
         """Called under the admission lock, BEFORE inserting a lane."""
+        if self.stopping.is_set():
+            raise ValueError("broker stopped before admission")
         generation = self.connection
+        if generation and not generation.free_lanes:
+            # Reusing a lane before its new response ID arrives would let a
+            # delayed old terminal settle the new call. Drain before rotation
+            # so name exhaustion does not abandon another caller's response.
+            try:
+                await asyncio.wait_for(generation.drained.wait(), IO_TIMEOUT)
+            except asyncio.TimeoutError:
+                raise ValueError("connection lane exhaustion wait timed out") from None
+            if self.stopping.is_set():
+                raise ValueError("broker stopped before admission")
+            if self.connection is generation:
+                self.retire(generation, transport_error("connection stream names exhausted"))
         if generation and time.monotonic() - generation.opened_at > CONNECTION_MAX_AGE:
             if not generation.lanes:
                 self.retire(generation, transport_error("idle connection rotated"))
         if self.connection is None:
             ws = await ws_connect(self.url, **connect_kwargs())
+            if self.stopping.is_set():
+                await self._close(ws)
+                raise ValueError("broker stopped before admission")
             self.connection = Connection(ws)
             self.track(self._read_forever(self.connection))
         return self.connection
@@ -601,6 +620,7 @@ class Broker:
         if generation.retired:
             return
         generation.retired = True
+        generation.drained.set()
         if self.connection is generation:
             self.connection = None
         try:
@@ -715,6 +735,7 @@ class Broker:
                 lane = generation.free_lanes.pop(0)
                 state = Lane()
                 generation.lanes[lane] = state
+                generation.drained.clear()
                 body = dict(body, stream_id=lane)
                 await generation.ws.send(encode_frame(body).decode("utf-8"))
             while True:
@@ -731,7 +752,8 @@ class Broker:
                     self.retire(generation, transport_error("caller abandoned or transport failed; response outcome unknown"))
                 if generation.lanes.get(lane) is state:
                     del generation.lanes[lane]
-                    generation.free_lanes.append(lane)
+                    if not generation.lanes:
+                        generation.drained.set()
             self.slots.release()
             self.last_activity = time.monotonic()
 

--- a/tools/responses-ws
+++ b/tools/responses-ws
@@ -109,6 +109,13 @@ def build_create(args, input_items) -> dict:
     if previous:
         body["previous_response_id"] = previous
 
+    # Server-held conversation state, the alternative to the id chain. llm
+    # refuses the pair before it reaches an adapter, so this is a plain
+    # override of whatever the body file said.
+    conversation = os.environ.get("LLM_RESPONSES_CONVERSATION", "")
+    if conversation:
+        body["conversation"] = conversation
+
     effort = args.thinking if args.thinking else args.effort
     if effort:
         reasoning = dict(body.get("reasoning") or {})

--- a/tools/responses-ws
+++ b/tools/responses-ws
@@ -1,0 +1,604 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["websockets>=13"]
+# ///
+"""WebSocket transport for the OpenAI Responses API, as a headlong adapter.
+
+This is an adapter, not core (design/providers.md): it needs Python and the
+websockets library, which bin/llm is not allowed to depend on. bin/llm runs it
+with LLM_PROVIDER=adapter and LLM_API_FORMAT=responses, which adds
+"--api-format responses" to the argv and hands over the Responses environment.
+The output contract is llm's Responses contract exactly: visible text on
+stdout as it streams, reasoning summaries on stderr, the terminal Response
+object in LLM_RESPONSE_FILE, token counts in LLM_USAGE_FILE, non-zero exit on
+failure.
+
+Two roles live in one file. The default role is the per-call adapter. The
+"serve" role is a broker that holds one connection open across many calls and
+multiplexes them onto stream_id lanes, which is where the latency win of
+WebSocket mode actually comes from: a run pays the handshake once instead of
+once per turn. shellm starts the broker for a run and points llm at this file
+through RESPONSES_WS_SOCKET.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import os
+import socket
+import sys
+import time
+import uuid
+
+import websockets
+from websockets.asyncio.client import connect as ws_connect
+
+# The guide (developers.openai.com/api/docs/guides/websocket-mode) documents
+# the mode against /v1/responses without spelling the scheme out, so the URL
+# stays configurable and this is only the default. ws:// is accepted too, which
+# is what the hermetic test's fake server speaks.
+DEFAULT_URL = "wss://api.openai.com/v1/responses"
+
+# Connection limits from the same guide. A connection accepts at most 16
+# in-flight responses and 32 distinct stream_id values, and lives at most 60
+# minutes. The broker recycles a fixed pool of lane names so a long run cannot
+# walk past the second limit, and rotates the connection before the third.
+MAX_IN_FLIGHT = 16
+MAX_LANES = 32
+CONNECTION_MAX_AGE = 55 * 60
+
+TERMINAL_EVENTS = ("response.completed", "response.incomplete", "response.failed")
+
+
+def die(message: str) -> None:
+    sys.stderr.write("responses-ws: error: %s\n" % message)
+    raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# Request construction
+# ---------------------------------------------------------------------------
+
+
+def read_body_file(path: str) -> dict:
+    """Extra create fields, with the same precedence bin/llm's builder uses."""
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            body = json.load(handle)
+    except (OSError, ValueError) as exc:
+        die("cannot read LLM_RESPONSES_BODY_FILE %s: %s" % (path, exc))
+    if not isinstance(body, dict):
+        die("LLM_RESPONSES_BODY_FILE must contain a JSON object: %s" % path)
+    return body
+
+
+def build_create(args, input_items) -> dict:
+    """The response.create payload.
+
+    Mirrors bin/llm's build_payload_responses so the two transports send the
+    same request: the caller's extra body is the base, llm owns the fields
+    coupled to its CLI, and encrypted reasoning content is always requested so
+    a stateless replay keeps exact reasoning items. Fields that belong to the
+    HTTP transport rather than the request (stream, background) are dropped,
+    because in WebSocket mode every response streams and the connection is the
+    thing that stays open.
+    """
+    body = {}
+    body_file = os.environ.get("LLM_RESPONSES_BODY_FILE", "")
+    if body_file:
+        body.update(read_body_file(body_file))
+    body.pop("stream", None)
+    body.pop("background", None)
+
+    body["model"] = args.model
+    body["input"] = input_items
+    body["max_output_tokens"] = args.max_tokens
+
+    if args.system_prompt_file:
+        try:
+            with open(args.system_prompt_file, "r", encoding="utf-8") as handle:
+                body["instructions"] = handle.read()
+        except OSError as exc:
+            die("cannot read --system-prompt-file: %s" % exc)
+
+    previous = os.environ.get("LLM_PREVIOUS_RESPONSE_ID", "")
+    if previous:
+        body["previous_response_id"] = previous
+
+    effort = args.thinking if args.thinking else args.effort
+    if effort:
+        reasoning = dict(body.get("reasoning") or {})
+        reasoning["effort"] = effort
+        reasoning["summary"] = "auto"
+        body["reasoning"] = reasoning
+
+    include = list(body.get("include") or [])
+    if "reasoning.encrypted_content" not in include:
+        include.append("reasoning.encrypted_content")
+    body["include"] = include
+
+    body["type"] = "response.create"
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Output contract
+# ---------------------------------------------------------------------------
+
+
+def write_private(path: str, payload: str) -> None:
+    """Atomic mode-0600 write, the same guarantee bin/llm's sidecar makes."""
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    tmp = os.path.join(directory, ".responses-ws.%d.%s" % (os.getpid(), uuid.uuid4().hex))
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def write_sidecar(obj) -> None:
+    path = os.environ.get("LLM_RESPONSE_FILE", "")
+    if not path:
+        return
+    try:
+        write_private(path, json.dumps(obj, separators=(",", ":")))
+    except OSError as exc:
+        die("cannot write LLM_RESPONSE_FILE %s: %s" % (path, exc))
+
+
+def write_usage(response) -> None:
+    path = os.environ.get("LLM_USAGE_FILE", "")
+    usage = (response or {}).get("usage") or {}
+    if not path or not usage:
+        return
+    record = {}
+    for key, source in (
+        ("in_tok", usage.get("input_tokens")),
+        ("out_tok", usage.get("output_tokens")),
+        ("think_tok", (usage.get("output_tokens_details") or {}).get("reasoning_tokens")),
+        ("cache_tok", (usage.get("input_tokens_details") or {}).get("cached_tokens")),
+    ):
+        if isinstance(source, int):
+            record[key] = source
+    if not record:
+        return
+    with contextlib.suppress(OSError):
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(record, handle, separators=(",", ":"))
+
+
+def extract_text(response) -> str:
+    parts = []
+    for item in (response or {}).get("output") or []:
+        if item.get("type") != "message":
+            continue
+        for chunk in item.get("content") or []:
+            if chunk.get("type") in ("output_text", "refusal"):
+                parts.append(chunk.get("text") or chunk.get("refusal") or "")
+    return "".join(parts)
+
+
+def extract_reasoning(response) -> str:
+    parts = []
+    for item in (response or {}).get("output") or []:
+        if item.get("type") != "reasoning":
+            continue
+        for chunk in item.get("summary") or []:
+            parts.append(chunk.get("text") or "")
+    return "".join(parts)
+
+
+class Emitter:
+    """Turns server events into the adapter's stdout, stderr, and artifacts.
+
+    It carries the "did anything reach the caller yet" state that decides
+    whether a buffered fallback would duplicate output, which is the same rule
+    bin/llm's stream_responses follows.
+    """
+
+    def __init__(self, stream: bool):
+        self.stream = stream
+        self.text_emitted = False
+        self.reasoning_emitted = False
+        self.terminal = False
+        self.exit_code = 1
+
+    def feed(self, event) -> bool:
+        """Handle one server event. Returns True when the exchange is over."""
+        kind = event.get("type") or ""
+        if kind in ("response.output_text.delta", "response.refusal.delta"):
+            delta = event.get("delta") or ""
+            if delta and self.stream:
+                self.text_emitted = True
+                sys.stdout.write(delta)
+                sys.stdout.flush()
+            return False
+        if kind == "response.reasoning_summary_text.delta":
+            delta = event.get("delta") or ""
+            if delta and self.stream:
+                self.reasoning_emitted = True
+                sys.stderr.write(delta)
+                sys.stderr.flush()
+            return False
+        if kind in ("response.completed", "response.incomplete"):
+            self._finish(event.get("response") or {}, kind)
+            return True
+        if kind == "response.failed":
+            response = event.get("response") or {}
+            write_sidecar(response)
+            message = ((response.get("error") or {}).get("message")) or "response failed"
+            sys.stderr.write("responses-ws: error: %s\n" % message)
+            self.terminal = True
+            self.exit_code = 1
+            return True
+        if kind == "error":
+            # Written through verbatim: shellm decides whether to fall back to
+            # its replay chain by reading this envelope, and a rejected
+            # previous_response_id is only recognisable in the provider's own
+            # fields.
+            write_sidecar(event)
+            message = (event.get("error") or {}).get("message") or event.get("message") or "unknown error"
+            sys.stderr.write("responses-ws: error: %s\n" % message)
+            self.terminal = True
+            self.exit_code = 1
+            return True
+        return False
+
+    def _finish(self, response, kind: str) -> None:
+        self.terminal = True
+        write_sidecar(response)
+        write_usage(response)
+        if not self.reasoning_emitted:
+            reasoning = extract_reasoning(response)
+            if reasoning:
+                sys.stderr.write(reasoning)
+        if not self.text_emitted:
+            text = extract_text(response)
+            if text:
+                sys.stdout.write(text)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        if kind == "response.incomplete":
+            reason = (response.get("incomplete_details") or {}).get("reason") or "unknown"
+            sys.stderr.write("\nresponses-ws: warning: response incomplete (%s)\n" % reason)
+        self.exit_code = 0
+
+
+# ---------------------------------------------------------------------------
+# Line-delimited JSON over the broker's unix socket
+# ---------------------------------------------------------------------------
+
+
+def send_line(writer, obj) -> None:
+    writer.write((json.dumps(obj, separators=(",", ":")) + "\n").encode("utf-8"))
+
+
+async def drain_line(writer, obj) -> None:
+    send_line(writer, obj)
+    await writer.drain()
+
+
+def socket_is_live(path: str) -> bool:
+    if not path or not os.path.exists(path):
+        return False
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    probe.settimeout(1.0)
+    try:
+        probe.connect(path)
+        return True
+    except OSError:
+        return False
+    finally:
+        probe.close()
+
+
+# ---------------------------------------------------------------------------
+# Adapter role
+# ---------------------------------------------------------------------------
+
+
+def connect_kwargs():
+    key = os.environ.get("OPENAI_API_KEY", "")
+    headers = {}
+    if key:
+        # The key travels in a header, never on argv, for the same reason
+        # bin/llm's add_auth_header exists: argv is world readable.
+        headers["Authorization"] = "Bearer %s" % key
+    return {"additional_headers": headers, "max_size": None}
+
+
+async def run_one_shot(url: str, create: dict, emitter: Emitter) -> int:
+    try:
+        async with ws_connect(url, **connect_kwargs()) as ws:
+            await ws.send(json.dumps(create, separators=(",", ":")))
+            async for raw in ws:
+                try:
+                    event = json.loads(raw)
+                except ValueError:
+                    continue
+                if emitter.feed(event):
+                    break
+    except OSError as exc:
+        sys.stderr.write("responses-ws: error: cannot reach %s: %s\n" % (url, exc))
+        return 1
+    except websockets.exceptions.WebSocketException as exc:
+        sys.stderr.write("responses-ws: error: websocket failed: %s\n" % exc)
+        return 1
+    if not emitter.terminal:
+        sys.stderr.write("responses-ws: error: connection closed before a terminal event\n")
+        return 1
+    return emitter.exit_code
+
+
+async def run_via_broker(path: str, create: dict, emitter: Emitter) -> int:
+    reader, writer = await asyncio.open_unix_connection(path)
+    try:
+        await drain_line(writer, {"op": "create", "body": create})
+        while True:
+            raw = await reader.readline()
+            if not raw:
+                break
+            try:
+                message = json.loads(raw)
+            except ValueError:
+                continue
+            if message.get("op") == "error":
+                sys.stderr.write("responses-ws: error: %s\n" % message.get("message", "broker error"))
+                return 1
+            if message.get("op") != "event":
+                continue
+            if emitter.feed(message.get("event") or {}):
+                break
+    finally:
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+    if not emitter.terminal:
+        sys.stderr.write("responses-ws: error: broker closed before a terminal event\n")
+        return 1
+    return emitter.exit_code
+
+
+def run_adapter(args) -> int:
+    if args.api_format != "responses":
+        die("only --api-format responses is supported (this adapter speaks the Responses protocol)")
+    raw_input_items = sys.stdin.read()
+    try:
+        input_items = json.loads(raw_input_items) if raw_input_items.strip() else []
+    except ValueError as exc:
+        die("stdin is not valid JSON input items: %s" % exc)
+    create = build_create(args, input_items)
+    emitter = Emitter(stream=not args.no_stream)
+
+    broker = os.environ.get("RESPONSES_WS_SOCKET", "")
+    if broker and socket_is_live(broker):
+        return asyncio.run(run_via_broker(broker, create, emitter))
+    url = os.environ.get("RESPONSES_WS_URL", "") or DEFAULT_URL
+    return asyncio.run(run_one_shot(url, create, emitter))
+
+
+# ---------------------------------------------------------------------------
+# Broker role
+# ---------------------------------------------------------------------------
+
+
+class Broker:
+    def __init__(self, url: str, idle_seconds: float):
+        self.url = url
+        self.idle_seconds = idle_seconds
+        self.ws = None
+        self.opened_at = 0.0
+        self.reader_task = None
+        self.lock = asyncio.Lock()
+        self.lanes = {}
+        self.free_lanes = ["lane-%d" % i for i in range(MAX_LANES)]
+        self.slots = asyncio.Semaphore(MAX_IN_FLIGHT)
+        self.last_activity = time.monotonic()
+        self.stopping = asyncio.Event()
+
+    async def ensure_connection(self):
+        async with self.lock:
+            stale = self.ws is not None and (time.monotonic() - self.opened_at) > CONNECTION_MAX_AGE
+            if stale and not self.lanes:
+                await self.close_connection()
+            if self.ws is None:
+                self.ws = await ws_connect(self.url, **connect_kwargs())
+                self.opened_at = time.monotonic()
+                self.reader_task = asyncio.create_task(self._read_forever(self.ws))
+            return self.ws
+
+    async def close_connection(self):
+        ws, self.ws = self.ws, None
+        if ws is not None:
+            with contextlib.suppress(Exception):
+                await ws.close()
+
+    async def _read_forever(self, ws):
+        """One reader per connection, fanning events out to their lanes.
+
+        Events are routed by stream_id. A server that omits it while exactly
+        one lane is open still lands correctly, which keeps a single-caller
+        broker working without guessing when several lanes are in flight.
+        """
+        try:
+            async for raw in ws:
+                try:
+                    event = json.loads(raw)
+                except ValueError:
+                    continue
+                lane = event.get("stream_id")
+                if lane is None and len(self.lanes) == 1:
+                    lane = next(iter(self.lanes))
+                queue = self.lanes.get(lane)
+                if queue is not None:
+                    await queue.put(event)
+        except Exception:
+            pass
+        finally:
+            # A closed connection is not an error for the broker, only for the
+            # calls riding it: tell them so they fail instead of hanging, and
+            # let the next call reconnect.
+            for queue in list(self.lanes.values()):
+                await queue.put({"__closed__": True})
+            if self.ws is ws:
+                self.ws = None
+
+    async def handle(self, reader, writer):
+        try:
+            raw = await reader.readline()
+            if not raw:
+                return
+            try:
+                message = json.loads(raw)
+            except ValueError:
+                await drain_line(writer, {"op": "error", "message": "malformed request"})
+                return
+            op = message.get("op")
+            if op == "stop":
+                await drain_line(writer, {"op": "stopped"})
+                self.stopping.set()
+                return
+            if op != "create":
+                await drain_line(writer, {"op": "error", "message": "unknown op %r" % op})
+                return
+            await self._relay(message.get("body") or {}, writer)
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    async def _relay(self, body, writer):
+        self.last_activity = time.monotonic()
+        await self.slots.acquire()
+        lane = None
+        queue = asyncio.Queue()
+        try:
+            while not self.free_lanes:
+                await asyncio.sleep(0.01)
+            lane = self.free_lanes.pop(0)
+            self.lanes[lane] = queue
+            body = dict(body)
+            body["stream_id"] = lane
+            try:
+                ws = await self.ensure_connection()
+                await ws.send(json.dumps(body, separators=(",", ":")))
+            except Exception as exc:
+                await drain_line(writer, {"op": "error", "message": "connect failed: %s" % exc})
+                return
+            while True:
+                event = await queue.get()
+                if event.get("__closed__"):
+                    await drain_line(writer, {"op": "error", "message": "connection closed before a terminal event"})
+                    return
+                await drain_line(writer, {"op": "event", "event": event})
+                if event.get("type") in TERMINAL_EVENTS or event.get("type") == "error":
+                    return
+        finally:
+            if lane is not None:
+                self.lanes.pop(lane, None)
+                self.free_lanes.append(lane)
+            self.slots.release()
+            self.last_activity = time.monotonic()
+
+    async def watch_idle(self):
+        while not self.stopping.is_set():
+            await asyncio.sleep(1)
+            if self.lanes:
+                self.last_activity = time.monotonic()
+                continue
+            if time.monotonic() - self.last_activity >= self.idle_seconds:
+                self.stopping.set()
+
+
+async def serve(path: str, idle_seconds: float, url: str) -> int:
+    if socket_is_live(path):
+        sys.stderr.write("responses-ws: error: a broker is already listening on %s\n" % path)
+        return 1
+    with contextlib.suppress(OSError):
+        os.unlink(path)
+    broker = Broker(url, idle_seconds)
+    # The socket is the run's private door onto an authenticated connection,
+    # so it is created 0600 and not left readable between the bind and the
+    # chmod.
+    previous_umask = os.umask(0o077)
+    try:
+        server = await asyncio.start_unix_server(broker.handle, path=path)
+    finally:
+        os.umask(previous_umask)
+    with contextlib.suppress(OSError):
+        os.chmod(path, 0o600)
+    idle_task = asyncio.create_task(broker.watch_idle())
+    async with server:
+        await broker.stopping.wait()
+    idle_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await idle_task
+    await broker.close_connection()
+    with contextlib.suppress(OSError):
+        os.unlink(path)
+    return 0
+
+
+async def stop(path: str) -> int:
+    if not socket_is_live(path):
+        return 0
+    try:
+        reader, writer = await asyncio.open_unix_connection(path)
+    except OSError:
+        return 0
+    try:
+        await drain_line(writer, {"op": "stop"})
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(reader.readline(), timeout=5)
+    finally:
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv) -> int:
+    if argv and argv[0] in ("serve", "stop"):
+        parser = argparse.ArgumentParser(prog="responses-ws %s" % argv[0])
+        parser.add_argument("--socket", required=True)
+        if argv[0] == "serve":
+            parser.add_argument("--idle", type=float, default=float(os.environ.get("RESPONSES_WS_IDLE", "10")))
+        args = parser.parse_args(argv[1:])
+        url = os.environ.get("RESPONSES_WS_URL", "") or DEFAULT_URL
+        if argv[0] == "serve":
+            return asyncio.run(serve(args.socket, max(args.idle, 0.1) * 60, url))
+        return asyncio.run(stop(args.socket))
+
+    parser = argparse.ArgumentParser(prog="responses-ws")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--max-tokens", type=int, required=True)
+    parser.add_argument("--effort", default="")
+    parser.add_argument("--thinking", nargs="?", const="", default="")
+    parser.add_argument("--no-stream", action="store_true")
+    parser.add_argument("--system-prompt-file", default="")
+    parser.add_argument("--api-format", default="chat")
+    args = parser.parse_args(argv)
+    return run_adapter(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except KeyboardInterrupt:
+        raise SystemExit(130)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -30,7 +30,7 @@ IDENTITIES="ask"      # ask | keep | delete
 # tests/test_uninstall.sh checks the two lists agree.
 TOOLS=(shellm shellm-docker skills mem llm responses context traj thinkers chat recap
        shellm-docker-broker identity shellm-explore headlong-skills headlong-init headlong-killall persona headlong-web
-       headlong-slack-bridge headlong-telegram-bridge headlong-tui)
+       headlong-slack-bridge headlong-telegram-bridge responses-ws headlong-tui)
 
 _usage() {
     cat <<'EOF'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -28,7 +28,7 @@ IDENTITIES="ask"      # ask | keep | delete
 # Same list as install.sh (BIN_TOOLS + AUX_TOOLS + the TUI binary). Kept
 # here too so this script works standalone, after the checkout is gone;
 # tests/test_uninstall.sh checks the two lists agree.
-TOOLS=(shellm shellm-docker skills mem llm context traj thinkers chat recap
+TOOLS=(shellm shellm-docker skills mem llm responses context traj thinkers chat recap
        shellm-docker-broker identity shellm-explore headlong-skills headlong-init headlong-killall persona headlong-web
        headlong-slack-bridge headlong-telegram-bridge headlong-tui)
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -30,7 +30,7 @@ IDENTITIES="ask"      # ask | keep | delete
 # tests/test_uninstall.sh checks the two lists agree.
 TOOLS=(shellm shellm-docker skills mem llm responses context traj thinkers chat recap
        shellm-docker-broker identity shellm-explore headlong-skills headlong-init headlong-killall persona headlong-web
-       headlong-slack-bridge headlong-telegram-bridge responses-ws headlong-tui)
+       headlong-slack-bridge headlong-telegram-bridge responses-ws headlong-jobs headlong-tui)
 
 _usage() {
     cat <<'EOF'


### PR DESCRIPTION
## What

Adds an opt-in OpenAI Responses completion protocol to `bin/llm` and process-local Responses continuation to `shellm`. Chat Completions remains the default; its retry behavior is unchanged.

Set `LLM_API_FORMAT=responses` for llm or `SHELLM_API_FORMAT=responses` for shellm to preserve typed reasoning and response state across turns.

## Completion contract

- Native OpenAI and OpenRouter select their Responses endpoints; `openai-compatible` uses its configured endpoint.
- Typed input is preserved, including multimodal messages, reasoning items, function calls and function outputs.
- `LLM_RESPONSES_BODY_FILE` accepts tools, include, store, text format, metadata, truncation, service tier and compatible extensions. CLI-owned fields stay deterministic; conversation state and background mode are rejected.
- Requests augment include with `reasoning.encrypted_content` for exact stateless replay. OpenRouter routing/privacy policy overlays remain effective.
- Buffered and SSE paths handle text, refusals, reasoning summaries, function-only output, incomplete/failed status, errors and usage.
- `LLM_RESPONSE_FILE` atomically records the terminal Response or error as mode 0600; an unwritable sidecar fails before dispatch or fails the call rather than reporting artifact-free success.

## Adversarial hardening

Responses CREATE is **never automatically retried**, even before output. Silence does not prove the provider did not accept work. Lost acknowledgements, missing terminals and malformed success envelopes fail with `error.code=outcome_unknown`, preserving any known response ID. No provider idempotency guarantee is invented.

Successful buffered/streamed completion requires a nonempty ID, output array, completed/incomplete status and no embedded error. Stream identity and terminal event/status must agree. Cancelled and failed terminals fail without recreation; incomplete remains partial output with a warning. Function-only output remains a valid protocol response.

Shellm retains process-local previous-response state and exact typed replay. A structured pre-generation continuation rejection can trigger one replay fallback, after which the run stays stateless. Unknown outcomes, known IDs, terminal failures and calls that emitted text cannot enter fallback merely because an error mentions a previous response. OpenRouter begins in replay mode; response IDs are not persisted into the durable trajectory.

## Scope boundary

Retrieve, cancel, delete, input-item listing, Conversations, background jobs, compaction and WebSocket transport **remain out of scope** (see PR on my fork for these capabilities I am happy to fold into here, I wanted to keep this in spirit of what the core impl looked like with completions and not raise the LoC limit, either). No SDK/Python dependency, lifecycle CLI or line-budget increase is introduced by this PR.

## Verification

- `test_llm_responses.sh`: **35 passed**.
- `test_llm_responses_faults.sh`: **30 passed**, including lost acknowledgements, retained recovery handles, malformed/unknown terminals, cancellation and stream identity mismatch; exactly one create asserted.
- `test_shellm_responses_continuation.sh`: **20 passed**.
- Full Linux harness with jq 1.7.1: **65 suites passed** in a linked worktree; the remaining existing runtime-prompt test assumes `.git/HEAD` is a file path and fails in linked worktrees. It passed **13/13** unchanged in a normal clone of the same commit.
- Warning-level ShellCheck passes; core remains below **11K** (about **10.7K**).
- [Full CI passed on this head](https://github.com/laude-institute/headlong/actions/runs/34180315402), including Linux/macOS Bash 3.2, Python projects, viewer, TUI, installation, lint and secret scans.

Design, ownership and failure contracts are in `design/responses-api.md`. Existing tests also cover chat retry preservation, OpenRouter policy, shrinking rendered context, uncapped sent-row IDs, preflight sidecar checks, body-file sandbox mounting and stop-after-code-block behavior.
