### PR TITLE
slack: prepend capped prior lines on first @mention in a thread

### DIFF
--- a/slack/README.md
+++ b/slack/README.md
@@ -11,6 +11,8 @@ are posted back to the right conversation.
 Slack <=(Socket Mode websocket)=> headlong-slack-bridge
     inbound:  event -> from_name "slack-<user>-<channel>[-<thread_ts>]"
               -> POST <web>/api/identities/<id>/chat
+              first @mention in an existing thread prepends a capped
+              prior-line digest (conversations.replies, fail-open)
               reaction_added on the bot's messages (and any DM reaction)
               lands as a `:emoji:` body (same from_name / thread)
     outbound: tail trajectory.jsonl -> message steps where from=<identity>
@@ -53,7 +55,9 @@ runs its own Slack-connected agent on.
 Other settings: `HEADLONG_SLACK_STATE_DIR`, legacy `SHELLM_SLACK_STATE_DIR`
 (cursor + thread state, default
 `<identity>/run/slack-bridge/`), `SLACK_THREAD_FOLLOWUPS=1` (answer
-un-mentioned replies in threads the bot is already part of).
+un-mentioned replies in threads the bot is already part of),
+`SLACK_THREAD_JOIN_BACKFILL` (how many messages above a first @mention
+to prepend; default 20, 0 disables, max 50).
 
 For the end-to-end procedure we used to install our agent, Audel, into a
 workspace on that stack (Slack app, tokens, SSM env, rebuild, verification),

--- a/slack/README.md
+++ b/slack/README.md
@@ -56,7 +56,7 @@ Other settings: `HEADLONG_SLACK_STATE_DIR`, legacy `SHELLM_SLACK_STATE_DIR`
 (cursor + thread state, default
 `<identity>/run/slack-bridge/`), `SLACK_THREAD_FOLLOWUPS=1` (answer
 un-mentioned replies in threads the bot is already part of),
-`SLACK_THREAD_JOIN_BACKFILL` (how many messages above a first @mention
+`SLACK_THREAD_JOIN_BACKFILL` (how many closest prior messages above a first @mention
 to prepend; default 20, 0 disables, max 50).
 
 For the end-to-end procedure we used to install our agent, Audel, into a

--- a/slack/src/headlong_slack/config.py
+++ b/slack/src/headlong_slack/config.py
@@ -21,6 +21,8 @@ class Config:
     web_url: str
     state_dir: Path
     thread_followups: bool
+    # How many messages above a first @mention to prepend. 0 disables.
+    thread_join_backfill: int = 20
 
     @property
     def identity_api_id(self) -> str:
@@ -106,4 +108,20 @@ def load(serve_root: Path) -> Config:
         ).rstrip("/"),
         state_dir=state_dir,
         thread_followups=os.environ.get("SLACK_THREAD_FOLLOWUPS", "") not in ("", "0"),
+        thread_join_backfill=_join_backfill_limit(),
     )
+
+
+def _join_backfill_limit() -> int:
+    """SLACK_THREAD_JOIN_BACKFILL: prior thread lines on first @mention.
+
+    Default 20. 0 disables. Clamped to 50 so a long thread cannot dump.
+    """
+    raw = os.environ.get("SLACK_THREAD_JOIN_BACKFILL", "")
+    if raw == "":
+        return 20
+    try:
+        n = int(raw)
+    except ValueError:
+        return 20
+    return max(0, min(50, n))

--- a/slack/src/headlong_slack/inbound.py
+++ b/slack/src/headlong_slack/inbound.py
@@ -168,10 +168,11 @@ class Inbound:
         self._lookup_pool = concurrent.futures.ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="slack-item-lookup"
         )
-        # At most one reactions.get in flight. Timed-out reactions use the
-        # fallback immediately instead of queueing another stale call.
+        # At most one Slack lookup in flight (reactions.get or
+        # conversations.replies). Timed-out work uses the fallback
+        # immediately instead of queueing another stale call.
         self._lookup_lock = threading.Lock()
-        self._lookup_future: concurrent.futures.Future[dict[str, Any] | None] | None = None
+        self._lookup_future: concurrent.futures.Future[Any] | None = None
         self._worker = threading.Thread(
             target=self._drain, name="slack-inbound", daemon=True
         )
