### PR TITLE
traj: formatted tail and cat return the steps --filter matches

### DIFF
--- a/bin/traj
+++ b/bin/traj
@@ -958,15 +958,15 @@ _format_line() {
         return 0
     fi
 
-    local entry_type content source ts step_id traj_hex
-    { read -r entry_type
-      IFS= read -r content
-      read -r source
-      read -r ts
-      read -r step_id
-      read -r traj_hex
-    } < <(
-        printf '%s' "$line" | jq -r --argjson filters "$_filter_json" '
+    # Capture first, then guard, the way the -a branch above does. A step the
+    # filter drops makes jq print nothing, and reading six lines straight from
+    # an empty process substitution failed at the first read; under set -e
+    # that ended the whole formatted stream instead of skipping one step, so
+    # `traj tail --filter type=...` at a terminal printed nothing and exited
+    # 1, usually on the header line. The same read cut an unfiltered stream
+    # off at the first malformed line.
+    local _fields
+    _fields=$(printf '%s' "$line" | jq -r --argjson filters "$_filter_json" '
             def matches_filters($fs):
                 . as $step |
                 ($fs | length == 0) or all($fs[];
@@ -994,8 +994,21 @@ _format_line() {
             ((.ts // .timestamp // "0") | tostring),
             (.step_id // "-"),
             (._traj_hex // "-")
-        ' 2>/dev/null
-    )
+        ' 2>/dev/null) || return 0
+    [[ -n "$_fields" ]] || return 0
+
+    local entry_type content source ts step_id traj_hex
+    # The capture drops trailing newlines, so a record whose last field is the
+    # empty string arrives one line short. The process substitution this
+    # replaces kept that newline and read the field as empty; keep doing so
+    # rather than letting the sixth read fail and end the stream.
+    { read -r entry_type
+      IFS= read -r content
+      read -r source
+      read -r ts
+      read -r step_id
+      read -r traj_hex
+    } <<< "$_fields" || true
     [[ -n "$entry_type" ]] || return 0
 
     # Normalize placeholders back to empty

--- a/tests/test_traj_formatted_filter.sh
+++ b/tests/test_traj_formatted_filter.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# tests/test_traj_formatted_filter.sh — `traj tail --filter` and `traj cat
+# --filter` work in formatted mode, which is what a terminal gets.
+#
+# Usage: tests/test_traj_formatted_filter.sh
+#
+# Why: in formatted mode _format_line hands each step to jq, whose program
+# starts with `select(matches_filters($filters))`, and reads the six result
+# lines back with a `{ read; read; ... } < <(jq ...)` group. When a step does
+# not match, jq emits nothing, the first `read` fails at EOF, and under the
+# file's `set -e` that kills the `while read` subshell driving the stream. The
+# guard meant to skip a non-matching step, `[[ -n "$entry_type" ]] || return 0`,
+# sits right after the group and is never reached. So `traj tail --filter ...`
+# at a terminal printed nothing and exited 1 — usually on the very first line,
+# the trajectory header, which matches no type filter. The same failing read
+# also cut an unfiltered formatted stream off at the first malformed line.
+#
+# The -a branch of the same function already does it right: capture jq's
+# output, return on failure or empty, then split. And since #110, the -r path
+# pre-filters in _sorted_tree_steps, so `traj cat -r --filter` worked while
+# `traj cat --filter` did not. Raw mode filters correctly, so the oracle for
+# "which steps should a filter select" is the raw stream itself.
+
+set -uo pipefail
+unset TRAJ_DIR TRAJ_ID ROOT_TRAJ_ID 2>/dev/null
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(dirname "$HERE")"
+export PATH="$REPO/bin:$PATH"
+
+pass=0
+fail=0
+ok()  { pass=$((pass+1)); printf 'ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf 'FAIL %s%s\n' "$1" "${2:+ — $2}"; }
+is()  { # is LABEL EXPECTED ACTUAL
+    if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1" "want [$2], got [$3]"; fi
+}
+
+command -v jq >/dev/null 2>&1 || { echo "FAIL jq not found"; exit 1; }
+
+WORK=$(mktemp -d)
+trap 'cd /; rm -rf "$WORK"' EXIT
+
+export TRAJ_DIR="$WORK/trajectories"
+mkdir -p "$TRAJ_DIR"
+TRAJ_ID=$(traj new --slug root | head -1)
+export TRAJ_ID
+traj append --field type=thought --field content=T1 >/dev/null
+traj append --field type=action  --field content=A1 >/dev/null
+traj append --field type=thought --field content=T2 >/dev/null
+traj append --field type=message --field content=M1 --field source=nick >/dev/null
+FILE=$(traj path)
+[[ -f "$FILE" ]] || { echo "FAIL could not build the trajectory"; exit 1; }
+
+# A formatted line is "date time step_id [type] content" (--no-color), so the
+# last field is the content and the third is the 8-hex step id.
+contents() { awk '{print $NF}' | tr '\n' ' ' | sed 's/ $//'; }
+lines()    { grep -c . ; }
+
+# --- the everyday command: a type filter at a terminal ------------------------
+out=$(traj cat --format --no-color --filter type=thought); rc=$?
+is "cat --filter exits 0 in formatted mode"       "0"     "$rc"
+is "cat --filter prints the matching steps"        "T1 T2" "$(printf '%s\n' "$out" | contents)"
+
+out=$(traj tail -n 10 --format --no-color --filter type=thought); rc=$?
+is "tail --filter exits 0 in formatted mode"      "0"     "$rc"
+is "tail --filter prints the matching steps"       "T1 T2" "$(printf '%s\n' "$out" | contents)"
+
+# --- formatted mode selects exactly what raw mode selects ---------------------
+want=$(traj cat --raw --filter type=thought | jq -r '.step_id[0:8]' | tr '\n' ' ' | sed 's/ $//')
+got=$(traj cat --format --no-color --filter type=thought | awk '{print $3}' | tr '\n' ' ' | sed 's/ $//')
+is "formatted and raw modes agree on which steps match" "$want" "$got"
+
+# --- a stream that starts matching and then stops must not die midway --------
+# Only the header matches type=trajectory; the step after it is the first
+# non-match, which is where the unguarded read used to kill the stream.
+# The two line-count checks here pass on main as well, because there the
+# stream dies at its first step; they guard against over-printing and lean on
+# the exit-code check beside each for the bug itself.
+out=$(traj cat --format --no-color --filter type=trajectory); rc=$?
+is "a filter only the header matches exits 0"      "0" "$rc"
+is "a filter only the header matches prints one line" "1" "$(printf '%s\n' "$out" | lines)"
+
+out=$(traj cat --format --no-color --filter type=nope); rc=$?
+is "a filter nothing matches exits 0"              "0" "$rc"
+is "a filter nothing matches prints nothing"       "0" "$(printf '%s\n' "$out" | lines)"
+
+# --- the filter grammar still works in formatted mode -------------------------
+is "two --filter flags are AND-ed"                 "T2" \
+   "$(traj cat --format --no-color --filter type=thought --filter content=T2 | contents)"
+is "comma-separated values are OR-ed"              "T1 A1 T2" \
+   "$(traj cat --format --no-color --filter type=thought,action | contents)"
+
+# --- the neighbours are unchanged ---------------------------------------------
+is "unfiltered formatted output still shows every step" "5" \
+   "$(traj cat --format --no-color | lines)"
+is "-a --filter still works"                       "T1 T2" \
+   "$(traj cat -a --format --no-color --filter type=thought | contents)"
+is "raw --filter is untouched"                     "2" \
+   "$(traj cat --raw --filter type=thought | lines)"
+
+# --- a formatted line is stamp, id, [type, source], content -------------------
+# Pins the correspondence between the six lines jq emits and the six reads that
+# consume them, which is exactly what moving the read block could break. The
+# stamp is derived from the raw stream, the oracle, so this does not depend on
+# the machine's timezone.
+sid=$(traj cat --raw --filter content=M1 | jq -r '.step_id[0:8]')
+ets=$(traj cat --raw --filter content=M1 | jq -r '.ts' | sed 's/T/ /; s/[.Z].*//; s/-/\//g')
+is "a formatted line carries stamp, id, type, source and content" \
+   "$ets $sid [message, nick] M1" "$(traj cat --format --no-color --filter content=M1)"
+is "the type column is each step's own type" "trajectory thought action thought message" \
+   "$(traj cat --format --no-color | sed -n 's/.*\[\([^],]*\).*/\1/p' | tr '\n' ' ' | sed 's/ $//')"
+hex=$(basename "$(dirname "$FILE")" | cut -d- -f1)
+is "-r prefixes the id column with the file hex" "$hex/$sid" \
+   "$(traj cat -r --format --no-color --filter content=M1 | awk '{print $3}')"
+
+# --- a malformed line no longer truncates the formatted stream ----------------
+# A writer killed mid-append leaves a line jq cannot parse. The steps after it
+# are fine and must still be shown, as -a and raw already do.
+printf 'this is not json\n' >> "$FILE"
+traj append --field type=thought --field content=T3 >/dev/null
+out=$(traj cat --format --no-color); rc=$?
+is "a malformed line does not end the formatted stream" "0" "$rc"
+is "steps after a malformed line are still shown" "6" "$(printf '%s\n' "$out" | lines)"
+is "the last step after the malformed line is there" "T3" "$(printf '%s\n' "$out" | tail -1 | contents)"
+is "a malformed line produces no stderr noise" "" "$(traj cat --format --no-color 2>&1 >/dev/null)"
+
+# --- a record with an empty trailing field is read, not fatal -----------------
+# jq emits the fields one per line and the capture drops trailing newlines, so
+# a step whose last field, _traj_hex, is the empty string comes back a line
+# short. The process substitution this replaces read it as empty. `traj
+# append` accepts any key, so traj itself can write such a step.
+traj append --field type=thought --field content=T4 --field _traj_hex= >/dev/null
+traj append --field type=thought --field content=T5 >/dev/null
+out=$(traj cat --format --no-color); rc=$?
+is "an empty trailing field does not end the formatted stream" "0" "$rc"
+is "the short record and the steps after it are shown" "T4 T5" "$(printf '%s\n' "$out" | tail -2 | contents)"
+
+# --- a step jq cannot render is skipped, not fabricated and not fatal ----------
+# `traj append` takes JSON on stdin and checks only that it parses, so .content
+# can be an object. The preview slices it, jq errors after emitting one of its
+# six lines, and on main the read group died there, taking the rest of the
+# stream with it (-r included, since its pre-filter passes the step). Guarding
+# the old read group with `|| true` instead would print a fabricated line with
+# a blank stamp and id; capturing first lets `|| return 0` see the failure and
+# skip the step.
+printf '%s' '{"type":"thought","content":{"plan":["a","b"]}}' | traj append >/dev/null
+traj append --field type=thought --field content=T6 >/dev/null
+out=$(traj cat --format --no-color); rc=$?
+is "a step jq cannot render does not end the formatted stream" "0" "$rc"
+is "the step after it is still shown" "T6" "$(printf '%s\n' "$out" | tail -1 | contents)"
+is "no fabricated line stands in for it" "0" "$(printf '%s\n' "$out" | grep -c -- '----/--/--')"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Follow-up to #110, same function.

## What

In formatted mode — what a terminal gets by default — `traj tail` and
`traj cat` end the stream at the first step `_format_line` cannot turn into
six lines, exit 1, and say nothing. Two ways to hit that:

**A filter.** `--filter type=thought` at a terminal prints nothing at all,
because the first step of every trajectory is its header and no type filter
matches it. Widen the filter so the header does match and it becomes silent
truncation instead:

```
$ traj cat --filter type=trajectory,thought        # at a tty
2026/09/05 03:25:48 e0e9ef46 [trajectory] root
2026/09/05 03:25:48 a882d8db [thought] alpha
$ echo $?
1                                                    # gamma, also a thought, is gone
```

**A step the preview cannot render.** `traj append` takes JSON on stdin
(`thinkers/monolith/prompt.md`) and checks only that it parses, so `.content`
can be an object. The preview slices it, jq errors after one of its six
lines, and the stream dies there — `-r` included, because its pre-filter
passes the step. A malformed line does the same to a bare `traj cat` with no
flags. `-a` gets past all of these — it renders the object step and skips the
malformed line — and `--raw` returns every step; the default formatted view is
the one that dies, and `-r` dies with it on the unrenderable step.

`tail -f --filter …` is the sharpest form: the follower dies at the first
non-matching step and stays dead, with no diagnostic.

## Why

`_format_line` hands each step to a jq program that begins with
`select(matches_filters($filters))` and reads the six result lines back with a
`{ read; read; … } < <(jq …)` group. Whenever jq emits fewer than six lines —
a filtered-out step emits none, an unrenderable one emits one — a `read` fails
at EOF, and under the file's `set -euo pipefail` that kills the `while read`
subshell driving the stream. The guard meant to skip such a step,
`[[ -n "$entry_type" ]] || return 0`, is right after the group and is never
reached.

2c74855 states the invariant this breaks — *"a single corrupt line skips
gracefully instead of aborting and dropping all subsequent entries"* — and
hardened every jq call that reads a trajectory file except this one, which is
handed a single line and cannot use `fromjson?`. 93ad7bb then added `--filter`,
which made the dead guard matter for every non-matching step rather than only
for corrupt lines.

The `-a` branch of the same function already does this right: capture jq's
output, `|| return 0`, guard empty, then split. This makes the default branch
do the same.

## The fix

```diff
-    local entry_type content source ts step_id traj_hex
-    { read -r entry_type
-      …
-    } < <(
-        printf '%s' "$line" | jq -r … '
+    local _fields
+    _fields=$(printf '%s' "$line" | jq -r … '
             …
-        ' 2>/dev/null
-    )
+        ' 2>/dev/null) || return 0
+    [[ -n "$_fields" ]] || return 0
+
+    local entry_type content source ts step_id traj_hex
+    { read -r entry_type
+      …
+    } <<< "$_fields" || true
     [[ -n "$entry_type" ]] || return 0
```

The jq program is unchanged. Two details worth a sentence each:

- **Why capture rather than `|| true` on the old group.** A one-token
  `|| true` after the process substitution also stops the deaths and passes
  every filter case — but on an unrenderable step it reads the one line jq
  did emit and prints a fabricated `----/--/-- --:--:--  [thought]` line with
  a blank id. Capturing first lets `|| return 0` see jq's exit status and skip
  the step. The test pins the difference.
- **Why `|| true` on the new group.** `$(…)` drops trailing newlines, so a
  record whose last field is the empty string comes back a line short. The
  process substitution kept that newline and read the field as empty; this
  keeps doing so instead of failing on the sixth read.

`_format_line` is reached only in formatted mode. Every scripted `traj` call
in the repo passes `--raw` and is untouched. One automated caller does run
formatted: the TUI sets `CLICOLOR_FORCE=1` on every `traj` it spawns
(`tui/headlong/src/main.rs:341`) and auto-refreshes with `tail -r -n 50`. For
any tree that view renders today its output is byte-identical; where it
used to die on an unrenderable step and show a truncated tree, it now shows
the rest. A `tail --filter …` typed into its `/traj` pane hits this bug today.
Output for every step that rendered before is unchanged; two small
differences, both matching the `-a` branch: a step whose preview jq errors is
now skipped rather than ending the stream, and on bash ≥ 4.4 a NUL byte in a
step's content now draws bash's "ignored null byte" warning on stderr, as it
already does under `-a`.

## Tests

`tests/test_traj_formatted_filter.sh` pins, in formatted mode: `cat` and
`tail` with a type filter exit 0 and print the matching steps; formatted and
raw modes select the same step ids (raw is the oracle); a filter only the
header matches prints one line and exits 0 — the first non-match no longer
ends the stream; a filter nothing matches prints nothing and exits 0; two
`--filter` flags AND and comma values OR; the `-a` and raw neighbours are
unchanged; a formatted line still carries stamp, id, `[type, source]` and
content in that order, so the six reads stay matched to the six lines jq
emits; `-r` still prefixes the id with the file hex; a malformed line no
longer truncates the stream and leaks nothing to stderr; a record with an
empty trailing field is shown; and a step jq cannot render is skipped with no
fabricated line in its place.

On `main`: 9 passed, 17 failed — the nine are the neighbour and rendering
controls. With the fix: 26 passed, 0 failed. The one-token alternative above:
25 passed, 1 failed, on the fabricated-line check. Mutation-tested against
fourteen deliberate breakages of `bin/traj` — reverting to the process
substitution, dropping the capture's `|| return 0`, inverting the empty guard,
dropping the read group's `|| true`, ignoring the filter, printing only the
first match, hardcoding the type, reordering or swapping jq fields, dropping a
read, breaking the timestamp branch, leaking jq's stderr, corrupting the
content column — thirteen are caught. The fourteenth, deleting
`[[ -n "$_fields" ]] || return 0`, is not observable because the read group
tolerates a short record and the `entry_type` guard then returns; the line
stays because it mirrors the `-a` branch and says what is meant.

Checked locally: `shellcheck -S warning` clean over the CI file set, the new
test clean at `-S info` too. Parses and runs under Apple's bash 3.2 and a pure
BSD userland as well as GNU coreutils; stable across timezones and locales.
`cloc bin/ thinkers/` +1 code line. `tests/run-all.sh` green apart from two
failures that are pre-existing on `main` here and green in CI:
`test_persona_chat_exit.sh` (pins `PATH` to `/usr/bin:/bin`, which has no `jq`
on a Homebrew Mac) and `test_workspace_runtime.sh` (`_runtime_line` stats
`.git/HEAD`, which does not exist when the checkout is a git worktree, as mine
is).
