### PR TITLE
Preserve per-identity thinker disabled state

### DIFF
--- a/tests/test_identity_sync_thinkers.sh
+++ b/tests/test_identity_sync_thinkers.sh
@@ -51,6 +51,8 @@ T="$WORK/.identities/alpha/thinkers"
 check "fresh identity has monolith"     test -d "$T/monolith"
 check "fresh identity has responder"    test -d "$T/responder"
 check_not "fresh identity lacks actor"  test -d "$T/actor"
+check "copy mode keeps disabled default identity-local" \
+    bash -c 'test -f "$1" && test ! -L "$1"' _ "$T/retrieval/disabled"
 
 check "fresh identity ledger seeded"    grep -qx actor "$T/.retired_done"
 
@@ -120,6 +122,40 @@ check_not "later user thinker survives on pre-ledger identity" \
 rm -f "$WORK/.identities/default"
 identity sync-thinkers alpha >/dev/null 2>&1
 check "works without a default identity" test $? -eq 0
+
+# In --symlinks installs, code stays linked to the checkout but disabled is
+# identity state. Linking that marker too makes a dashboard/CLI opt-in last
+# only until the next sync, which silently re-links the bundled default.
+mkdir -p "$HOME/.headlong-thinkers"
+touch "$HOME/.headlong-thinkers/.use-symlinks"
+identity new delta >/dev/null 2>&1 || { bad "identity new delta (symlink mode)"; exit 1; }
+TD="$WORK/.identities/delta/thinkers"
+check "symlink mode links retrieval code" test -L "$TD/retrieval/step"
+check "disabled default is identity-local" \
+    bash -c 'test -f "$1" && test ! -L "$1"' _ "$TD/retrieval/disabled"
+
+# Upgrade the exact legacy layout: disabled used to point into the bundle.
+# Sync must preserve its effective disabled state while localizing the file.
+rm "$TD/retrieval/disabled"
+ln -s "$REPO/thinkers/retrieval/disabled" "$TD/retrieval/disabled"
+identity sync-thinkers delta >/dev/null 2>&1
+check "legacy live disabled link becomes identity-local" \
+    bash -c 'test -f "$1" && test ! -L "$1"' _ "$TD/retrieval/disabled"
+
+# Once the localized marker is removed, later syncs preserve the opt-in.
+rm "$TD/retrieval/disabled"
+identity sync-thinkers delta >/dev/null 2>&1
+check_not "retrieval opt-in survives symlink sync" \
+    test -e "$TD/retrieval/disabled"
+
+# Some old installs were enabled by removing the bundled target and leaving
+# the identity link dangling. Localize that effective enabled state too.
+ln -s "$WORK/missing-disabled-marker" "$TD/retrieval/disabled"
+identity sync-thinkers delta >/dev/null 2>&1
+check_not "dangling legacy disabled link stays enabled" \
+    test -e "$TD/retrieval/disabled"
+check_not "dangling legacy disabled link is removed" \
+    test -L "$TD/retrieval/disabled"
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 exit $((fail > 0))

--- a/thinkers/README.md
+++ b/thinkers/README.md
@@ -8,8 +8,9 @@ thinker: a `step` executable that produces the next thought, and a
 - `monolith/` is the main mind loop, with its prompt in `prompt.md`.
 - `responder/` handles fast chat replies.
 - `retrieval/` is passive memory recall (memories that share words with
-  the current step surface as observations). Ships disabled: delete its
-  `disabled` marker in an identity's `thinkers/retrieval/` to turn it on.
+  the current step surface as observations). Ships disabled: enable it in
+  the dashboard or delete the identity's `thinkers/retrieval/disabled`
+  marker. Updates preserve that per-identity choice.
 - `_lib/` holds shell helpers shared by the thinkers.
 
 Code here counts against the under-10K-lines core (`cloc bin/ thinkers/`).

--- a/thinkers/retrieval/disabled
+++ b/thinkers/retrieval/disabled
@@ -1,1 +1,1 @@
-shipped disabled by default — delete this file to enable passive memory recall for this identity (see step for the knobs; on a --symlinks install delete the marker in the checkout too)
+shipped disabled by default — this marker is copied as per-identity state; delete the identity's copy (or use the dashboard) to enable passive memory recall, and updates will preserve that choice