@@ -232,28 +233,39 @@ class Inbound:
             return None
         return found.get("thread_ts") or None
 
+    def _try_lookup(self, fn: Any, *, timeout: float, what: str, channel: str, ts: str) -> Any | None:
+        """Run fn on the shared lookup worker. At most one call in flight.
+
+        If a previous call is still running after a timeout, do not queue
+        another stale lookup — return None immediately so the drain thread
+        can take the next item. Fail open on timeout or Slack error.
+        """
+        with self._lookup_lock:
+            fut = self._lookup_future
+            if fut is not None and not fut.done():
+                return None
+            fut = self._lookup_pool.submit(fn)
+            self._lookup_future = fut
+        try:
+            return fut.result(timeout=timeout)
+        except Exception:
+            log.warning("%s failed for %s ts=%s", what, channel, ts, exc_info=True)
+            return None
+
     def _lookup_item_message(self, channel: str, ts: str) -> dict[str, Any] | None:
         def _call() -> dict[str, Any] | None:
             resp = self.app.client.reactions_get(channel=channel, timestamp=ts)
             msg = resp.get("message") or {}
             return msg or None
 
-        # At most one in-flight reactions.get. If a previous call is still
-        # running after a timeout, do not queue another stale lookup —
-        # fail open immediately so the drain thread can take the next item.
-        with self._lookup_lock:
-            fut = self._lookup_future
-            if fut is not None and not fut.done():
-                return None
-            fut = self._lookup_pool.submit(_call)
-            self._lookup_future = fut
-        try:
-            return fut.result(timeout=ITEM_LOOKUP_TIMEOUT)
-        except Exception:
-            log.warning(
-                "reactions.get failed for %s ts=%s", channel, ts, exc_info=True
-            )
-            return None
+        found = self._try_lookup(
+            _call,
+            timeout=ITEM_LOOKUP_TIMEOUT,
+            what="reactions.get",
+            channel=channel,
+            ts=ts,
+        )
+        return found or None
 
     def _on_event(self, event: dict[str, Any], logger: logging.Logger) -> None:
         if event.get("bot_id") or event.get("subtype"):
@@ -321,35 +333,51 @@ class Inbound:
     ) -> list[dict[str, Any]]:
         """Prior messages in a thread, closest to before_ts, capped at limit.
 
-        One conversations.replies call, bounded by JOIN_BACKFILL_TIMEOUT.
-        Fail open to [] so the mention still lands. Slack returns the parent
-        plus replies oldest-first; we keep ts < before_ts and take the tail.
+        conversations.replies pages oldest-first, so one `limit`-sized
+        request would return the parent and earliest replies. Cursor-walk
+        to the last page (bounded by JOIN_BACKFILL_TIMEOUT and a page
+        cap); keep ts < before_ts and take the tail. Fail open to [] so
+        the mention still lands. Shares the one-in-flight lookup worker.
         """
         fetch = min(200, max(limit + 1, 1))
+        # Enough pages for a long thread at this fetch size; the submit
+        # timeout is the real bound. Stop short of the end: return []
+        # rather than the oldest page.
+        max_pages = 50
 
         def _call() -> list[dict[str, Any]]:
-            # One page, fail open. Slack returns oldest-first; we take the
-            # tail after filtering. Threads longer than `fetch` may miss
-            # the closest lines — the cap is the point (no dump, no stall).
-            resp = self.app.client.conversations_replies(
-                channel=channel,
-                ts=thread_ts,
-                latest=before_ts,
-                inclusive=False,
-                limit=fetch,
-            )
-            return list(resp.get("messages") or [])
+            collected: list[dict[str, Any]] = []
+            cursor = ""
+            exhausted = False
+            for _ in range(max_pages):
+                kwargs: dict[str, Any] = {
+                    "channel": channel,
+                    "ts": thread_ts,
+                    "latest": before_ts,
+                    "inclusive": False,
+                    "limit": fetch,
+                }
+                if cursor:
+                    kwargs["cursor"] = cursor
+                resp = self.app.client.conversations_replies(**kwargs)
+                batch = list(resp.get("messages") or [])
+                collected.extend(batch)
+                cursor = (resp.get("response_metadata") or {}).get("next_cursor") or ""
+                if not cursor or not batch:
+                    exhausted = True
+                    break
+            return collected if exhausted else []
 
