### PR TITLE
persona: simple chat loop exits cleanly

### DIFF
--- a/tests/test_persona_chat_exit.sh
+++ b/tests/test_persona_chat_exit.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# tests/test_persona_chat_exit.sh — the simple `persona <name>` chat loop
+# (used when the Rust TUI is not installed) exits cleanly and takes its
+# background message watcher with it.
+#
+# Usage: tests/test_persona_chat_exit.sh
+#
+# Why: the loop's EXIT trap kills a watcher whose pid lives in a function
+# local. The trap runs after the function has returned, so it must carry the
+# pid itself rather than read the variable (fatal under set -u).
+#
+# Everything runs under a throwaway HOME / app dir, so the real
+# ~/.headlong and the repo's own .identities are never touched.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK=$(mktemp -d)
+# A unique identity name so the pgrep below cannot match anything else on
+# the machine, and so cleanup can kill a leaked watcher.
+NAME="chatexit$$"
+cleanup() { pkill -f "bin/$NAME\$" 2>/dev/null; cd /; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+check() { local label="$1"; shift; if "$@" >/dev/null 2>&1; then ok "$label"; else bad "$label"; fi; }
+check_not() { local label="$1"; shift; if "$@" >/dev/null 2>&1; then bad "$label"; else ok "$label"; fi; }
+
+# wait_until <seconds> <command...>
+wait_until() {
+    local deadline=$(( $(date +%s) + $1 )); shift
+    while ! "$@" >/dev/null 2>&1; do
+        [[ $(date +%s) -ge $deadline ]] && return 1
+        sleep 0.2
+    done
+}
+# The watcher is a subshell of the chat process, so it shows up under the
+# same command line.
+watcher_gone() { ! pgrep -f "bin/$NAME\$" >/dev/null 2>&1; }
+
+# --- a fake install ----------------------------------------------------------
+export HOME="$WORK/home"
+export HEADLONG_HOME="$WORK/home/.headlong"
+export HEADLONG_APP_DIR="$WORK/app"
+mkdir -p "$HOME" "$HEADLONG_HOME" "$HEADLONG_APP_DIR" "$WORK/bin"
+ln -s "$REPO/bin" "$HEADLONG_APP_DIR/bin"
+ln -s "$REPO/tools" "$HEADLONG_APP_DIR/tools"
+ln -s "$REPO/thinkers" "$HEADLONG_APP_DIR/thinkers"
+ln -s "$REPO/identities" "$HEADLONG_APP_DIR/identities"
+
+# The name is linked to persona the way headlong-init does it, so the chat
+# runs as a bare `<name>`, the same as a real install. No headlong-tui on
+# this PATH, so persona takes the simple chat loop.
+ln -s "$REPO/tools/persona" "$WORK/bin/$NAME"
+export PATH="$WORK/bin:$REPO/bin:$REPO/tools:/usr/bin:/bin"
+
+(cd "$HEADLONG_APP_DIR" && identity new "$NAME" >/dev/null 2>&1) || { bad "identity new $NAME"; exit 1; }
+ID="$HEADLONG_APP_DIR/.identities/$NAME"
+
+# --- one line, then EOF ------------------------------------------------------
+printf 'hello there\n' | "$NAME" >"$WORK/stdout" 2>"$WORK/stderr"
+rc=$?
+
+check     "chat exits 0 on EOF"                    test "$rc" -eq 0
+check_not "no unbound-variable error on exit"      grep -q 'unbound variable' "$WORK/stderr"
+check     "background watcher killed on exit"      wait_until 5 watcher_gone
+# Proves the loop ran the send path before leaving, not that it bailed early.
+check     "typed message landed in the trajectory" grep -rq '"hello there"' "$ID"/trajectories/*/trajectory.jsonl
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/tools/persona
+++ b/tools/persona
@@ -386,7 +386,7 @@ cmd_chat() {
         done
     ) &
     watcher=$!
-    trap 'kill "$watcher" 2>/dev/null || true' EXIT
+    trap "kill $watcher 2>/dev/null || true" EXIT
     local line
     while IFS= read -r -p "you> " line; do
         [[ -z "$line" ]] && continue

--- a/tools/persona
+++ b/tools/persona
@@ -386,6 +386,8 @@ cmd_chat() {
         done
     ) &
     watcher=$!
+    # Expand the function-local PID while it is still in scope.
+    # shellcheck disable=SC2064
     trap "kill $watcher 2>/dev/null || true" EXIT
     local line
     while IFS= read -r -p "you> " line; do


### PR DESCRIPTION
## Summary

Leaving the simple `persona` chat loop failed with `watcher: unbound variable` and left the background message watcher running. This fixes the EXIT trap in `tools/persona` and adds a regression test.

## Details

The simple chat loop runs when `headlong-tui` is not on PATH. You reach it by typing the identity's name alone, e.g. `iota`. The loop starts a background process that polls for new replies and prints them. It then registers an EXIT trap to kill that process when you leave.

The trap read a variable declared local to the chat function. The trap runs after the function has returned, so by then the variable is gone. Under `set -u` that is a fatal error. Leaving the chat by any route hit it: Ctrl-C, Ctrl-D, or a failed `chat send`. The user saw an error such as:

```
/root/.local/bin/iota: line 1: watcher: unbound variable
```

The watcher was never killed, and the error hid whatever caused the exit.

The fix is one line. The trap now uses double quotes, so bash writes the pid into the trap text at the moment it is set. The trap no longer depends on the variable.

`tests/test_persona_chat_exit.sh` builds a throwaway install, runs the simple chat loop with one piped line and then EOF, and checks four things. The chat exits 0. Nothing on stderr mentions an unbound variable. The watcher is gone afterward. The typed message landed in the trajectory. Before the fix, three of the four fail. The test passes under bash 5.3 and the macOS bash 3.2.