--- a/thinkers/retrieval/prompt.md
+++ b/thinkers/retrieval/prompt.md
@@ -8,4 +8,5 @@ and has not surfaced recently, emit an observation: "I'm reminded of memory
 <id>: <summary>". Memories surface when the current step resonates with
 them, without the mind asking. No LLM call unless `RETRIEVAL_SEMANTIC=1`.
 
-Shipped disabled: delete the `disabled` marker to turn it on.
+Shipped disabled: enable it in the dashboard or delete the identity's
+`disabled` marker. Updates preserve that per-identity choice.

--- a/thinkers/retrieval/step
+++ b/thinkers/retrieval/step
@@ -14,10 +14,9 @@ set -euo pipefail
 # whenever a memory is newer than the index) and no LLM call, unless
 # RETRIEVAL_SEMANTIC=1 adds a `mem search` (one llm call) on each hit.
 #
-# Ships DISABLED (the `disabled` marker next to this file). To turn it on
-# for an identity, delete <identity>/thinkers/retrieval/disabled; on a
-# --symlinks install delete the marker in the checkout too, or
-# `identity sync-thinkers` links it back.
+# Ships DISABLED. To turn it on for one identity, use the dashboard or delete
+# <identity>/thinkers/retrieval/disabled. The marker is per-identity state,
+# including on --symlinks installs, so syncs and updates preserve that choice.
 #
 # Knobs: RETRIEVAL_MIN_HITS (default 2 shared words), RETRIEVAL_SEEN
 # (default 20: a memory is not resurfaced within that many surfacings),