-        try:
-            msgs = self._lookup_pool.submit(_call).result(timeout=JOIN_BACKFILL_TIMEOUT)
-        except Exception:
-            log.warning(
-                "conversations.replies failed for %s ts=%s",
-                channel,
-                thread_ts,
-                exc_info=True,
-            )
+        msgs = self._try_lookup(
+            _call,
+            timeout=JOIN_BACKFILL_TIMEOUT,
+            what="conversations.replies",
+            channel=channel,
+            ts=thread_ts,
+        )
+        if not msgs:
             return []
+
         def _key(ts: str) -> float:
             try:
                 return float(ts)

--- a/slack/src/headlong_slack/inbound.py
+++ b/slack/src/headlong_slack/inbound.py
@@ -32,6 +32,11 @@ DELIVERY_ERROR_TEXT = (
 # Bound reaction parent-lookups so a hung reactions.get cannot stall
 # the single inbound drain thread. Fail open rather than wait.
 ITEM_LOOKUP_TIMEOUT = 2
+# Same bound for first-join conversations.replies. Fail open: deliver
+# the mention without prior lines rather than stall later messages.
+JOIN_BACKFILL_TIMEOUT = 2
+# Per-line cap so a single huge Slack message cannot dump the mind log.
+JOIN_BACKFILL_LINE_CHARS = 200
 
 
 def reaction_text(reaction: str, item_ts: str, thread_ts: str | None) -> str:
@@ -62,6 +67,9 @@ class InboundMessage:
     # client's default timeout is 30s; a burst of reaction permalink
     # lookups would otherwise stall later human messages.
     is_reaction: bool = False
+    # First @mention in a thread: drain worker prepends capped prior lines.
+    # Bolt must not wait on conversations.replies.
+    backfill: bool = False
 
 
 class SlackNames:
@@ -261,6 +269,7 @@ class Inbound:
         if not self.dedupe.add(f"{channel}:{ts}"):
             return
 
+        first_join = False
         if event.get("channel_type") == "im":
             # DMs: everything is for us; replies go top-level.
             from_name = naming.encode(user, channel)
@@ -278,9 +287,22 @@ class Inbound:
             else:
                 return
             from_name = naming.encode(user, channel, thread_ts)
+            # First @mention in an existing thread: fetch prior lines on
+            # the drain worker. Already-active threads have been fed
+            # followups; a top-level mention has no thread above it.
+            first_join = bool(
+                mentioned
+                and event.get("thread_ts")
+                and not self.threads.is_active(channel, thread_ts)
+                and self.cfg.thread_join_backfill > 0
+            )
             self.threads.touch(channel, thread_ts)
 
-        self.queue.put(InboundMessage(from_name, user, channel, thread_ts, ts, text))
+        self.queue.put(
+            InboundMessage(
+                from_name, user, channel, thread_ts, ts, text, backfill=first_join
+            )
+        )
 
     # -- delivery worker -----------------------------------------------------
 
@@ -294,7 +316,96 @@ class Inbound:
             except Exception:
                 log.exception("failed delivering %s", msg.from_name)
 
+    def _thread_lines_before(
+        self, channel: str, thread_ts: str, before_ts: str, limit: int
+    ) -> list[dict[str, Any]]:
+        """Prior messages in a thread, closest to before_ts, capped at limit.
+
+        One conversations.replies call, bounded by JOIN_BACKFILL_TIMEOUT.
+        Fail open to [] so the mention still lands. Slack returns the parent
+        plus replies oldest-first; we keep ts < before_ts and take the tail.
+        """
+        fetch = min(200, max(limit + 1, 1))
+
+        def _call() -> list[dict[str, Any]]:
+            # One page, fail open. Slack returns oldest-first; we take the
+            # tail after filtering. Threads longer than `fetch` may miss
+            # the closest lines — the cap is the point (no dump, no stall).
+            resp = self.app.client.conversations_replies(
+                channel=channel,
+                ts=thread_ts,
+                latest=before_ts,
+                inclusive=False,
+                limit=fetch,
+            )
+            return list(resp.get("messages") or [])
+
+        try:
+            msgs = self._lookup_pool.submit(_call).result(timeout=JOIN_BACKFILL_TIMEOUT)
+        except Exception:
+            log.warning(
+                "conversations.replies failed for %s ts=%s",
+                channel,
+                thread_ts,
+                exc_info=True,
+            )
+            return []
+        def _key(ts: str) -> float:
+            try:
+                return float(ts)
+            except (TypeError, ValueError):
+                return 0.0
+
+        cutoff = _key(before_ts)
+        out = []
+        for m in msgs:
+            ts = m.get("ts") or ""
+            if not ts or _key(ts) >= cutoff:
+                continue
+            if m.get("subtype"):
+                continue
+            out.append(m)
+        out.sort(key=lambda m: _key(m.get("ts") or ""))
+        return out[-limit:]
+
+    def _format_backfill(self, messages: list[dict[str, Any]]) -> str:
+        lines: list[str] = []
+        for m in messages:
+            user = m.get("user")
+            name = self.names.user(user) if user else (m.get("username") or "unknown")
+            text = clean_inbound(m.get("text") or "", self.bot_user_id)
+            if not text:
+                continue
+            text = " ".join(text.split())
+            if len(text) > JOIN_BACKFILL_LINE_CHARS:
+                text = text[: JOIN_BACKFILL_LINE_CHARS - 3] + "..."
+            lines.append(f"{name}: {text}")
+        if not lines:
+            return ""
+        n = len(lines)
+        noun = "message" if n == 1 else "messages"
+        header = f"[thread before this mention — {n} earlier {noun}]"
+        return header + "\n" + "\n".join(lines)
+
     def _deliver(self, msg: InboundMessage) -> None:
+        if msg.backfill and msg.thread_ts and msg.message_ts:
+            prior = self._thread_lines_before(
+                msg.channel,
+                msg.thread_ts,
+                msg.message_ts,
+                self.cfg.thread_join_backfill,
+            )
+            block = self._format_backfill(prior)
+            if block:
+                msg = InboundMessage(
+                    msg.from_name,
+                    msg.user,
+                    msg.channel,
+                    msg.thread_ts,
+                    msg.message_ts,
+                    block + "\n\n" + msg.text,
+                    backfill=False,
+                )
         if msg.resolve_parent and msg.thread_ts:
             item_ts = msg.thread_ts
             parent = self._item_thread_ts(msg.channel, item_ts)

--- a/slack/tests/test_config.py
+++ b/slack/tests/test_config.py
@@ -78,3 +78,32 @@ def test_a_dangling_default_link_names_the_link(tmp_path):
         config.load(tmp_path)
     assert "default identity link" in str(exc.value)
     assert "ghost" in str(exc.value)
+
+
+
+def test_join_backfill_defaults_to_twenty(tmp_path, monkeypatch):
+    _identity(tmp_path, "ada")
+    (tmp_path / ".identities" / "default").symlink_to("ada")
+    monkeypatch.delenv("SLACK_THREAD_JOIN_BACKFILL", raising=False)
+    assert config.load(tmp_path).thread_join_backfill == 20
+
+
+def test_join_backfill_zero_disables(tmp_path, monkeypatch):
+    _identity(tmp_path, "ada")
+    (tmp_path / ".identities" / "default").symlink_to("ada")
+    monkeypatch.setenv("SLACK_THREAD_JOIN_BACKFILL", "0")
+    assert config.load(tmp_path).thread_join_backfill == 0
+
+
+def test_join_backfill_clamps_to_fifty(tmp_path, monkeypatch):
+    _identity(tmp_path, "ada")
+    (tmp_path / ".identities" / "default").symlink_to("ada")
+    monkeypatch.setenv("SLACK_THREAD_JOIN_BACKFILL", "999")
+    assert config.load(tmp_path).thread_join_backfill == 50
+
+
+def test_join_backfill_garbage_falls_back(tmp_path, monkeypatch):
+    _identity(tmp_path, "ada")
+    (tmp_path / ".identities" / "default").symlink_to("ada")
+    monkeypatch.setenv("SLACK_THREAD_JOIN_BACKFILL", "nope")
+    assert config.load(tmp_path).thread_join_backfill == 20

--- a/slack/tests/test_inbound.py
+++ b/slack/tests/test_inbound.py
@@ -178,11 +178,44 @@ class _FakeClient:
             {"channel": channel, "ts": ts, "latest": latest,
              "inclusive": inclusive, "limit": limit, "cursor": cursor}
         )
