### PR TITLE
slack: add outbound emoji reactions via chat react

### DIFF
--- a/bin/chat
+++ b/bin/chat
@@ -263,6 +263,63 @@ cmd_send_file() {
     printf 'File sent: %s\n' "$filename" >&2
 }
 
+cmd_react() {
+    local from="${IDENTITY_NAME:-}" to="" reply_to="" source_url="" emoji=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --from) from="${2:?--from requires a name}"; shift 2 ;;
+            --to)   to="${2:?--to requires a name}"; shift 2 ;;
+            --reply-to) reply_to="${2:?--reply-to requires a step id}"; shift 2 ;;
+            --source-url) source_url="${2:?--source-url requires a URL}"; shift 2 ;;
+            *) break ;;
+        esac
+    done
+    if [[ -z "$to" && $# -gt 0 ]]; then
+        to="$1"; shift
+    fi
+    [[ -z "$to" ]] && die "Usage: chat react [--reply-to <step_id>] [--source-url <url>] <to_name> <emoji>"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --from) from="${2:?--from requires a name}"; shift 2 ;;
+            --to)   to="${2:?--to requires a name}"; shift 2 ;;
+            --reply-to) reply_to="${2:?--reply-to requires a step id}"; shift 2 ;;
+            --source-url) source_url="${2:?--source-url requires a URL}"; shift 2 ;;
+            *) break ;;
+        esac
+    done
+    emoji="${1:-}"
+    [[ -z "$emoji" ]] && die "Usage: chat react [--reply-to <step_id>] [--source-url <url>] <to_name> <emoji>"
+    shift
+    [[ $# -eq 0 ]] || die "unexpected extra arguments"
+
+    # Slack reactions.add wants the short name (thumbsup), not :thumbsup: or 👍.
+    emoji="${emoji#:}"
+    emoji="${emoji%:}"
+    [[ "$emoji" =~ ^[a-z0-9_+\-:]{1,64}$ ]] || die "invalid Slack emoji name: $emoji"
+
+    _resolve_from_to
+
+    if [[ -z "$source_url" && -n "$reply_to" ]]; then
+        source_url=$(
+            traj show --traj_dir "$TRAJ_DIR" "$reply_to" --field source_url 2>/dev/null \
+                | tr -d '\n'
+        ) || true
+    fi
+
+    jq -nc \
+        --arg from "$from" \
+        --arg to "$to" \
+        --arg reaction "$emoji" \
+        --arg reply_to "$reply_to" \
+        --arg source_url "$source_url" \
+        '{type:"message", content:(":" + $reaction + ":"), reaction:$reaction, from:$from, to:$to, source:"chat"}
+         + (if $reply_to == "" then {} else {reply_to:$reply_to} end)
+         + (if $source_url == "" then {} else {source_url:$source_url} end)' \
+        | _chat_append
+
+    printf 'Reaction sent: :%s:\n' "$emoji" >&2
+}
+
 # UTF-8, no NUL: the historical `content=$(cat ...)` shape Slack/web still read.
 # JSON strings cannot hold NUL; jq --rawfile requires UTF-8.
 _chat_is_text_file() {
@@ -595,6 +652,9 @@ Usage:
                              default_send_from, to defaults to $IDENTITY_NAME)
   chat send-file [--from <name>] [--to <name>] <file>
                              Send a file's contents as a message
+  chat react [--reply-to <step_id>] [--source-url <url>] <to_name> <emoji>
+                             Add a Slack emoji reaction (name, not unicode).
+                             Stamps reaction on a chat-sourced message step.
   chat reply [--reply-to <step_id>] [--follow-up] <to_name> <message>
                              Agent sends a reply (from is $IDENTITY_NAME).
                              Stamps reply_to with the step it answers —
@@ -650,6 +710,7 @@ EOF
 case "${1:-}" in
     send)      shift; cmd_send "$@" ;;
     send-file) shift; cmd_send_file "$@" ;;
+    react)     shift; cmd_react "$@" ;;
     reply)     shift; cmd_reply "$@" ;;
     history) shift; cmd_history "$@" ;;
     pending)   shift; cmd_pending "$@" ;;

