### PR TITLE
slack: upload chat send-file steps via files.upload_v2

### DIFF
--- a/slack/PLAYBOOK.md
+++ b/slack/PLAYBOOK.md
@@ -40,9 +40,10 @@ After the rebuild, copy the archive back and run `identity import`.
 
 Work from the `slack/` directory. `manifest.json` is the source of truth.
 
-`reaction_added` needs bot scope `reactions:read` (in `manifest.json`). A
-scope change requires reinstall / re-grant; until then Socket Mode will
-not deliver reaction events.
+`reaction_added` needs bot scope `reactions:read` (in `manifest.json`).
+Outbound `chat send-file` needs `files:write`. A scope change requires
+reinstall / re-grant; until then Socket Mode will not deliver reaction
+events, and file uploads will fail.
 
 ```bash
 cd slack

--- a/slack/README.md
+++ b/slack/README.md
@@ -16,7 +16,8 @@ Slack <=(Socket Mode websocket)=> headlong-slack-bridge
               reaction_added on the bot's messages (and any DM reaction)
               lands as a `:emoji:` body (same from_name / thread)
     outbound: tail trajectory.jsonl -> message steps where from=<identity>
-              and to=slack-* -> chat.postMessage(channel, thread_ts)
+              and to=slack-* -> chat.postMessage, or files.upload_v2 when
+              the step has filename (chat send-file)
 ```
 
 The Slack conversation is encoded into the chat `from` name, which the
@@ -92,6 +93,8 @@ Information → App-Level Tokens, scope `connections:write`). Box-side day-2
 ```bash
 uv run --project slack pytest slack/tests
 ```
+
+Outbound `chat send-file` posts use Slack `files.upload_v2` and need the bot scope `files:write` in addition to `chat:write`. A scope change requires reinstall / re-grant.
 
 ## Security notes
 