-        if self.replies_delay:
-            time.sleep(self.replies_delay)
-        if self.replies_exc:
-            raise RuntimeError("replies failed")
-        return {"ok": True, "messages": list(self.replies_messages)}
+        with self._lock:
+            self._live += 1
+            if self._live > self.max_live:
+                self.max_live = self._live
+        try:
+            if self.replies_delay:
+                time.sleep(self.replies_delay)
+            if self.replies_exc:
+                raise RuntimeError("replies failed")
+            msgs = list(self.replies_messages)
+
+            def _key(m):
+                try:
+                    return float(m.get("ts") or 0)
+                except (TypeError, ValueError):
+                    return 0.0
+
+            if latest is not None:
+                cut = float(latest)
+                if inclusive:
+                    msgs = [m for m in msgs if _key(m) <= cut]
+                else:
+                    msgs = [m for m in msgs if _key(m) < cut]
+            start = int(cursor) if cursor else 0
+            if limit is None:
+                page = msgs[start:]
+            else:
+                page = msgs[start:start + int(limit)]
+            next_cursor = ""
+            if limit is not None and start + int(limit) < len(msgs):
+                next_cursor = str(start + int(limit))
+            out = {"ok": True, "messages": page}
+            if next_cursor:
+                out["response_metadata"] = {"next_cursor": next_cursor}
+            return out
+        finally:
+            with self._lock:
+                self._live -= 1
 
 
 def _cfg(tmp_path, followups=True, join_backfill=20):
