### PR TITLE
identity: ask in-thread on first GitHub failure

### DIFF
--- a/identities/README.md
+++ b/identities/README.md
@@ -8,3 +8,5 @@ interview.
 Runtime identities (an agent's persona, trajectories, memories, and
 activate script) are data, not code. They live in `.identities/`, which
 is gitignored.
+
+Also: [operating-constraints.md](operating-constraints.md), constraints that should survive a box rebuild.

--- a/identities/README.md
+++ b/identities/README.md
@@ -9,4 +9,5 @@ Runtime identities (an agent's persona, trajectories, memories, and
 activate script) are data, not code. They live in `.identities/`, which
 is gitignored.
 
-Also: [operating-constraints.md](operating-constraints.md), constraints that should survive a box rebuild.
+[operating-constraints.md](operating-constraints.md) is a reviewable
+record of operating constraints. Runtime copies are managed separately.

--- a/identities/operating-constraints.md
+++ b/identities/operating-constraints.md
@@ -1,15 +1,13 @@
-# Operating constraints (shipped notes)
+# Operating constraints
 
 Runtime identity goals live in `.identities/<name>/goals.md` and are
-gitignored. This file is the reviewable copy of constraints we want on
-the record in git.
+gitignored. This file is a reviewable record of constraints we want to
+preserve across rebuilds. It does not update runtime identity files.
 
-## GitHub ops
+## GitHub operations
 
-On first failure or surprise (auth, permissions, wrong account, 403):
-stop. One question in the originating thread. No second GitHub attempt.
-Don't retry, switch account, fork around, or "I'll just make it work."
-
-Source: Andy in #headlong-bot, 2026-08 (thread
-`slack-U0614H65RN3-C0BMVH6LM4K-1787508187.726149`). Historical fail:
-kept retrying after the ask.
+On the first GitHub failure or unexpected result, including an
+authentication, permission, wrong account, or 403 error, stop. Ask one
+question in the originating thread. Do not make another GitHub request
+until the user replies. Do not retry, change accounts, use a fork to
+bypass the failure, or use another workaround.

--- a/identities/operating-constraints.md
+++ b/identities/operating-constraints.md
@@ -1,0 +1,15 @@
+# Operating constraints (shipped notes)
+
+Runtime identity goals live in `.identities/<name>/goals.md` and are
+gitignored. This file is the reviewable copy of constraints we want on
+the record in git.
+
+## GitHub ops
+
+On first failure or surprise (auth, permissions, wrong account, 403):
+stop. One question in the originating thread. No second GitHub attempt.
+Don't retry, switch account, fork around, or "I'll just make it work."
+
+Source: Andy in #headlong-bot, 2026-08 (thread
+`slack-U0614H65RN3-C0BMVH6LM4K-1787508187.726149`). Historical fail:
+kept retrying after the ask.


### PR DESCRIPTION
## What

Adds a tracked note for the GitHub-ask constraint (stop on first failure / surprise; one question in the originating thread; no retry, account-switch, or workaround).

## Why this file, not `.identities/.../goals.md`

Runtime `goals.md` is gitignored (`.identities/`). Audel's live copy already has the same bullet under **Current operating constraints**; this PR is the reviewable git side.

## Eval

- good: stop + one question in-thread; no second GitHub attempt
- bad: retry / switch account / fork around / "I'll just make it work"