--- a/bin/chat
+++ b/bin/chat
@@ -295,7 +295,7 @@ cmd_react() {
     # Slack reactions.add wants the short name (thumbsup), not :thumbsup: or 👍.
     emoji="${emoji#:}"
     emoji="${emoji%:}"
-    [[ "$emoji" =~ ^[a-z0-9_+\-:]{1,64}$ ]] || die "invalid Slack emoji name: $emoji"
+    [[ "$emoji" =~ ^[-a-z0-9_+:]{1,64}$ ]] || die "invalid Slack emoji name: $emoji"
 
     _resolve_from_to
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -34,6 +34,20 @@ chat reply slack-U07AB12CD-C09XYZ123-1722400000.123456 "On it — deploy is gree
 Always use the sender's full `slack-…` name verbatim as the reply target.
 Do not shorten it or substitute the person's display name.
 
+### Reacting
+
+Add an emoji reaction to the Slack message you are answering. Use the
+Slack short name (`thumbsup`, `eyes`, `+1`), not unicode:
+
+```bash
+chat react slack-U07AB12CD-C09XYZ123-1722400000.123456 thumbsup
+chat react --reply-to <inbound-step-id> slack-U07AB12CD-C09XYZ123-1722400000.123456 eyes
+```
+
+`--reply-to` copies that inbound step's `source_url` so the reaction
+lands on the specific message, not just the thread root. Needs the
+Slack app's `reactions:write` scope (reinstall after it lands).
+
 ### Following up proactively
 
 To continue a Slack conversation later (e.g. after finishing a task someone

--- a/slack/PLAYBOOK.md
+++ b/slack/PLAYBOOK.md
@@ -41,9 +41,10 @@ After the rebuild, copy the archive back and run `identity import`.
 Work from the `slack/` directory. `manifest.json` is the source of truth.
 
 `reaction_added` needs bot scope `reactions:read` (in `manifest.json`).
-Outbound `chat send-file` needs `files:write`. A scope change requires
-reinstall / re-grant; until then Socket Mode will not deliver reaction
-events, and file uploads will fail.
+Outbound `chat send-file` needs `files:write`. Outbound `chat react`
+needs `reactions:write`. A scope change requires reinstall / re-grant;
+until then Socket Mode will not deliver reaction events, file uploads
+will fail, and outbound emoji reactions will fail.
 
 ```bash
 cd slack

--- a/slack/README.md
+++ b/slack/README.md
@@ -16,8 +16,9 @@ Slack <=(Socket Mode websocket)=> headlong-slack-bridge
               reaction_added on the bot's messages (and any DM reaction)
               lands as a `:emoji:` body (same from_name / thread)
     outbound: tail trajectory.jsonl -> message steps where from=<identity>
-              and to=slack-* -> chat.postMessage, or files.upload_v2 when
-              the step has filename (chat send-file)
+              and to=slack-* -> chat.postMessage, files.upload_v2 when
+              the step has filename (chat send-file), or reactions.add
+              when the step has reaction (chat react)
 ```
 
 The Slack conversation is encoded into the chat `from` name, which the

--- a/slack/manifest.json
+++ b/slack/manifest.json
@@ -28,7 +28,8 @@
         "groups:history",
         "groups:read",
         "users:read",
-        "reactions:read"
+        "reactions:read",
+        "reactions:write"
       ]
     }
   },

--- a/slack/src/headlong_slack/outbound.py
+++ b/slack/src/headlong_slack/outbound.py
@@ -12,6 +12,7 @@ import logging
 import threading
 import time
 from typing import Any
+from urllib.parse import urlsplit
 
 from . import mindlog, naming
 from .config import Config
@@ -50,6 +51,62 @@ class RecentPosts:
     def record(self, conversation: str, text: str, now: float | None = None) -> None:
         now = time.time() if now is None else now
         self._last[conversation] = (text, now)