@@ -553,6 +586,37 @@ def test_first_mention_in_thread_prepends_capped_prior_lines(tmp_path, posted):
     assert client.replies_calls[0]["inclusive"] is False
 
 
+def test_join_backfill_cap_is_closest_prior_on_long_thread(tmp_path, posted):
+    """Nick #108: fake must honor limit; cap is the latest context, not the oldest page."""
+    client = _FakeClient()
+    mention_ts = "111.500"
+    client.replies_messages = [
+        {"ts": PARENT, "user": NICK, "text": "parent"},
+        {"ts": "111.301", "user": NICK, "text": "early one"},
+        {"ts": "111.302", "user": NICK, "text": "early two"},
+        {"ts": "111.303", "user": NICK, "text": "late one"},
+        {"ts": "111.304", "user": NICK, "text": "late two"},
+        {"ts": mention_ts, "user": NICK, "text": f"<@{BOT}> catch up?"},
+    ]
+    event = _message_event(text=f"<@{BOT}> catch up?", ts=mention_ts)
+    _run_message(tmp_path, client, event, posted, join_backfill=2)
+
+    assert len(posted.items) == 1
+    body = posted.items[0]["json"]["content"]
+    assert "thread before this mention — 2 earlier messages" in body
+    assert "early one" not in body
+    assert "early two" not in body
+    assert "Nick Jalbert: late one" in body
+    assert "Nick Jalbert: late two" in body
+    assert "catch up?" in body
+    # First page is oldest (parent + early one + early two at fetch=3);
+    # a second page is required to reach the two replies before the mention.
+    assert len(client.replies_calls) >= 2
+    assert client.replies_calls[0]["cursor"] in (None, "")
+    assert client.replies_calls[0]["limit"] == 3
+    assert client.replies_calls[1]["cursor"]
+
+
 def test_already_active_thread_does_not_backfill(tmp_path, posted):
     threads = ActiveThreads(tmp_path / "pre-threads.json")
     threads.touch(CHAN, PARENT)
@@ -620,3 +684,64 @@ def test_dm_does_not_backfill(tmp_path, posted):
 
     assert len(posted.items) == 1
     assert client.replies_calls == []