--- a/tools/identity
+++ b/tools/identity
@@ -211,20 +211,25 @@ _ensure_thinkers() {
         local name
         name=$(basename "$src_dir")
         local dest="$thinkers_dir/$name"
+        local dest_existed=0
 
         # Guard: if a prior (mis)install left `dest` as a directory symlink
         # pointing back at the source, the file-level symlink pass below would
         # resolve `$dest/<file>` through it and create self-referential links
         # *inside the source repo* (ELOOP corruption). A thinker dir must be a
         # real directory, so drop any symlink here and rebuild it.
-        [[ -L "$dest" ]] && rm -f "$dest"
+        if [[ -L "$dest" ]]; then
+            rm -f "$dest"
+        elif [[ -d "$dest" ]]; then
+            dest_existed=1
+        fi
 
         # Resolve src_dir through symlinks (bundled_dir entries may be symlinks)
         local real_src
         real_src="$(cd "$src_dir" && pwd -P)"
 
         if [[ "$use_symlinks" -eq 1 ]]; then
-            # Symlink mode: link code files, copy subscriptions.jsonl
+            # Symlink mode: link code files, copy per-identity state.
             mkdir -p "$dest"
 
             # Symlink code files (step, start, stop, *.md, *.sh)
@@ -237,6 +242,31 @@ _ensure_thinkers() {
                 # subscriptions.jsonl is per-identity — only copy if missing
                 if [[ "$fname" == "subscriptions.jsonl" ]]; then
                     [[ -f "$dest/$fname" ]] || cp "$src_file" "$dest/$fname"
+                    continue
+                fi
+
+                # `disabled` in the bundle is a default for fresh identities,
+                # not shared state. Keep a real per-identity copy so removing
+                # it in the dashboard survives the next sync/update. Convert
+                # old installs that linked the marker into a local copy once;
+                # an absent marker on an existing dir means the operator
+                # deliberately enabled that thinker and must stay absent.
+                if [[ "$fname" == "disabled" ]]; then
+                    if [[ -L "$dest/$fname" ]]; then
+                        # A live legacy link means the thinker was disabled;
+                        # preserve that state in a regular identity-local file.
+                        # A dangling link means its bundled marker was removed
+                        # to enable the thinker; remove the stale link without
+                        # silently restoring the disabled default.
+                        if [[ -e "$dest/$fname" ]]; then
+                            rm -f "$dest/$fname"
+                            cp "$src_file" "$dest/$fname"
+                        else
+                            rm -f "$dest/$fname"
+                        fi
+                    elif [[ "$dest_existed" -eq 0 && ! -e "$dest/$fname" ]]; then
+                        cp "$src_file" "$dest/$fname"
+                    fi
                     continue
                 fi
 
@@ -1197,7 +1227,8 @@ upstream has retired. User-authored thinkers are never touched. In copy
 mode (the default), existing dirs and their local edits are never
 modified or deleted; in a symlink install (.use-symlinks), bundled CODE
 files (step, *.md) are re-pointed at the bundle, so local edits to those
-belong upstream, not in the identity dir. Runs on every `thinkers start`
+belong upstream, not in the identity dir. The `disabled` marker is copied
+as per-identity state and is never re-linked to the bundle. Runs on every `thinkers start`
 via the systemd service wrapper, so an upgraded deployment picks up
 roster changes on restart — this command exists for running the same
 reconcile by hand.

--- a/web/src/headlong_web/thinker_sync.py
+++ b/web/src/headlong_web/thinker_sync.py
@@ -8,11 +8,13 @@ drift by file-content comparison: in_sync / outdated / not_installed, plus
 local_only for identity thinkers with no bundled counterpart.
 
 Per-identity state is never overwritten: `subscriptions.jsonl` (carries the
-injected traj_id) and the `disabled` marker survive a pull. The shared
-`_lib` dir is compared and synced like a thinker — step scripts source it
-at wakeup, so a stale _lib is as real a drift as a stale step. File writes
-are atomic (temp + rename), so a thinker mid-step keeps executing its old
-inode and picks the new code up next wakeup.
+injected traj_id) and the `disabled` marker survive a pull. A bundled
+`disabled` marker is inherited on first install only; removing it is an
+identity opt-in that later pulls preserve. The shared `_lib` dir is compared
+and synced like a thinker — step scripts source it at wakeup, so a stale _lib
+is as real a drift as a stale step. File writes are atomic (temp + rename), so
+a thinker mid-step keeps executing its old inode and picks the new code up
+next wakeup.
 """
 
 import json
@@ -218,6 +220,9 @@ def sync(identity_dir: Path, names: list[str]) -> dict:
                 copied.append(str(rel))
         if fresh:
             _install_subscriptions(bundled_dir, installed_dir, identity_dir)
+            disabled_default = bundled_dir / "disabled"
+            if disabled_default.is_file():
+                _atomic_copy(disabled_default, installed_dir / "disabled")
         results.append(
             {
                 "name": name,

--- a/web/tests/test_thinker_sync.py
+++ b/web/tests/test_thinker_sync.py
@@ -97,6 +97,27 @@ def test_install_injects_traj_id(bundled: Path, identity: Path):
     assert sub["traj_id"] == ROOT_TRAJ
 
 
+def test_fresh_install_keeps_bundled_disabled_default(
+    bundled: Path, identity: Path
+):
+    retrieval = bundled / "retrieval"
+    retrieval.mkdir()
+    (retrieval / "step").write_text("#!/bin/bash\n")
+    (retrieval / "subscriptions.jsonl").write_text('{"types":["thought"]}\n')
+    (retrieval / "disabled").write_text("disabled by default\n")
+
+    result = thinker_sync.sync(identity, ["retrieval"])
+    marker = identity / "thinkers" / "retrieval" / "disabled"
+    assert result["results"][0]["action"] == "installed"
+    assert marker.read_text() == "disabled by default\n"
+
+    # Enabling is an identity choice. A later pull must not restore the
+    # bundled default and silently turn the thinker back off.
+    marker.unlink()
+    thinker_sync.sync(identity, ["retrieval"])
+    assert not marker.exists()
+
+
 def test_endpoints(bundled: Path, identity: Path, tmp_path: Path):
     client = TestClient(create_app(tmp_path))
     identity_id = ".identities~bot"


### PR DESCRIPTION
## Problem

A bundled `disabled` marker is a safe default for a thinker that ships disabled, but treating it as shared code caused updates to overwrite per-identity enablement. Symlink installs could silently re-disable an explicitly enabled thinker, while fresh dashboard installs could omit a bundled disabled default.

## Fix

Treat `disabled` as per-identity state:

- fresh CLI and dashboard installs inherit the disabled default only when that bundled thinker ships a `disabled` marker;
- legacy symlinked markers are converted once to regular identity-local files;
- later syncs preserve either state, including an absent marker after explicit opt-in;
- docs describe dashboard/manual enablement and update durability.

This does not globally enable retrieval, restart identities, or change runtime settings.

## Verification

- `bash tests/test_identity_sync_thinkers.sh` — 26 passed, 0 failed