+
+
+def reaction_name(step: dict[str, Any]) -> str | None:
+    """Slack emoji name from a chat-react step, or None if this is not one."""
+    raw = step.get("reaction")
+    if not isinstance(raw, str):
+        return None
+    name = raw.strip().strip(":")
+    if not name or any(c.isspace() for c in name):
+        return None
+    if not all(c.isalnum() or c in "_+-:" for c in name):
+        return None
+    if len(name) > 100:
+        return None
+    return name
+
+
+def message_ts_from_source_url(url: object) -> str | None:
+    """Decode Slack archive permalink /archives/<channel>/p<ts-without-dot>."""
+    if not isinstance(url, str) or not url:
+        return None
+    try:
+        parts = [p for p in urlsplit(url).path.split("/") if p]
+    except ValueError:
+        return None
+    if len(parts) < 3 or parts[-3] != "archives":
+        return None
+    last = parts[-1]
+    if not last.startswith("p") or not last[1:].isdigit() or len(last) < 8:
+        return None
+    digits = last[1:]
+    return f"{digits[:-6]}.{digits[-6:]}"
+
+
+def _already_reacted(exc: BaseException) -> bool:
+    resp = getattr(exc, "response", None)
+    error = ""
+    if isinstance(resp, dict):
+        error = str(resp.get("error") or "")
+    elif resp is not None and hasattr(resp, "get"):
+        error = str(resp.get("error") or "")
+    return error == "already_reacted" or "already_reacted" in str(exc)
+
+
+def _add_reaction(
+    client: Any,
+    conv: naming.Conversation,
+    name: str,
+    timestamp: str,
+) -> None:
+    try:
+        client.reactions_add(channel=conv.channel, timestamp=timestamp, name=name)
+    except Exception as exc:
+        if _already_reacted(exc):
+            return
+        raise
 
 
 def _post_notice(client: Any, conv: naming.Conversation, text: str) -> None:
@@ -113,6 +170,25 @@ def run(
         if not naming.is_slack_name(to):
             continue
         conv = naming.decode(to)
+        if "reaction" in step:
+            name = reaction_name(step)
+            ts = message_ts_from_source_url(step.get("source_url")) or conv.thread_ts
+            sig = f"react:{name}:{ts}" if name and ts else None
+            if not name:
+                log.error("invalid reaction on step %s", step.get("step_id"))
+            elif not ts:
+                log.error("reaction %s for %s has no message timestamp", name, to)
+            elif sig is not None and recent.seen(to, sig):
+                log.warning("skipping duplicate reaction %s on %s", name, to)
+            elif not hasattr(client, "reactions_add"):
+                log.error("client cannot add reactions for %s", to)
+            else:
+                try:
+                    _add_reaction(client, conv, name, ts)
+                    recent.record(to, sig)
+                except Exception:
+                    log.exception("reactions.add failed for %s (%s)", to, name)
+            continue
         payload = file_payload(step)
         if payload is not None:
             # File steps travel in content_b64 and often have empty `content`.

--- a/slack/tests/test_outbound.py
+++ b/slack/tests/test_outbound.py
@@ -295,3 +295,248 @@ def test_client_without_upload_posts_notice(tmp_path, monkeypatch):
 
     outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
     assert sent == ["(failed to deliver file note.txt)"]
+
+
+def test_message_ts_from_source_url():
+    parse = outbound.message_ts_from_source_url
+    assert parse(
+        "https://laudesters.slack.com/archives/C123/p1788451200123456"
+    ) == "1788451200.123456"
+    assert parse("https://slack.com/archives/C1/p12345678") == "12.345678"
+    assert parse("https://example.com/archives/C123/p1788451200123456") == "1788451200.123456"
+    assert parse("not-a-url") is None
+    assert parse("") is None
+    assert parse(None) is None
+    assert parse("https://slack.com/archives/C123") is None
+    assert parse("https://slack.com/files/C123/p1788451200123456") is None
+
+
+def test_reaction_name_strips_colons():
+    assert outbound.reaction_name({"reaction": "thumbsup"}) == "thumbsup"
+    assert outbound.reaction_name({"reaction": ":eyes:"}) == "eyes"
+    assert outbound.reaction_name({"reaction": "+1"}) == "+1"
+    assert outbound.reaction_name({"reaction": "thumbsup::skin-tone-2"}) == "thumbsup::skin-tone-2"
+    assert outbound.reaction_name({"reaction": "not a name"}) is None
+    assert outbound.reaction_name({"reaction": ""}) is None
+    assert outbound.reaction_name({"content": ":eyes:"}) is None
+
+
+def test_reaction_step_calls_reactions_add(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1722400000.123456",
+         "source": "chat", "reaction": "thumbsup", "content": ":thumbsup:",
+         "source_url": "https://laudesters.slack.com/archives/C1/p1722400000123456",
+         "step_id": "r1"},
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1722400000.123456",
+         "source": "chat", "content": "text after", "step_id": "t1"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    added = []
+    sent = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            sent.append(text)
+
+        def reactions_add(self, channel, timestamp, name):
+            added.append((channel, timestamp, name))
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert added == [("C1", "1722400000.123456", "thumbsup")]
+    assert sent == ["text after"]
+
+
+def test_reaction_falls_back_to_thread_ts_without_permalink(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1722400000.123456",
+         "source": "chat", "reaction": "eyes", "content": ":eyes:",
+         "step_id": "r1"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    added = []
+
+    class FakeClient:
+        def chat_postMessage(self, **kw):
+            raise AssertionError("reaction must not post text")
+
+        def reactions_add(self, channel, timestamp, name):
+            added.append((channel, timestamp, name))
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert added == [("C1", "1722400000.123456", "eyes")]
+
+
+def test_dm_reaction_without_permalink_is_skipped(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel", "to": "slack-U1-D1",
+         "source": "chat", "reaction": "thumbsup", "content": ":thumbsup:",
+         "step_id": "r1"},
+        {"type": "message", "from": "audel", "to": "slack-U1-D1",
+         "source": "chat", "content": "later", "step_id": "t1"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    added = []
+    sent = []
+
+    class FakeClient:
+        def chat_postMessage(self, channel, thread_ts, text, unfurl_links=False, **kw):
+            sent.append(text)
+
+        def reactions_add(self, **kw):
+            added.append(kw)
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert added == []
+    assert sent == ["later"]
+
+
+def test_identical_reactions_are_suppressed(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1.1",
+         "source": "chat", "reaction": "eyes", "content": ":eyes:",
+         "step_id": "a"},
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1.1",
+         "source": "chat", "reaction": "eyes", "content": ":eyes:",
+         "step_id": "b"},
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1.1",
+         "source": "chat", "reaction": "thumbsup", "content": ":thumbsup:",
+         "step_id": "c"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    added = []
+
+    class FakeClient:
+        def chat_postMessage(self, **kw):
+            raise AssertionError("no text")
+
+        def reactions_add(self, channel, timestamp, name):
+            added.append(name)
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert added == ["eyes", "thumbsup"]
+
+
+def test_failed_reaction_is_not_recorded_so_retry_works(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1.1",
+         "source": "chat", "reaction": "eyes", "content": ":eyes:",
+         "step_id": "a"},
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1.1",
+         "source": "chat", "reaction": "eyes", "content": ":eyes:",
+         "step_id": "b"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    added = []
+
+    class FakeClient:
+        def chat_postMessage(self, **kw):
+            raise AssertionError("no text")
+
+        def reactions_add(self, channel, timestamp, name):
+            added.append(name)
+            if len(added) == 1:
+                raise RuntimeError("transient")
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert added == ["eyes", "eyes"]
+
+
+def test_already_reacted_counts_as_success(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1.1",
+         "source": "chat", "reaction": "eyes", "content": ":eyes:",
+         "step_id": "a"},
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1.1",
+         "source": "chat", "reaction": "eyes", "content": ":eyes:",
+         "step_id": "b"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    added = []
+
+    class Already(Exception):
+        response = {"error": "already_reacted"}
+
+    class FakeClient:
+        def chat_postMessage(self, **kw):
+            raise AssertionError("no text")
+
+        def reactions_add(self, channel, timestamp, name):
+            added.append(name)
+            raise Already("already_reacted")
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    # first already_reacted is success -> recorded; second is suppressed
+    assert added == ["eyes"]
+
+
+def test_forged_reaction_without_chat_source_is_ignored(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel",
+         "to": "slack-U1-C1-1.1",
+         "source": "responder", "reaction": "eyes", "content": ":eyes:",
+         "step_id": "forged"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    added = []
+
+    class FakeClient:
+        def reactions_add(self, **kw):
+            added.append(kw)
+
+        def chat_postMessage(self, **kw):
+            raise AssertionError("no text")
+
+    class FakeThreads:
+        def touch(self, channel, thread_ts):
+            pass
+
+    outbound.run(_cfg(tmp_path), FakeClient(), FakeThreads(), threading.Event())
+    assert added == []

--- a/telegram/src/headlong_telegram/outbound.py
+++ b/telegram/src/headlong_telegram/outbound.py
@@ -72,6 +72,9 @@ def run(cfg: Config, bot: Bot, allowlist: Allowlist, stop_event: threading.Event
         if not naming.is_telegram_name(to):
             continue
         conv = naming.decode(to)
+        if "reaction" in step:
+            # Slack-only: a chat-react step must not become a Telegram message.
+            continue
         if not allowlist.is_approved(conv.user):
             log.warning("dropping reply to unapproved user %s", conv.user)
             continue

--- a/telegram/tests/test_outbound.py
+++ b/telegram/tests/test_outbound.py
@@ -383,3 +383,28 @@ def test_invalid_file_content_does_not_stop_later_replies(tmp_path, monkeypatch)
     assert docs == []
     assert sent == ["(failed to deliver file bad.bin)", "later reply"]
 
+
+
+def test_slack_reaction_step_is_not_posted(tmp_path, monkeypatch):
+    steps = [
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "reaction": "thumbsup", "content": ":thumbsup:",
+         "step_id": "r1"},
+        {"type": "message", "from": "audel", "to": "telegram-1-1",
+         "source": "chat", "content": "later reply", "step_id": "t1"},
+    ]
+    monkeypatch.setattr(outbound.mindlog, "find_trajectory", lambda d: tmp_path / "t.jsonl")
+    monkeypatch.setattr(outbound.mindlog, "follow", lambda *a, **k: iter(steps))
+
+    sent = []
+
+    class FakeBot:
+        def send_message(self, chat, text, html=False):
+            sent.append(text)
+
+    class ApproveAll:
+        def is_approved(self, user):
+            return True
+
+    outbound.run(_cfg(tmp_path), FakeBot(), ApproveAll(), threading.Event())
+    assert sent == ["later reply"]

--- a/tests/test_chat_react.sh
+++ b/tests/test_chat_react.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# tests/test_chat_react.sh — producer for `chat react`.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+
+WORK="${SHELLM_TEST_WORK:-}"
+if [[ -z "$WORK" ]]; then
+    WORK=$(mktemp -d)
+    trap 'rm -rf "$WORK"' EXIT
+else
+    rm -rf "$WORK"; mkdir -p "$WORK"
+fi
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+
+export PATH="$REPO/bin:$PATH"
+export TRAJ_DIR="$WORK/traj"
+mkdir -p "$TRAJ_DIR"
+
+new_out=$(traj new --traj_dir "$TRAJ_DIR" --slug react-test)
+tid=$(printf '%s\n' "$new_out" | head -1)
+export TRAJ_ID="$tid"
+export ROOT_TRAJ_ID="$tid"
+export IDENTITY_NAME="tester"
+export CHATRC="$WORK/.chatrc"
+printf 'default_send_from=tester\n' > "$CHATRC"
+cd "$WORK" || exit 1
+
+# --- happy path: stamps reaction + source:"chat" ---
+if chat react --from tester --to slack-U1-C1-1.1 thumbsup >/dev/null 2>"$WORK/err"; then
+    step=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
+    got_r=$(printf '%s' "$step" | jq -r '.reaction')
+    got_c=$(printf '%s' "$step" | jq -r '.content')
+    got_from=$(printf '%s' "$step" | jq -r '.from')
+    got_to=$(printf '%s' "$step" | jq -r '.to')
+    got_src=$(printf '%s' "$step" | jq -r '.source')
+    if [[ "$got_r" == "thumbsup" && "$got_c" == ":thumbsup:" \
+          && "$got_from" == "tester" && "$got_to" == "slack-U1-C1-1.1" \
+          && "$got_src" == "chat" ]]; then
+        ok "react stamps reaction field"
+    else
+        bad "react stamps reaction field" " $step"
+    fi
+else
+    bad "react happy path" " $(cat "$WORK/err")"
+fi
+
+# --- :colons: are stripped ---
+if chat react slack-U1-C1-1.1 :eyes: >/dev/null 2>"$WORK/err"; then
+    step=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
+    got_r=$(printf '%s' "$step" | jq -r '.reaction')
+    if [[ "$got_r" == "eyes" ]]; then
+        ok "react strips surrounding colons"
+    else
+        bad "react strips surrounding colons" " $step"
+    fi
+else
+    bad "react colon strip" " $(cat "$WORK/err")"
+fi
+
+# --- +1 is a valid Slack name ---
+if chat react slack-U1-C1-1.1 +1 >/dev/null 2>"$WORK/err"; then
+    step=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
+    got_r=$(printf '%s' "$step" | jq -r '.reaction')
+    if [[ "$got_r" == "+1" ]]; then
+        ok "react accepts +1"
+    else
+        bad "react accepts +1" " $step"
+    fi
+else
+    bad "react +1" " $(cat "$WORK/err")"
+fi
+
+# --- --source-url is stamped ---
+url="https://laudesters.slack.com/archives/C1/p1722400000123456"
+if chat react --source-url "$url" slack-U1-C1-1.1 white_check_mark >/dev/null 2>"$WORK/err"; then
+    step=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
+    got=$(printf '%s' "$step" | jq -r '.source_url')
+    if [[ "$got" == "$url" ]]; then
+        ok "react stamps source_url"
+    else
+        bad "react stamps source_url" " $step"
+    fi
+else
+    bad "react source-url" " $(cat "$WORK/err")"
+fi
+
+# --- --reply-to copies source_url from the inbound step ---
+chat send --from slack-U1-C1-1.1 --to tester --source-url "$url" "please look" >/dev/null 2>"$WORK/err" || true
+inbound=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
+in_id=$(printf '%s' "$inbound" | jq -r '.step_id')
+if chat react --reply-to "$in_id" slack-U1-C1-1.1 eyes >/dev/null 2>"$WORK/err"; then
+    step=$(traj cat "$TRAJ_ID" --filter type=message --raw 2>/dev/null | tail -n 1)
+    got=$(printf '%s' "$step" | jq -r '.source_url // empty')
+    got_rt=$(printf '%s' "$step" | jq -r '.reply_to // empty')
+    if [[ "$got" == "$url" && "$got_rt" == "$in_id" ]]; then
+        ok "react --reply-to copies source_url"
+    else
+        bad "react --reply-to copies source_url" " $step"
+    fi
+else
+    bad "react --reply-to" " $(cat "$WORK/err")"
+fi
+
+# --- unicode / spaces refused ---
+if chat react slack-U1-C1-1.1 "thumbs up" >/dev/null 2>"$WORK/err"; then
+    bad "space in name should be refused"
+else
+    ok "space in name is refused"
+fi
+if chat react slack-U1-C1-1.1 "👍" >/dev/null 2>"$WORK/err"; then
+    bad "unicode emoji should be refused"
+else
+    ok "unicode emoji is refused"
+fi
+
+# --- missing emoji refused ---
+if chat react slack-U1-C1-1.1 >/dev/null 2>"$WORK/err"; then
+    bad "missing emoji should be refused"
+else
+    ok "missing emoji is refused"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+if (( fail > 0 )); then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Nick asked for outbound Slack emoji reactions (respond with emojis).

`chat react <slack-name> <emoji>` stamps a chat-sourced message step with a Slack short name (`thumbsup`, `eyes`, `+1`). The Slack bridge calls `reactions.add` on the inbound permalink (`source_url`) when present, otherwise the conversation `thread_ts`. Telegram skips those steps so they are not posted as text.

Needs bot scope `reactions:write` — reinstall after merge/deploy.

Usage:
```bash
chat react slack-U07AB12CD-C09XYZ123-1722400000.123456 thumbsup
chat react --reply-to <inbound-step-id> slack-U07AB12CD-C09XYZ123-1722400000.123456 eyes
```

Tests: slack 85, telegram 71, `tests/test_chat_react.sh` 8/8.