+
+
+def test_join_backfill_timeouts_share_one_worker(tmp_path, posted, monkeypatch):
+    """Nick #108: do not queue stale conversations.replies after a timeout.
+
+    One in-flight backfill lookup; later first mentions fail open
+    immediately instead of submitting more work. A human message after
+    the burst is delivered without waiting for the stale calls.
+    """
+    monkeypatch.setattr(inbound, "JOIN_BACKFILL_TIMEOUT", 0.05)
+    client = _FakeClient()
+    client.replies_delay = 0.8
+    client.replies_messages = [
+        {"ts": PARENT, "user": NICK, "text": "stale context"},
+    ]
+    cfg = _cfg(tmp_path, join_backfill=2)
+    threads = ActiveThreads(cfg.state_dir / "threads.json")
+    ib = Inbound(cfg, _FakeApp(client), BOT, threads)
+    logger = logging.getLogger("test")
+    try:
+        t0 = time.time()
+        for i in range(5):
+            parent = f"300.{i:03d}"
+            ts = f"301.{i:03d}"
+            ib._on_event(
+                _message_event(
+                    text=f"<@{BOT}> ping {i}",
+                    ts=ts,
+                    thread_ts=parent,
+                ),
+                logger,
+            )
+        ib._on_event(
+            {
+                "type": "message",
+                "user": NICK,
+                "text": "hello after burst",
+                "channel": DM,
+                "ts": "400.000",
+                "channel_type": "im",
+            },
+            logger,
+        )
+        deadline = t0 + 3
+        while time.time() < deadline and len(posted.items) < 6:
+            time.sleep(0.02)
+        elapsed = time.time() - t0
+        assert len(posted.items) == 6, posted.items
+        assert client.max_live == 1
+        assert len(client.replies_calls) == 1
+        # Five 2s waits would be 10s; one 50ms timeout plus delivery is far less.
+        assert elapsed < 1.0, elapsed
+        assert "hello after burst" in posted.items[-1]["json"]["content"]
+        for item in posted.items[:-1]:
+            body = item["json"]["content"]
+            assert "ping" in body
+            assert "thread before this mention" not in body
+            assert "stale context" not in body
+    finally:
+        ib.stop()
+        ib._worker.join(timeout=1)

--- a/slack/tests/test_inbound.py
+++ b/slack/tests/test_inbound.py
@@ -690,8 +690,10 @@ def test_join_backfill_timeouts_share_one_worker(tmp_path, posted, monkeypatch):
     """Nick #108: do not queue stale conversations.replies after a timeout.
 
     One in-flight backfill lookup; later first mentions fail open
-    immediately instead of submitting more work. A human message after
-    the burst is delivered without waiting for the stale calls.
+    immediately instead of submitting more work. Observe pool.submit
+    counts (not replies_calls at start-of-call) so queued-but-unstarted
+    lookups still fail the test. Wait until the first slow call finishes
+    before asserting no second call started.
     """
     monkeypatch.setattr(inbound, "JOIN_BACKFILL_TIMEOUT", 0.05)
     client = _FakeClient()
@@ -703,6 +705,14 @@ def test_join_backfill_timeouts_share_one_worker(tmp_path, posted, monkeypatch):
     threads = ActiveThreads(cfg.state_dir / "threads.json")
     ib = Inbound(cfg, _FakeApp(client), BOT, threads)
     logger = logging.getLogger("test")
+    submits: list[object] = []
+    orig_submit = ib._lookup_pool.submit
+
+    def counting_submit(*args, **kwargs):
+        submits.append(args)
+        return orig_submit(*args, **kwargs)
+
+    ib._lookup_pool.submit = counting_submit  # type: ignore[method-assign]
     try:
         t0 = time.time()
         for i in range(5):
@@ -732,8 +742,6 @@ def test_join_backfill_timeouts_share_one_worker(tmp_path, posted, monkeypatch):
             time.sleep(0.02)
         elapsed = time.time() - t0
         assert len(posted.items) == 6, posted.items
-        assert client.max_live == 1
-        assert len(client.replies_calls) == 1
         # Five 2s waits would be 10s; one 50ms timeout plus delivery is far less.
         assert elapsed < 1.0, elapsed
         assert "hello after burst" in posted.items[-1]["json"]["content"]
@@ -742,6 +750,14 @@ def test_join_backfill_timeouts_share_one_worker(tmp_path, posted, monkeypatch):
             assert "ping" in body
             assert "thread before this mention" not in body
             assert "stale context" not in body