--- a/slack/manifest.json
+++ b/slack/manifest.json
@@ -19,6 +19,7 @@
       "bot": [
         "app_mentions:read",
         "chat:write",
+        "files:write",
         "im:history",
         "im:read",
         "im:write",

--- a/slack/src/headlong_slack/filepayload.py
+++ b/slack/src/headlong_slack/filepayload.py
@@ -1,0 +1,92 @@
+"""Detect file-bearing mind-log steps for Slack outbound.
+
+`chat send-file` stamps `filename` on the message step. Binary files
+travel in `content_b64` (standard base64) because JSON cannot hold raw
+bytes; text may sit in `content`. Outbound uploads the decoded bytes
+via files.upload_v2 rather than stuffing them into chat.postMessage.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from .slackfmt import strip_leaked_command
+
+COMMENT_MAX = 3000  # Slack files.upload_v2 initial_comment
+
+
+def file_signature(filename: str, content: bytes | str) -> str:
+    """Bounded RecentPosts key: basename plus a hash of the decoded bytes."""
+    raw = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+    return f"{filename}:{hashlib.sha256(raw).hexdigest()}"
+
+
+class DecodeError(Exception):
+    """File bytes could not be recovered from the step."""
+
+
+def _content(step: dict[str, Any]) -> bytes | str | None:
+    if "content_b64" in step:
+        b64 = step.get("content_b64")
+        if not isinstance(b64, str) or not b64:
+            raise DecodeError("empty content_b64")
+        try:
+            raw = base64.b64decode(b64, validate=True)
+        except (binascii.Error, ValueError) as e:
+            raise DecodeError(str(e)) from e
+        if not raw:
+            raise DecodeError("empty content_b64")
+        return raw
+    content = step.get("content")
+    if content is None or content == "":
+        return None
+    if isinstance(content, str):
+        return strip_leaked_command(content)
+    raise DecodeError("non-string content")
+
+
+def file_payload(step: dict[str, Any]) -> dict[str, Any] | None:
+    """Return upload kwargs, or None if this step is ordinary text.
+
+    A file step is one with an explicit `filename` field. The `file`
+    alias is not accepted: an ordinary message that happens to carry
+    that key must stay a chat.postMessage. Content is leak-filtered so a
+    stray `chat reply` in a caption cannot re-trigger the agent.
+
+    If `content_b64` is present but not strict base64 (or decodes to
+    empty), the returned dict has `content` None and `decode_error`
+    True so outbound can fail loudly instead of falling through to
+    chat.postMessage.
+    """
+    raw_name = step.get("filename")
+    if not isinstance(raw_name, str) or not raw_name.strip():
+        return None
+    filename = Path(raw_name).name
+    if not filename or filename in {".", ".."}:
+        return None
+
+    decode_error = False
+    try:
+        content = _content(step)
+    except DecodeError:
+        content = None
+        decode_error = True
+    if content is None and not decode_error:
+        return None
+
+    caption = step.get("caption")
+    if caption is None or caption == "":
+        comment_out = None
+    else:
+        comment_out = strip_leaked_command(str(caption))[:COMMENT_MAX] or None
+
+    return {
+        "filename": filename,
+        "content": content,
+        "initial_comment": comment_out,
+        "decode_error": decode_error,
+    }

--- a/slack/src/headlong_slack/outbound.py
+++ b/slack/src/headlong_slack/outbound.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from . import mindlog, naming
 from .config import Config
+from .filepayload import file_payload, file_signature
 from .slackfmt import chunk, strip_leaked_command, to_mrkdwn
 from .state import ActiveThreads
 
@@ -40,6 +41,38 @@ class RecentPosts:
             return True
         self._last[conversation] = (text, now)
         return False
+
+
+def _post_notice(client: Any, conv: naming.Conversation, text: str) -> None:
+    try:
+        client.chat_postMessage(
+            channel=conv.channel,
+            thread_ts=conv.thread_ts,
+            text=text,
+            unfurl_links=False,
+        )
+    except Exception:
+        log.exception("delivery-failed notice also failed for %s/%s", conv.channel, conv.thread_ts)
+
+
+def _upload_file(
+    client: Any,
+    conv: naming.Conversation,
+    filename: str,
+    data: bytes | str,
+    comment: str | None,
+) -> None:
+    kwargs: dict[str, Any] = {
+        "channel": conv.channel,
+        "filename": filename,
+        "title": filename,
+        "content": data,
+    }
+    if conv.thread_ts:
+        kwargs["thread_ts"] = conv.thread_ts
+    if comment:
+        kwargs["initial_comment"] = comment
+    client.files_upload_v2(**kwargs)
 
 
 def run(
@@ -71,6 +104,31 @@ def run(
         if not naming.is_slack_name(to):
             continue
         conv = naming.decode(to)
+        payload = file_payload(step)
+        if payload is not None:
+            # File steps travel in content_b64 and often have empty `content`.
+            # Do not require text, and do not fall back to posting bytes as a message.
+            name = payload["filename"]
+            data = payload["content"]
+            comment = payload.get("initial_comment")
+            sent_file = False
+            if payload.get("decode_error") or data is None:
+                log.error("undecodable file payload for %s (%s)", to, name)
+            elif recent.is_duplicate(to, file_signature(name, data)):
+                log.warning("skipping duplicate file post to %s", to)
+                continue
+            elif not hasattr(client, "files_upload_v2"):
+                log.error("client cannot upload files for %s", to)
+            else:
+                try:
+                    _upload_file(client, conv, name, data, comment)
+                    sent_file = True
+                except Exception:
+                    log.exception("file upload failed for %s", to)
+            threads.touch(conv.channel, conv.thread_ts)
+            if not sent_file:
+                _post_notice(client, conv, f"(failed to deliver file {name})")
+            continue
         text = to_mrkdwn(strip_leaked_command(str(step.get("content") or ""))).strip()
         if not text:
             continue

--- a/slack/src/headlong_slack/outbound.py
+++ b/slack/src/headlong_slack/outbound.py
@@ -36,11 +36,20 @@ class RecentPosts:
 
     def is_duplicate(self, conversation: str, text: str, now: float | None = None) -> bool:
         now = time.time() if now is None else now
-        previous = self._last.get(conversation)
-        if previous and previous[0] == text and now - previous[1] < self._window:
+        if self.seen(conversation, text, now=now):
             return True
-        self._last[conversation] = (text, now)
+        self.record(conversation, text, now=now)
         return False
+
+    def seen(self, conversation: str, text: str, now: float | None = None) -> bool:
+        """True if this payload was already recorded in the window. Does not record."""
+        now = time.time() if now is None else now
+        previous = self._last.get(conversation)
+        return bool(previous and previous[0] == text and now - previous[1] < self._window)
+
+    def record(self, conversation: str, text: str, now: float | None = None) -> None:
+        now = time.time() if now is None else now
+        self._last[conversation] = (text, now)
 
 
 def _post_notice(client: Any, conv: naming.Conversation, text: str) -> None:
@@ -112,9 +121,10 @@ def run(
             data = payload["content"]
             comment = payload.get("initial_comment")
             sent_file = False
+            sig = file_signature(name, data) if data is not None else None
             if payload.get("decode_error") or data is None:
                 log.error("undecodable file payload for %s (%s)", to, name)
-            elif recent.is_duplicate(to, file_signature(name, data)):
+            elif sig is not None and recent.seen(to, sig):
                 log.warning("skipping duplicate file post to %s", to)
                 continue
             elif not hasattr(client, "files_upload_v2"):
@@ -123,6 +133,8 @@ def run(
                 try:
                     _upload_file(client, conv, name, data, comment)
                     sent_file = True
+                    if sig is not None:
+                        recent.record(to, sig)
                 except Exception:
                     log.exception("file upload failed for %s", to)
             threads.touch(conv.channel, conv.thread_ts)

--- a/slack/tests/test_filepayload.py
+++ b/slack/tests/test_filepayload.py
@@ -1,0 +1,100 @@
+from headlong_slack.filepayload import COMMENT_MAX, file_payload, file_signature
+
+
+def test_plain_text_is_not_a_file():
+    assert file_payload({"type": "message", "content": "hello"}) is None
+
+
+def test_filename_stamps_a_document():
+    payload = file_payload({"filename": "note.txt", "content": "hi"})
+    assert payload is not None
+    assert payload["filename"] == "note.txt"
+    assert payload["content"] == "hi"
+    assert payload["initial_comment"] is None
+    assert payload["decode_error"] is False
+
+
+def test_content_b64_roundtrips_png_bytes():
+    import base64
+    png = b"\x89PNG\r\n\x1a\n" + b"rest"
+    payload = file_payload({
+        "filename": "fig.png",
+        "content_b64": base64.b64encode(png).decode("ascii"),
+    })
+    assert payload is not None
+    assert payload["content"] == png
+
+
+def test_svg_without_filename_stays_text():
+    assert file_payload({"content": "<svg xmlns='x'></svg>"}) is None
+
+
+def test_path_is_reduced_to_basename():
+    payload = file_payload({"filename": "/etc/passwd", "content": "x"})
+    assert payload is not None
+    assert payload["filename"] == "passwd"
+
+
+def test_invalid_b64_is_decode_error():
+    payload = file_payload({
+        "filename": "a.bin",
+        "content_b64": "!!!!",
+        "content": "[file: a.bin]",
+    })
+    assert payload is not None
+    assert payload["content"] is None
+    assert payload["decode_error"] is True
+
+
+def test_empty_content_b64_is_decode_error():
+    payload = file_payload({
+        "filename": "note.txt",
+        "content_b64": "",
+        "content": "[file: note.txt]",
+    })
+    assert payload is not None
+    assert payload["content"] is None
+    assert payload["decode_error"] is True
+
+
+def test_file_signature_is_filename_plus_content_hash():
+    same = file_signature("note.txt", b"aaa")
+    assert same == file_signature("note.txt", "aaa")
+    assert same != file_signature("note.txt", b"bbb")
+    assert same != file_signature("other.txt", b"aaa")
+
+
+def test_non_string_content_is_decode_error():
+    payload = file_payload({
+        "filename": "bad.bin",
+        "content": {"x": "y"},
+    })
+    assert payload is not None
+    assert payload["content"] is None
+    assert payload["decode_error"] is True
+
+
+def test_file_alias_is_ignored():
+    assert file_payload({"file": "note.txt", "content": "hi"}) is None
+    payload = file_payload({"filename": "note.txt", "file": "other.bin", "content": "hi"})
+    assert payload is not None
+    assert payload["filename"] == "note.txt"
+
+
+def test_caption_and_text_content_are_leak_filtered():
+    payload = file_payload({
+        "filename": "note.txt",
+        "content": "chat reply slack-U1-C1 secret notes",
+        "caption": "chat reply slack-U1-C1 look",
+    })
+    assert payload is not None
+    assert payload["content"] == "secret notes"
+    assert payload["initial_comment"] == "look"
+
+
+def test_caption_is_truncated():
+    payload = file_payload({
+        "filename": "a.txt", "content": "x", "caption": "c" * (COMMENT_MAX + 50),
+    })
+    assert payload is not None
+    assert payload["initial_comment"] == "c" * COMMENT_MAX

--- a/slack/tests/test_outbound.py
+++ b/slack/tests/test_outbound.py
@@ -168,6 +168,48 @@ def test_undecodable_file_falls_back_to_notice(tmp_path, monkeypatch):
     assert sent == ["(failed to deliver file note.txt)"]
 
 
+
+def test_file_upload_retries_after_slack_rejects_first_identical_step(tmp_path, monkeypatch):
+    """Do not suppress a retry after Slack rejects the first upload.
+
+    recent.seen/record must not stamp the file signature until files_upload_v2
+    succeeds. Otherwise a transient Slack failure plus a repeated chat send-file
+    step posts one notice and skips the second attempt for five minutes.
+    """
+    raw = b"same-bytes"
+    b64 = base64.b64encode(raw).decode("ascii")
+    steps = [
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "note.txt", "content_b64": b64,
+         "step_id": "a"},
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "note.txt", "content_b64": b64,
+         "step_id": "b"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    uploads = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            sent.append(text)
+
+        def files_upload_v2(self, **kw):
+            uploads.append(kw["content"])
+            if len(uploads) == 1:
+                raise RuntimeError("upload rejected")
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert uploads == [raw, raw]
+    assert sent == ["(failed to deliver file note.txt)"]
+
+
 def test_identical_file_steps_are_suppressed(tmp_path, monkeypatch):
     raw = b"same-bytes"
     b64 = base64.b64encode(raw).decode("ascii")

--- a/slack/tests/test_outbound.py
+++ b/slack/tests/test_outbound.py
@@ -1,22 +1,28 @@
 """Outbound filter: only bin/chat speaks for the identity."""
 
+import base64
 import threading
 
 from headlong_slack import outbound
 from headlong_slack.config import Config
 
 
+def _cfg(tmp_path):
+    return Config(
+        serve_root=tmp_path, identity="audel", identity_dir=tmp_path,
+        bot_token="x", app_token="x", web_url="http://x", state_dir=tmp_path,
+        thread_followups=True,
+    )
+
+
 def test_run_delivers_only_chat_sourced_messages(tmp_path, monkeypatch):
     """Message steps without source:"chat" (a thinker appending raw message
     steps to the trajectory) must not reach Slack."""
     steps = [
-        # legit reply, stamped by bin/chat
         {"type": "message", "from": "audel", "to": "slack-C1-U1",
          "source": "chat", "content": "real reply", "step_id": "aaa"},
-        # forged: thinker-appended, wrong source
         {"type": "message", "from": "audel", "to": "slack-C1-U1",
          "source": "responder", "content": "forged reply", "step_id": "bbb"},
-        # forged: no source at all
         {"type": "message", "from": "audel", "to": "slack-C1-U1",
          "content": "unstamped reply", "step_id": "ccc"},
     ]
@@ -33,24 +39,204 @@ def test_run_delivers_only_chat_sourced_messages(tmp_path, monkeypatch):
         def touch(self, channel, thread_ts):
             pass
 
-    cfg = Config(
-        serve_root=tmp_path, identity="audel", identity_dir=tmp_path,
-        bot_token="x", app_token="x", web_url="http://x", state_dir=tmp_path,
-        thread_followups=True,
-    )
-    outbound.run(cfg, FakeClient(), FakeThreads(), threading.Event())
-
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
     assert sent == ["real reply"]
 
 
-def test_text_file_posts_file_contents(tmp_path, monkeypatch):
-    """chat send-file stores text in content; Slack must deliver that body."""
+def test_text_file_uploads_via_files_upload_v2(tmp_path, monkeypatch):
+    """chat send-file stamps filename + content_b64; Slack must upload, not post."""
+    body = b"hello file\n"
     steps = [
         {"type": "message", "from": "audel", "to": "slack-U1-C1",
          "source": "chat", "filename": "note.txt",
          "content": "hello file",
-         "content_b64": "aGVsbG8gZmlsZQo=",
+         "content_b64": base64.b64encode(body).decode("ascii"),
          "step_id": "fff"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    uploads = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            sent.append(text)
+
+        def files_upload_v2(self, **kw):
+            uploads.append(kw)
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert sent == []
+    assert len(uploads) == 1
+    assert uploads[0]["filename"] == "note.txt"
+    assert uploads[0]["content"] == body
+    assert uploads[0]["channel"] == "C1"
+    assert "thread_ts" not in uploads[0]
+
+
+def test_png_uploads_bytes_in_thread(tmp_path, monkeypatch):
+    png = b"\x89PNG\r\n\x1a\n" + b"rest"
+    steps = [
+        {"type": "message", "from": "audel", "to": "slack-U1-C09XYZ-1722400000.123456",
+         "source": "chat", "filename": "fig.png",
+         "content": "[file: fig.png]",
+         "content_b64": base64.b64encode(png).decode("ascii"),
+         "step_id": "png"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    uploads = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            sent.append(text)
+
+        def files_upload_v2(self, **kw):
+            uploads.append(kw)
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert sent == []
+    assert uploads[0]["content"] == png
+    assert uploads[0]["filename"] == "fig.png"
+    assert uploads[0]["channel"] == "C09XYZ"
+    assert uploads[0]["thread_ts"] == "1722400000.123456"
+
+
+def test_file_upload_failure_falls_back_to_notice(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "note.txt", "content": "hi",
+         "step_id": "fail"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            sent.append(text)
+
+        def files_upload_v2(self, **kw):
+            raise RuntimeError("upload rejected")
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert sent == ["(failed to deliver file note.txt)"]
+
+
+def test_undecodable_file_falls_back_to_notice(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "note.txt",
+         "content": "[file: note.txt]", "content_b64": "@@@bad@@@",
+         "step_id": "bad"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+    uploads = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            sent.append(text)
+
+        def files_upload_v2(self, **kw):
+            uploads.append(kw)
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert uploads == []
+    assert sent == ["(failed to deliver file note.txt)"]
+
+
+def test_identical_file_steps_are_suppressed(tmp_path, monkeypatch):
+    raw = b"same-bytes"
+    b64 = base64.b64encode(raw).decode("ascii")
+    other = b"other-bytes"
+    steps = [
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "note.txt", "content_b64": b64,
+         "step_id": "a"},
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "note.txt", "content_b64": b64,
+         "step_id": "b"},
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "note.txt",
+         "content_b64": base64.b64encode(other).decode("ascii"),
+         "step_id": "c"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    uploads = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            raise AssertionError("no text fallback")
+
+        def files_upload_v2(self, **kw):
+            uploads.append(kw["content"])
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert uploads == [raw, other]
+
+
+def test_invalid_file_content_does_not_stop_later_replies(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "bad.bin",
+         "content": {"x": "y"}, "step_id": "bad"},
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "content": "later reply", "step_id": "ok"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            sent.append(text)
+
+        def files_upload_v2(self, **kw):
+            raise AssertionError("should not upload")
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert sent == ["(failed to deliver file bad.bin)", "later reply"]
+
+
+def test_client_without_upload_posts_notice(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel", "to": "slack-U1-C1",
+         "source": "chat", "filename": "note.txt", "content": "hi",
+         "step_id": "n"},
     ]
     monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
     monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
@@ -65,10 +251,5 @@ def test_text_file_posts_file_contents(tmp_path, monkeypatch):
         def touch(self, channel, thread_ts):
             pass
 
-    cfg = Config(
-        serve_root=tmp_path, identity="audel", identity_dir=tmp_path,
-        bot_token="x", app_token="x", web_url="http://x", state_dir=tmp_path,
-        thread_followups=True,
-    )
-    outbound.run(cfg, FakeClient(), FakeThreads(), threading.Event())
-    assert sent == ["hello file"]
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert sent == ["(failed to deliver file note.txt)"]


### PR DESCRIPTION
Outbound used to `chat.postMessage` every reply, so a `chat send-file` step to a `slack-*` name never actually uploaded.

This slice:
- detects file-bearing mind-log steps (`filename` + `content` / `content_b64`, same contract as Telegram)
- uploads via `files.upload_v2` into the right channel/thread
- falls back to a short notice if decode/upload fails, without killing later replies
- adds bot scope `files:write` in `manifest.json`

Needs a Slack app reinstall / re-grant for `files:write` before uploads will land (same drill as `reactions:read`).