+        # Submissions are counted at pool.submit, so a queued second lookup
+        # fails this even before conversations.replies starts. Then wait out
+        # the first slow call so a queued worker would have started.
+        assert len(submits) == 1, len(submits)
+        time.sleep(client.replies_delay + 0.15)
+        assert client.max_live == 1
+        assert len(client.replies_calls) == 1
+        assert len(submits) == 1, len(submits)
     finally:
         ib.stop()
         ib._worker.join(timeout=1)

--- a/slack/tests/test_inbound.py
+++ b/slack/tests/test_inbound.py
@@ -125,6 +125,10 @@ class _FakeClient:
         self.permalink_delay = permalink_delay
         self.reactions_get_calls = []
         self.permalink_calls = []
+        self.replies_calls = []
+        self.replies_messages = []
+        self.replies_delay = 0.0
+        self.replies_exc = False
         self._live = 0
         self.max_live = 0
         self._lock = __import__("threading").Lock()
@@ -168,8 +172,20 @@ class _FakeClient:
     def chat_postMessage(self, **kwargs):
         raise AssertionError(f"unexpected chat_postMessage {kwargs}")
 
+    def conversations_replies(self, *, channel, ts, latest=None, inclusive=None,
+                              limit=None, cursor=None, **_kw):
+        self.replies_calls.append(
+            {"channel": channel, "ts": ts, "latest": latest,
+             "inclusive": inclusive, "limit": limit, "cursor": cursor}
+        )
+        if self.replies_delay:
+            time.sleep(self.replies_delay)
+        if self.replies_exc:
+            raise RuntimeError("replies failed")
+        return {"ok": True, "messages": list(self.replies_messages)}
 
-def _cfg(tmp_path, followups=True):
+
+def _cfg(tmp_path, followups=True, join_backfill=20):
     serve = tmp_path / "serve"
     ident = serve / "audel"
     ident.mkdir(parents=True)
@@ -184,6 +200,7 @@ def _cfg(tmp_path, followups=True):
         web_url="http://127.0.0.1:9",
         state_dir=state,
         thread_followups=followups,
+        thread_join_backfill=join_backfill,
     )
 
 
@@ -474,3 +491,132 @@ def test_permalink_failure_does_not_drop_message(monkeypatch):
 
     assert len(posts) == 1
     assert "source_url" not in posts[0]
+
+
+
+def _message_event(*, text, ts="111.500", thread_ts=PARENT, channel=CHAN,
+                   user=NICK, event_type="app_mention", channel_type="channel"):
+    event = {
+        "type": event_type,
+        "user": user,
+        "text": text,
+        "channel": channel,
+        "ts": ts,
+        "channel_type": channel_type,
+    }
+    if thread_ts is not None:
+        event["thread_ts"] = thread_ts
+    return event
+
+
+def _run_message(tmp_path, client, event, posted, followups=True, join_backfill=20,
+                 threads=None):
+    cfg = _cfg(tmp_path, followups=followups, join_backfill=join_backfill)
+    if threads is None:
+        threads = ActiveThreads(cfg.state_dir / "threads.json")
+    ib = Inbound(cfg, _FakeApp(client), BOT, threads)
+    logger = logging.getLogger("test")
+    try:
+        ib._on_event(event, logger)
+        deadline = time.time() + 2
+        while time.time() < deadline and not posted.items:
+            time.sleep(0.02)
+        time.sleep(0.05)
+    finally:
+        ib.stop()
+        ib._worker.join(timeout=1)
+    return threads
+
+
+def test_first_mention_in_thread_prepends_capped_prior_lines(tmp_path, posted):
+    client = _FakeClient()
+    mention_ts = "111.500"
+    client.replies_messages = [
+        {"ts": PARENT, "user": NICK, "text": "context one"},
+        {"ts": "111.300", "user": NICK, "text": "context two"},
+        {"ts": "111.400", "user": NICK, "text": "context three"},
+        {"ts": mention_ts, "user": NICK, "text": f"<@{BOT}> what do you think?"},
+    ]
+    event = _message_event(text=f"<@{BOT}> what do you think?", ts=mention_ts)
+    _run_message(tmp_path, client, event, posted, join_backfill=2)
+
+    assert len(posted.items) == 1
+    body = posted.items[0]["json"]["content"]
+    assert "thread before this mention — 2 earlier messages" in body
+    assert "context one" not in body
+    assert "Nick Jalbert: context two" in body
+    assert "Nick Jalbert: context three" in body
+    assert "what do you think?" in body
+    assert client.replies_calls
+    assert client.replies_calls[0]["ts"] == PARENT
+    assert client.replies_calls[0]["latest"] == mention_ts
+    assert client.replies_calls[0]["inclusive"] is False
+
+
+def test_already_active_thread_does_not_backfill(tmp_path, posted):
+    threads = ActiveThreads(tmp_path / "pre-threads.json")
+    threads.touch(CHAN, PARENT)
+    client = _FakeClient()
+    client.replies_messages = [
+        {"ts": PARENT, "user": NICK, "text": "old context"},
+    ]
+    event = _message_event(text=f"<@{BOT}> ping")
+    _run_message(tmp_path, client, event, posted, threads=threads)
+
+    assert len(posted.items) == 1
+    body = posted.items[0]["json"]["content"]
+    assert "thread before this mention" not in body
+    assert "old context" not in body
+    assert client.replies_calls == []
+
+
+def test_top_level_mention_does_not_backfill(tmp_path, posted):
+    client = _FakeClient()
+    event = _message_event(
+        text=f"<@{BOT}> hello",
+        ts="111.500",
+        thread_ts=None,
+    )
+    _run_message(tmp_path, client, event, posted)
+
+    assert len(posted.items) == 1
+    assert "thread before this mention" not in posted.items[0]["json"]["content"]
+    assert client.replies_calls == []
+
+
+def test_join_backfill_failure_still_delivers_mention(tmp_path, posted):
+    client = _FakeClient()
+    client.replies_exc = True
+    event = _message_event(text=f"<@{BOT}> still there?")
+    _run_message(tmp_path, client, event, posted)
+
+    assert len(posted.items) == 1
+    body = posted.items[0]["json"]["content"]
+    assert "still there?" in body
+    assert "thread before this mention" not in body
+
+
+def test_join_backfill_zero_skips_lookup(tmp_path, posted):
+    client = _FakeClient()
+    event = _message_event(text=f"<@{BOT}> hi")
+    _run_message(tmp_path, client, event, posted, join_backfill=0)
+
+    assert len(posted.items) == 1
+    assert client.replies_calls == []
+    assert "thread before this mention" not in posted.items[0]["json"]["content"]
+
+
+def test_dm_does_not_backfill(tmp_path, posted):
+    client = _FakeClient()
+    event = _message_event(
+        text="hello",
+        ts="111.500",
+        thread_ts=None,
+        channel=DM,
+        event_type="message",
+        channel_type="im",
+    )
+    _run_message(tmp_path, client, event, posted)
+
+    assert len(posted.items) == 1
+    assert client.replies_calls == []


### PR DESCRIPTION
## Why

A first `@mention` in an existing Slack thread currently delivers only that one event. The unaddressed history sitting above it never reaches the mind — that's the gap that produced the overclaim about already having the thread.

Nick asked whether the bridge should forward the whole thread once the bot is added to it. Yes, capped so a long thread cannot dump.

## What

On first join of an existing thread (`app_mention` / in-text mention, thread already has a parent `thread_ts`, thread not yet in `ActiveThreads`), the inbound **drain worker** (not the Bolt handler) calls `conversations.replies` and prepends a digest of earlier lines:

```
(thread before this mention, last N)
  display-name: text
  ...
```

then the mention itself, same `from_name` / permalink as today.

- Cap: `SLACK_THREAD_JOIN_BACKFILL` (default 20, max 50, `0` disables).
- Fail open: Slack timeout / error still delivers the mention with no digest.
- Already-active threads, top-level mentions that *start* a thread, and DMs skip the lookup.
- Bolt still acks immediately.

No new Slack scopes (`conversations.replies` is covered by the existing history / channels read scopes).

## Not in this PR

Outbound `reactions.add` (sending emoticons). Receiving reactions is #88. Sending them is a new `chat` surface plus `reactions:write` + reinstall — not a small add. Happy to do it as a follow-up if you want it.

## Tests

`uv run --project slack pytest slack/tests/` — 55 passed.